### PR TITLE
Fix missing icalerror.h during install.

### DIFF
--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -380,7 +380,7 @@ install(FILES
   ${CMAKE_BINARY_DIR}/src/libical/icalderivedvalue.h
   icalduration.h
   icalenums.h
-  ${CMAKE_BINARY_DIR}/src/libical/icalerror.h
+  icalerror.h
   icallangbind.h
   icalmemory.h
   icalmime.h


### PR DESCRIPTION
Using current master the installation fails due to icalerror.h missing in the build directory. As a consequence, libicalss and libicalvcal do not get installed. In addition, the installed headers of libical are incomplete. This pull request fixes that.

Verified on cmake version 3.2.0-rc2.

### How to reproduce issue

    $ mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=/tmp/libical .. && make install && cd ..
    [...]
    CMake Error at src/libical/cmake_install.cmake:146 (file):
      file INSTALL cannot find
      "/home/rsto/libical/build/src/libical/icalerror.h".

    $ ls /tmp/libical/include/libical/
    ical.h                 icalcomponent.h        icalderivedvalue.h
    icalarray.h            icalderivedparameter.h icalduration.h
    icalattach.h           icalderivedproperty.h  icalenums.h

    $ ls /tmp/libical/lib/
    cmake                   libical.dylib           libical_cxx.dylib
    libical.2.0.0.dylib     libical_cxx.2.0.0.dylib pkgconfig
    libical.2.dylib         libical_cxx.2.dylib
    libical.a               libical_cxx.a


### After applying this pull request

    $ ls /tmp/libical/lib/
    cmake                     libicalss.a
    libical.2.0.0.dylib       libicalss.dylib
    libical.2.dylib           libicalss_cxx.2.0.0.dylib
    libical.a                 libicalss_cxx.2.dylib
    libical.dylib             libicalss_cxx.a
    libical_cxx.2.0.0.dylib   libicalss_cxx.dylib
    libical_cxx.2.dylib       libicalvcal.2.0.0.dylib
    libical_cxx.a             libicalvcal.2.dylib
    libical_cxx.dylib         libicalvcal.a
    libicalss.2.0.0.dylib     libicalvcal.dylib
    libicalss.2.dylib         pkgconfig

    $ ls /tmp/libical/include/libical/
    ical.h                 icalgauge.h            icalss.h
    icalarray.h            icalgaugeimpl.h        icalssyacc.h
    icalattach.h           icallangbind.h         icaltime.h
    icalcalendar.h         icalmemory.h           icaltimezone.h
    icalclassify.h         icalmessage.h          icaltypes.h
    icalcluster.h          icalmime.h             icaltz-util.h
    icalcomponent.h        icalparameter.h        icalvalue.h
    icalderivedparameter.h icalparameter_cxx.h    icalvalue_cxx.h
    icalderivedproperty.h  icalparser.h           icalvcal.h
    icalderivedvalue.h     icalperiod.h           icptrholder_cxx.h
    icaldirset.h           icalproperty.h         port.h
    icaldirsetimpl.h       icalproperty_cxx.h     pvl.h
    icalduration.h         icalrecur.h            sspm.h
    icalenums.h            icalrestriction.h      vcaltmp.h
    icalerror.h            icalset.h              vcc.h
    icalfileset.h          icalspanlist.h         vcomponent_cxx.h
    icalfilesetimpl.h      icalspanlist_cxx.h     vobject.h