### PR TITLE
build: ICU must appear as Requires in pkgconfig

### DIFF
--- a/libical.pc.in
+++ b/libical.pc.in
@@ -2,11 +2,11 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-threadslib=@PTHREAD_LIBS@
-iculibs=@ICUUC_LIBS@ @ICUI18N_LIBS@
 
 Name: libical
 Description: An implementation of basic iCAL protocols
 Version: @LIBICAL_LIB_VERSION_STRING@
-Libs: -L${libdir} -lical -licalss -licalvcal ${threadslib} ${iculibs}
+Libs: -L${libdir} -lical -licalss -licalvcal
+Libs.private: @PTHREAD_LIBS@
+Requires.private: icu-i18n
 Cflags: -I${includedir}


### PR DESCRIPTION
libical.pc specifies -licu-i18n in its Libs: field,
but no Requires: icu-i18n. As a result, the automatic dependency
generator in Linux distributions won't see the ICU requirement,
won't install it, and builds of secondary software fails.

$ gcc icalthing.c `pkg-config libical --cflags --libs`
[...]
gcc: error: /usr/lib64/libicuuc.so: No such file or directory

Move ICU from Libs to Requires, so the dependency scanner can do its
job. Specifically move it to Requires.private, since specifying -licu*
is not normally needed when libical is a shared library since it
already has it recorded in the ELF.
