### PR TITLE
Create typedef for line_gen_func in icalparser.h and icalparser.c

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -476,8 +476,8 @@ static char *parser_get_next_parameter(char *line, char **end)
  * Get a single property line, from the property name through the
  * final new line, and include any continuation lines
  */
-char *icalparser_get_line(icalparser *parser,
-                          char *(*line_gen_func) (char *s, size_t size, void *d))
+char *icalparser_get_line(icalparser *parser, 
+                          icalparser_line_gen_func *line_gen_func)
 {
     char *line;
     char *line_p;
@@ -626,7 +626,7 @@ static int line_is_blank(char *line)
 }
 
 icalcomponent *icalparser_parse(icalparser *parser,
-                                char *(*line_gen_func) (char *s, size_t size, void *d))
+                                icalparser_line_gen_func *line_gen_func)
 {
     char *line;
     icalcomponent *c = 0;

--- a/src/libical/icalparser.h
+++ b/src/libical/icalparser.h
@@ -71,6 +71,8 @@ typedef enum icalparser_state
     ICALPARSER_IN_PROGRESS
 } icalparser_state;
 
+typedef char *(icalparser_line_gen_func) (char *s, size_t size, void *d);
+
 /**
  * @brief Creates a new ::icalparser.
  * @return An ::icalparser object
@@ -269,8 +271,7 @@ LIBICAL_ICAL_EXPORT void icalparser_free(icalparser *parser);
  * ```
  */
 LIBICAL_ICAL_EXPORT icalcomponent *icalparser_parse(icalparser *parser,
-                                                    char *(*line_gen_func) (char *s,
-                                                                            size_t size, void *d));
+                                                    icalparser_line_gen_func *line_gen_func);
 
 /**
  * @brief Sets the data that icalparser_parse will give to the line_gen_func
@@ -331,8 +332,7 @@ LIBICAL_ICAL_EXPORT icalcomponent *icalparser_parse_string(const char *str);
  * call icalparser_set_gen_data().
  */
 LIBICAL_ICAL_EXPORT char *icalparser_get_line(icalparser *parser,
-                                              char *(*line_gen_func) (char *s,
-                                                                      size_t size, void *d));
+                                              icalparser_line_gen_func *line_gen_func);
 
 LIBICAL_ICAL_EXPORT char *icalparser_string_line_generator(char *out, size_t buf_size, void *d);
 


### PR DESCRIPTION
I think it would be smart to make a typedef for the `line_gen_func` in `icalparser.h` — like this it's easier to document it with doxygen and it keeps things DRY. 😊

What do you think?