### PR TITLE
Use GNUInstallDirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,10 +135,12 @@ if(WIN32)
   add_definitions(-DBIG_ENDIAN=0 -DLITTLE_ENDIAN=1 -DBYTE_ORDER=BIG_ENDIAN)
 endif()
 
-set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
-set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE STRING "Library directory name" FORCE)
-set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE STRING "Include directory name" FORCE)
-set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share" CACHE STRING "Share directory name")
+# Use GNUInstallDirs
+
+include(GNUInstallDirs)
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING "Library directory name" FORCE)
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING "Include directory name" FORCE)
+set(SHARE_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR} CACHE STRING "Share directory name")
 
 # set the output paths
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)

--- a/cmake/modules/GObjectIntrospectionMacros.cmake
+++ b/cmake/modules/GObjectIntrospectionMacros.cmake
@@ -85,7 +85,7 @@ macro(gir_add_introspections introspections_girs)
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
     list(APPEND _gir_typelibs ${CMAKE_CURRENT_BINARY_DIR}/${_typelib})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_typelib} DESTINATION lib${LIB_SUFFIX}/girepository-1.0)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_typelib} DESTINATION lib/girepository-1.0)
 
   endforeach()
 


### PR DESCRIPTION
Removed the specified LIB_SUFFIX and use the provided GNUInstallDirs.
Removed LIB_SUFFIX from cmake/modules/GObjectIntrospectionMacros.cmake, the installed file is architecture-independant.