### PR TITLE
Generate Vala vapi file on the go

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@
 #  Requires GObject Introspection development package v0.6.7 or higher
 #  Default=false (do not generate the introspection files)
 #
+# -DICAL_GLIB_VAPI=[true|false]
+#  Set to build Vala "vapi" files
+#  Requires Vala package
+#  Default=false (build the libical-glib interface)
+#
 # -DICAL_GLIB=[true|false]
 #  Set to build libical-glib (GObject) interface
 #  Requires glib development package v2.20 or higher
@@ -245,6 +250,23 @@ if(GOBJECT_INTROSPECTION)
     endif()
   else()
     message(FATAL_ERROR "You requested to build with GObject Introspection but the necessary development package is missing or too low a version (version ${MIN_GOBJECT_INTROSPECTION} or higher is required)")
+  endif()
+endif()
+
+option(ICAL_GLIB_VAPI "Build Vala \"vapi\" files.")
+if(ICAL_GLIB_VAPI)
+  if(NOT GOBJECT_INTROSPECTION)
+    message(FATAL_ERROR "You requested to build the Vapi but have not enabled the GObject Introspection, please retry by passing -DGOBJECT_INTROSPECTION=True to CMake")
+  endif()
+
+  find_program(VALAC valac)
+  if(NOT VALAC)
+    message(FATAL_ERROR "The valac not found. Install it or disable Vala bindings with -DICAL_GLIB_VAPI=False")
+  endif()
+
+  find_program(VAPIGEN vapigen)
+  if(NOT VAPIGEN)
+    message(FATAL_ERROR "The vapigen not found. Install it or disable Vala bindings with -DICAL_GLIB_VAPI=False")
   endif()
 endif()
 

--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -166,6 +166,31 @@ if(HAVE_INTROSPECTION)
   gir_add_introspections(INTROSPECTION_GIRS)
 endif()
 
+if(ICAL_GLIB_VAPI)
+  add_custom_target(vala ALL)
+  set(gir_fullname ${CMAKE_BINARY_DIR}/src/libical-glib/ICalGLib-${LIBICAL_GLIB_GIR_VERSION_STRING}.gir)
+  set (vapi_file ${CMAKE_CURRENT_BINARY_DIR}/libical-glib.vapi)
+
+  add_custom_command(OUTPUT ${vapi_file}
+    COMMAND ${VAPIGEN}
+      --vapidir=${CMAKE_CURRENT_SOURCE_DIR}
+      --vapidir=${CMAKE_CURRENT_BINARY_DIR}
+      --girdir=${CMAKE_BINARY_DIR}/src/libical-glib
+      --pkg gio-2.0
+      --library libical-glib
+      --metadatadir=${CMAKE_CURRENT_SOURCE_DIR}
+      ${gir_fullname}
+    DEPENDS
+      ${gir_fullname}
+  )
+
+  add_custom_target(valafile DEPENDS ${vapi_file})
+
+  add_dependencies(vala valafile)
+
+  install(FILES ${vapi_file} DESTINATION ${SHARE_INSTALL_DIR}/vala/vapi)
+endif()
+
 if(MSVC)
   set_target_properties(ical-glib PROPERTIES OUTPUT_NAME "libical-glib")
   if(NOT SHARED_ONLY)


### PR DESCRIPTION
This is required to use libical-glib with Vala, this is a soft dependency as it is only used if specified by the ICAL_GLIB_VAPI flag and only at required compilation time.