### PR TITLE
icalrecur: export recurrence enum conversion routines

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -207,7 +207,7 @@ static struct freq_map
     {ICAL_NO_RECURRENCE, 0}
 };
 
-static icalrecurrencetype_frequency icalrecur_string_to_freq(const char *str)
+icalrecurrencetype_frequency icalrecur_string_to_freq(const char *str)
 {
     int i;
 
@@ -219,7 +219,7 @@ static icalrecurrencetype_frequency icalrecur_string_to_freq(const char *str)
     return ICAL_NO_RECURRENCE;
 }
 
-static const char *icalrecur_freq_to_string(icalrecurrencetype_frequency kind)
+const char *icalrecur_freq_to_string(icalrecurrencetype_frequency kind)
 {
     int i;
 
@@ -242,7 +242,7 @@ static struct skip_map
     {ICAL_SKIP_UNDEFINED, 0}
 };
 
-static icalrecurrencetype_skip icalrecur_string_to_skip(const char *str)
+icalrecurrencetype_skip icalrecur_string_to_skip(const char *str)
 {
     int i;
 
@@ -254,7 +254,7 @@ static icalrecurrencetype_skip icalrecur_string_to_skip(const char *str)
     return ICAL_SKIP_UNDEFINED;
 }
 
-static const char *icalrecur_skip_to_string(icalrecurrencetype_skip kind)
+const char *icalrecur_skip_to_string(icalrecurrencetype_skip kind)
 {
     int i;
 
@@ -281,7 +281,7 @@ static struct wd_map
     {ICAL_NO_WEEKDAY, 0}
 };
 
-static const char *icalrecur_weekday_to_string(icalrecurrencetype_weekday kind)
+const char *icalrecur_weekday_to_string(icalrecurrencetype_weekday kind)
 {
     int i;
 
@@ -294,7 +294,7 @@ static const char *icalrecur_weekday_to_string(icalrecurrencetype_weekday kind)
     return 0;
 }
 
-static icalrecurrencetype_weekday icalrecur_string_to_weekday(const char *str)
+icalrecurrencetype_weekday icalrecur_string_to_weekday(const char *str)
 {
     int i;
 

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -72,7 +72,7 @@ whatever timezone that dtstart is in.
 #include "icaltime.h"
 
 /*
- * Recurrance enumerations
+ * Recurrence enumerations
  */
 
 typedef enum icalrecurrencetype_frequency
@@ -115,6 +115,19 @@ enum icalrecurrence_array_max_values
     ICAL_RECURRENCE_ARRAY_MAX = 0x7f7f,
     ICAL_RECURRENCE_ARRAY_MAX_BYTE = 0x7f
 };
+
+/*
+ * Recurrence enumerations conversion routines.
+ */
+
+LIBICAL_ICAL_EXPORT icalrecurrencetype_frequency icalrecur_string_to_freq(const char *str);
+LIBICAL_ICAL_EXPORT const char *icalrecur_freq_to_string(icalrecurrencetype_frequency kind);
+
+LIBICAL_ICAL_EXPORT icalrecurrencetype_skip icalrecur_string_to_skip(const char *str);
+LIBICAL_ICAL_EXPORT const char *icalrecur_skip_to_string(icalrecurrencetype_skip kind);
+
+LIBICAL_ICAL_EXPORT const char *icalrecur_weekday_to_string(icalrecurrencetype_weekday kind);
+LIBICAL_ICAL_EXPORT icalrecurrencetype_weekday icalrecur_string_to_weekday(const char *str);
 
 /**
  * Recurrence type routines


### PR DESCRIPTION
The recurrence enumerations are exported in icalrecur.h, but their conversion routines are static to icalrecur.c. 

Since similar routines are exported for icalproperty, icalkind and others, I propose to also export the recurrence converters. That way, library users don't need to write their own (and possibly outdated) converters for recurrence enumerations.

All unit tests passed.