### PR TITLE
Fixed comparison of float time with timezoned time

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -778,8 +778,10 @@ int icaltime_compare(const struct icaltimetype a_in, const struct icaltimetype b
 {
     struct icaltimetype a, b;
 
-    /* We only need to perform time zone conversion if times aren't in the same time zone */
-    if (a_in.zone != b_in.zone || a_in.is_utc != b_in.is_utc) {
+    /* We only need to perform time zone conversion if times aren't in the same time zone
+       or neither of them is floating (zone equals NULL) */
+    if ((a_in.zone != b_in.zone || a_in.is_utc != b_in.is_utc)
+        && (a_in.zone != NULL && b_in.zone != NULL)) {
         a = icaltime_convert_to_zone(a_in, icaltimezone_get_utc_timezone());
         b = icaltime_convert_to_zone(b_in, icaltimezone_get_utc_timezone());
     } else {

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -221,10 +221,6 @@ LIBICAL_ICAL_EXPORT int icaltime_is_date(const struct icaltimetype t);
 LIBICAL_ICAL_EXPORT int icaltime_is_utc(const struct icaltimetype t);
 
 /** Return -1, 0, or 1 to indicate that a<b, a==b or a>b */
-LIBICAL_ICAL_EXPORT int icaltime_compare_with_zone(const struct icaltimetype a,
-                                                   const struct icaltimetype b);
-
-/** Return -1, 0, or 1 to indicate that a<b, a==b or a>b */
 LIBICAL_ICAL_EXPORT int icaltime_compare(const struct icaltimetype a, const struct icaltimetype b);
 
 /** like icaltime_compare, but only use the date parts. */

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1760,6 +1760,34 @@ void do_test_time(const char *zone)
        (strncmp(ictt_as_string(icttla), "2001-05-22 11:30:30", 19) == 0));
 
     icalerror_set_errors_are_fatal(1);
+
+    /* Do some checks for icaltime_compare */
+    if (VERBOSE) {
+        printf("\n icaltime_compare() tests \n");
+    }
+
+    ictt = icaltime_from_string("20001203T183030");
+    icttutc = icaltime_convert_to_zone(ictt, utczone);
+    icttny = icaltime_convert_to_zone(ictt,
+                                      icaltimezone_get_builtin_timezone("America/New_York"));
+
+    int_is("icaltime_compare(): same float and UTC",
+           icaltime_compare(ictt, icttutc),
+           0);
+
+    int_is("icaltime_compare(): same float and NY",
+           icaltime_compare(ictt, icttny),
+           0);
+
+    /* The offset is set as from UTC: see issue #231 */
+    icttny.hour = icttny.hour - 5;
+    int_is("icaltime_compare(): different float and NY",
+           icaltime_compare(ictt, icttny),
+           1);
+
+    int_is("icaltime_compare(): same UTC and NY",
+           icaltime_compare(icttutc, icttny),
+           0);
 }
 
 void test_iterators()


### PR DESCRIPTION
During comparison, float time would be converted to UTC if
compared to anything else resulting in wrong comparison as
float time should be time zone indenpendent.

Also removed non-existing function icaltime_compare_with_zone
from icaltime.h

https://github.com/libical/libical/issues/231