### PR TITLE
Set visibility of icalerrorenum to default

### DIFF
--- a/src/libical/icalerror.h
+++ b/src/libical/icalerror.h
@@ -34,6 +34,7 @@ LIBICAL_ICAL_EXPORT void icalerror_stop_here(void);
 
 LIBICAL_ICAL_EXPORT void icalerror_crash_here(void);
 
+#pragma GCC visibility push(default)
 typedef enum icalerrorenum
 {
     ICAL_NO_ERROR = 0,
@@ -48,6 +49,7 @@ typedef enum icalerrorenum
     ICAL_UNIMPLEMENTED_ERROR,
     ICAL_UNKNOWN_ERROR  /* Used for problems in input to icalerror_strerror() */
 } icalerrorenum;
+#pragma GCC visibility pop
 
 LIBICAL_ICAL_EXPORT icalerrorenum *icalerrno_return(void);
 

--- a/src/test/regression-cxx.cpp
+++ b/src/test/regression-cxx.cpp
@@ -165,8 +165,6 @@ void test_cxx(void)
     delete vAgenda;
     delete cal;
 
-//FIXME: causes an uncaught exception runtime error on APPLE. unknown reason.
-#if !defined(__APPLE__) //krazy:exclude=cpp
     int caughtException = 0;
     try {
         VComponent v = VComponent(string("HFHFHFHF"));
@@ -176,5 +174,4 @@ void test_cxx(void)
         }
     }
     int_is("Testing exception handling", caughtException, 1);
-#endif
 }


### PR DESCRIPTION
I only tested this on macOS, but the added #pragmas should be portable.

Fixes not being able to catch exceptions from libraries in clang (#264).