### PR TITLE
icaltime_compare fix when comparing UTC and non-UTC times

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -738,7 +738,7 @@ int icaltime_compare(const struct icaltimetype a_in, const struct icaltimetype b
     /* We only need to perform time zone conversion if times aren't in the same time zone
        or neither of them is floating (zone equals NULL) */
     if ((a_in.zone != b_in.zone || a_in.is_utc != b_in.is_utc) &&
-        (a_in.zone != NULL && b_in.zone != NULL)) {
+        ((a_in.zone != NULL && b_in.zone != NULL) || (a_in.zone != NULL && b_in.is_utc) || (a_in.is_utc && b_in.zone != NULL))) {
         a = icaltime_convert_to_zone(a_in, icaltimezone_get_utc_timezone());
         b = icaltime_convert_to_zone(b_in, icaltimezone_get_utc_timezone());
     } else {

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -392,6 +392,28 @@ void test_utf8()
     icalcomponent_free(comp);
 }
 
+void test_icaltime_compare_utc_zone()
+{
+    struct icaltimetype a;
+    struct icaltimetype b;
+
+    /* test comparing a UTC and floating time */
+    a = icaltime_from_string("20170130T103000Z");
+    b = icaltime_from_string("20170130T103000");
+    int_is("a == b", icaltime_compare(a, b), 0);
+
+    /* test comparing times across time zones (where UTC is specified by zone) */
+    a = icaltime_from_string("20170130T103000Z");
+    b = icaltime_from_string("20170130T103000");
+    b.zone = icaltimezone_get_builtin_timezone("America/Los_Angeles");
+    int_is("a < b", icaltime_compare(a, b), -1);
+
+    /* test comparing times across time zones (where UTC is specified by is_utc and zone is NULL) */
+    a.zone = NULL;
+    int_is("a.is_utc", a.is_utc, 1);
+    int_is("a < b", icaltime_compare(a, b), -1);
+}
+
 void test_parameters()
 {
     icalparameter *p;
@@ -3986,6 +4008,7 @@ int main(int argc, char *argv[])
     test_run("Test Dirset", test_dirset, do_test, do_header);
     test_run("Test vCal to iCal conversion", test_vcal, do_test, do_header);
     test_run("Test UTF-8 Handling", test_utf8, do_test, do_header);
+    test_run("Test icaltime_compare UTC and zone handling", test_icaltime_compare_utc_zone, do_test, do_header);
     test_run("Test exclusion of recurrences as per r961", test_recurrenceexcluded, do_test,
              do_header);
 #if ADD_TESTS_REQUIRING_INVESTIGATION


### PR DESCRIPTION
icaltime_compare wasn't converting time zones if the UTC time was specified with is_utc = 1 but zone = NULL. It works if zone = icaltimezone_get_utc_timezone(), but there are two different ways to specify that a time is in UTC.

A better long term solution might be to remove is_utc from the icaltimetype struct, that way there's no way to have this ambiguity where UTC times can be set in two different places. Then zone = NULL can mean the time is floating, otherwise the zone explicitly specifies the time zone.