### PR TITLE
Use bsearch in icalparameter_string_to_kind

### DIFF
--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -79,22 +79,25 @@ const char* icalparameter_kind_to_string(icalparameter_kind kind)
 
 }
 
+int icalparameter_compare_kind_map(const struct icalparameter_kind_map *a, const struct icalparameter_kind_map *b)
+{
+    return strcasecmp(a->name, b->name);
+}
+
 icalparameter_kind icalparameter_string_to_kind(const char* string)
 {
-    int i;
-
-    if (string ==0 ) {
+    if (string == 0) {
         return ICAL_NO_PARAMETER;
     }
 
-    for (i=0; parameter_map[i].kind  != ICAL_NO_PARAMETER; i++) {
+    const struct icalparameter_kind_map key = {ICAL_ANY_PARAMETER, string};
+    struct icalparameter_kind_map *result = bsearch(&key, parameter_map, sizeof(parameter_map) / sizeof(struct icalparameter_kind_map), sizeof(struct icalparameter_kind_map), (int(*)(const void *, const void *))icalparameter_compare_kind_map);
 
-        if (strcasecmp(parameter_map[i].name, string) == 0) {
-            return parameter_map[i].kind;
-        }
+    if (result) {
+        return result->kind;
     }
 
-    if(strncmp(string,"X-",2)==0){
+    if (strncmp(string,"X-",2) == 0) {
         return ICAL_X_PARAMETER;
     }
 


### PR DESCRIPTION
Use bsearch in icalparameter_string_to_kind instead of linearly searching all parameters. This matters more here since it calls strcasecmp instead of doing an equality check like most of the other string_to_kind or kind_to_string functions.

mkderivedparameters.pl explicitly sorts parameters by their name, so it's safe to use binary search here.