### PR TITLE
icaltime_as_ical_string_r: fix doc string

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -367,6 +367,10 @@ time_t icaltime_as_timet_with_zone(const struct icaltimetype tt, const icaltimez
     return t;
 }
 
+/**
+ * Return a string represention of the time, in RFC5545 format. The
+ * string is owned by libical.
+ */
 const char *icaltime_as_ical_string(const struct icaltimetype tt)
 {
     char *buf;
@@ -378,7 +382,7 @@ const char *icaltime_as_ical_string(const struct icaltimetype tt)
 
 /**
  * Return a string represention of the time, in RFC5545 format. The
- * string is owned by libical
+ * string is owned by the caller.
  */
 char *icaltime_as_ical_string_r(const struct icaltimetype tt)
 {


### PR DESCRIPTION
icaltime_as_ical_string_r returns newly allocated memory to be owned by the caller. However, the C documentation string of this function erroneously claims the memory to be owned by libical.