### PR TITLE
Fixed a regression in icaltimezone_get_utc_offset when expanding times far in the past

### DIFF
--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -832,6 +832,14 @@ int icaltimezone_get_utc_offset(icaltimezone *zone, struct icaltimetype *tt, int
         if (step == -1 && found_change == 1)
             break;
 
+        /* If we go past the start of the changes array, then we have no data
+         for this time so we return the prev UTC offset. */
+        if (change_num == 0 && step < 0) {
+            if (is_daylight)
+                *is_daylight = ! tmp_change.is_daylight;
+            return tmp_change.prev_utc_offset;
+        }
+
         change_num += step;
 
         if (change_num >= zone->changes->num_elements)

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -196,7 +196,8 @@ const char *icaltzutil_get_zone_directory(void)
 icalcomponent *icaltzutil_fetch_timezone(const char *location)
 {
     tzinfo type_cnts;
-    size_t i, num_trans, num_types, num_chars, num_leaps, num_isstd, num_isgmt;
+    size_t i, num_trans, num_chars, num_leaps, num_isstd, num_isgmt;
+    size_t num_types = 0;
     size_t size;
 
     const char *zonedir;


### PR DESCRIPTION
icaltimezone_get_utc_offset was crashing from a change introduced in b9e3d247bc5f241190a4ee150f725728531c4255. One of the checks for times far in the past (any time that was before the first change in the array) got removed, this readds it.

For example, trying to convert a time such as 19000101T120000 was crashing in America/New_York since the first time zone change libical generates is in 1969.