### PR TITLE
build: Pass 'CC' to the introspection scanner

### DIFF
--- a/cmake/modules/GObjectIntrospectionMacros.cmake
+++ b/cmake/modules/GObjectIntrospectionMacros.cmake
@@ -50,7 +50,8 @@ macro(gir_add_introspections introspections_girs)
     set(_gir_libtool "--no-libtool")
 
     add_custom_command(
-      COMMAND ${INTROSPECTION_SCANNER}
+      COMMAND ${CMAKE_COMMAND} -E env "CC='${CMAKE_C_COMPILER}'"
+              ${INTROSPECTION_SCANNER}
               ${INTROSPECTION_SCANNER_ARGS}
               --namespace=${_gir_namespace}
               --nsversion=${_gir_version}


### PR DESCRIPTION
This change avoids g-ir-scanner picking up a different compiler from the
environment than the one specified when building. When CC is absent from
the environment used to launch g-ir-scanner, it'll fall back to the
default behaviour of distutils, which is to use the compiler with with
distutils themselves were built. This causes compilation failure because
of missing system includes if distutils was built on a different machine
or with different arguments.

The behaviour introduced by this commit similar as the one provided by
GObject introspection itself in its autotools integration, except it's
missing CFLAGS, CPPFLAGS, and LDFLAGS, because their presence makes the
command line generated by cmake too long. The only way to match
behaviours would be to create a small wrapper script that set all the
environment variables and then called g-ir-scanner. Currently, this is
not necessary.