### PR TITLE
Use SHARE_INSTALL_DIR to install gobject-instrospection files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ endif()
 set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
 set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE STRING "Library directory name" FORCE)
 set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE STRING "Include directory name" FORCE)
-set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share" CACHE STRING "Share directory name" FORCE)
+set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share" CACHE STRING "Share directory name")
 
 # set the output paths
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)

--- a/cmake/modules/GObjectIntrospectionMacros.cmake
+++ b/cmake/modules/GObjectIntrospectionMacros.cmake
@@ -71,7 +71,7 @@ macro(gir_add_introspections introspections_girs)
       VERBATIM
     )
     list(APPEND _gir_girs ${CMAKE_CURRENT_BINARY_DIR}/${gir})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${gir} DESTINATION share/gir-1.0)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${gir} DESTINATION ${SHARE_INSTALL_DIR}/gir-1.0)
 
     string(REPLACE ".gir" ".typelib" _typelib "${gir}")
     add_custom_command(


### PR DESCRIPTION
This is helpful on a multiarch layout where the prefix is /usr/${host}
but arch-independent files should still be installed to /usr/share.