### PR TITLE
Run parser test on all the ics files in test-data

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -107,7 +107,8 @@ buildme(parser "${parser_SRCS}")
 file(GLOB TEST_FILES ${CMAKE_SOURCE_DIR}/test-data/*.ics)
 foreach(TEST_FILE ${TEST_FILES})
   get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
-  add_test(NAME "parser-${TEST_NAME}" COMMAND parser ${TEST_FILE})
+  add_test(NAME parser-${TEST_NAME} COMMAND parser ${TEST_FILE})
+  setprops(parser-${TEST_NAME})
 endforeach()
 
 ########### next target ###############

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -104,6 +104,12 @@ testme(regression "${regression_SRCS}")
 set(parser_SRCS icaltestparser.c)
 buildme(parser "${parser_SRCS}")
 
+file(GLOB TEST_FILES ${CMAKE_SOURCE_DIR}/test-data/*.ics)
+foreach(TEST_FILE ${TEST_FILES})
+  get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+  add_test(NAME "parser-${TEST_NAME}" COMMAND parser ${TEST_FILE})
+endforeach()
+
 ########### next target ###############
 
 if(NOT WIN32)


### PR DESCRIPTION
Run parser on all the ics files in test-data. This ensures parsing the test files doesn't crash, but it doesn't perform any specific verification or error checking on the files.
Fixes #255.