### PR TITLE
icaltime_compare optimization when comparing times with the same time zone.

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -773,8 +773,14 @@ int icaltime_compare(const struct icaltimetype a_in, const struct icaltimetype b
 {
     struct icaltimetype a, b;
 
-    a = icaltime_convert_to_zone(a_in, icaltimezone_get_utc_timezone());
-    b = icaltime_convert_to_zone(b_in, icaltimezone_get_utc_timezone());
+    /* We only need to perform time zone conversion if times aren't in the same time zone */
+    if (a_in.zone != b_in.zone || a_in.is_utc != b_in.is_utc) {
+        a = icaltime_convert_to_zone(a_in, icaltimezone_get_utc_timezone());
+        b = icaltime_convert_to_zone(b_in, icaltimezone_get_utc_timezone());
+    } else {
+        a = a_in;
+        b = b_in;
+    }
 
     if (a.year > b.year) {
         return 1;


### PR DESCRIPTION
icaltime_compare was showing up in one of my profiles of a tight loop when handling recurring times. icaltime_compare doesn't need to perform time zone conversion if both of the times being compared are in the same time zone.