### PR TITLE
Add doxygen documentation to icalparameter.h

### DIFF
--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -173,7 +173,7 @@ char *icalparameter_as_ical_string(icalparameter *param)
     return buf;
 }
 
-/**
+/*
  * checks whether this character is allowed in a (Q)SAFE-CHAR
  *
  * QSAFE-CHAR   = WSP / %x21 / %x23-7E / NON-US-ASCII

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -20,7 +20,8 @@
 /**
  * @file icalparameter.h
  *
- * Functions to work with ical parameter objects.
+ * Functions to work with ical parameter objects, which represent
+ * parameters to property objects.
  */
 
 #ifndef ICALPARAMETER_H
@@ -33,128 +34,233 @@
 /*typedef struct icalparameter_impl icalparameter;*/
 
 /**
- * @brief Creates new icalparameter object.
- * @param kind The kind of icalparameter to create.
- * @return An icalparameter with the given kind.
+ * @brief Creates new ::icalparameter object.
+ * @param kind The kind of ::icalparameter to create.
+ * @return An ::icalparameter with the given kind.
  *
  * @par Error hadling
  * If there was an interal error regarding
- * memory allocation, it returns NULL and sets
- * icalerrno to ICAL_NEWFAILED_ERROR.
+ * memory allocation, it returns `NULL` and sets
+ * ::icalerrno to ::ICAL_NEWFAILED_ERROR.
  *
  * @par Ownership
  * Objects created by this method are owned by the caller and
  * must be released with the icalparameter_free() method.
+ *
+ * ### Usage
+ * ```c
+ * // create new parameter
+ * icalparameter *parameter = icalparameter_new();
+ *
+ * if(parameter) {
+ *     // use parameter ...
+ * }
+ *
+ * // release parameter
+ * icalparameter_free(parameter);
+ * ```
  */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new(icalparameter_kind kind);
 
 /**
- * @brief Creates new icalparameter as a clone of the given one.
- * @param p The existing, non-NULL parameter to clone.
- * @return A icalparameter that is a clone of the given one.
+ * @brief Creates new ::icalparameter as a clone of the given one.
+ * @param p The existing, non-`NULL` parameter to clone.
+ * @return An ::icalparameter that is a clone of the given one.
  *
  * @par Error handling
- * If p is `NULL`, it returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR.
+ * If @a p is `NULL`, it returns `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR.
  * If there was an internal error cloning the data, it returns `NULL`
- * without reporting any error in icalerrno.
+ * without reporting any error in ::icalerrno.
  *
  * @par Ownership
  * Objects created by this method are owned by the caller and
  * must be released with the icalparameter_free() method.
+ *
+ * ### Usage
+ * ```x
+ * // create an icalparameter
+ * icalparameter *param = icalparameter_new_from_string("ROLE=CHAIR");
+ *
+ * // clone the parameter
+ * icalparameter *clone = icalparameter_new_clone(param);
+ *
+ * if(clone) {
+ *     // use clone ...
+ * }
+ *
+ * // release parameters
+ * icalparameter_free(param);
+ * icalparameter_free(clone);
+ * ```
  */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new_clone(icalparameter *p);
 
-/** 
- * @brief Create icalparameter object from string 
- * @param value The string from which to create the icalparameter, in the form "PARAMNAME=VALUE"
- * @return An icalparameter that corresponds to the given string.
+/**
+ * @brief Create ::icalparameter object from string
+ * @param value The string from which to create the ::icalparameter, in the form `"PARAMNAME=VALUE"`
+ * @return An ::icalparameter that corresponds to the given string.
  *
  * @par Error handling
- * If there was an internal error copying data, it returns NULL and sets
- * icalerrno to `ICAL_NEWFAILED_ERROR`. If value was `NULL`, it returns
- * `NULL` and sets icalerrno to ICAL_BADARG_ERROR. If value was malformed,
- * it returns `NULL` and sets icalerrno to ICAL_MALFORMEDDATA_ERROR.
- *  
+ * If there was an internal error copying data, it returns `NULL` and sets
+ * ::icalerrno to ::ICAL_NEWFAILED_ERROR. If @a value was `NULL`, it returns
+ * `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR. If @a value was malformed,
+ * it returns `NULL` and sets ::icalerrno to ::ICAL_MALFORMEDDATA_ERROR.
+ *
  * @par Ownership
  * Objects created by this method are owned by the caller and
  * must be released with the icalparameter_free() method.
+ *
+ * ### Usage
+ * ```c
+ * icalparameter *param = icalparameter_new_from_string("ROLE=CHAIR");
+ *
+ * if(param) {
+ *     // use param ...
+ * }
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new_from_string(const char *value);
 
 /**
- * @brief Create icalparameter of a given kind with a given value
- * @param kind The kind of icalparameter to create
+ * @brief Create ::icalparameter of a given @a kind with a given @a value
+ * @param kind The kind of ::icalparameter to create
  * @param value The value of the parameter
- * @return An icalparameter with the given kind and value.
+ * @return An ::icalparameter with the given kind and value.
  *
  * @par Error handling
- * If value is `NULL`, it returns `NULL` and set icalerrno to ICAL_BADARG_ERROR.
+ * If value is `NULL`, it returns `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR.
  *
  * @par Ownership
  * Objects created by this method are owned by the caller and
  * must be released with the icalparameter_free() method.
+ *
+ * ### Example
+ * ```c
+ * // create new parameter
+ * icalparameter *param;
+ * param = icalparameter_new_from_value_string(ICAL_ROLE_PARAMETER, "CHAIR");
+ *
+ * // check parameter
+ * assert(0 == strcmp(icalparameter_get_iana_name(param), "ROLE"));
+ * assert(0 == strcmp(icalparameter_get_iana_value(param), "CHAIR"));
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new_from_value_string(icalparameter_kind kind,
                                                                        const char *value);
 
 /**
- * @brief Frees an icalparameter object.
+ * @brief Frees an ::icalparameter object.
  * @param parameter The icalparameter to free
  *
  * This method needs to be used on all parameter objects returned
- * from any of the `new` methods including icalparameter_new(), icalparameter_new_clone(),
+ * from any of the `_new()` methods including icalparameter_new(), icalparameter_new_clone(),
  * icalparameter_new_from_string() and icalparameter_new_from_value_string(),
- * when they are not needed anymore.
+ * when they are not needed anymore and to be released.
+ *
+ * ### Usage
+ * ```c
+ * icalparameter *param = icalparameter_new();
+ *
+ * if(param) {
+ *     // use param...
+ * }
+ *
+ * // after use, release it
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT void icalparameter_free(icalparameter *parameter);
 
 /**
- * @brief Convert icalparameter into an string representation
- * @param parameter The icalparameter to convert
+ * @brief Convert ::icalparameter into an string representation
+ * @param parameter The ::icalparameter to convert
  * @return A string representing the parameter according to RFC5445/RFC6868.
+ * @sa icalparameter_as_ical_string_r()
  *
  * @par Error handling
  * If there is any error, the method returns `NULL`. Furthermore,
- * if parameter is `NULL`, it also sets icalerrno to ICAL_BADARG_ERROR. 
- * If it doesn't recognize the kind of the parameter, it sets icalerrno 
- * it ICAL_BADARG_ERROR. If the parameter is otherwise malformed, it 
- * sets icalerrno to ICAL_MALFORMEDDATE_ERROR.
+ * if @a parameter is `NULL`, it also sets ::icalerrno to ::ICAL_BADARG_ERROR.
+ * If it doesn't recognize the kind of the parameter, it sets ::icalerrno
+ * it ::ICAL_BADARG_ERROR. If the parameter is otherwise malformed, it
+ * sets ::icalerrno to ::ICAL_MALFORMEDDATA_ERROR.
  *
  * @par Ownership
  * Strings returned by this method are owned by libical, they must
  * not be free'd and they may be reclaimed with the next call into
  * the library. A version of this function, which returns strings
  * that are not owned by libical, is icalparameter_as_ical_string_r().
+ *
+ * ### Usage
+ * ```c
+ * icalparameter *param = icalparameter_new_from_string("ROLE=CHAIR");
+ *
+ * if(param) {
+ *     printf("%s\n", icalparameter_as_ical_string(param));
+ * }
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter);
 
 /**
- * @brief Convert icalparameter into an string representation
- * @param parameter The icalparameter to convert
+ * @brief Convert ::icalparameter into an string representation
+ * @param parameter The ::icalparameter to convert
  * @return A string representing the parameter according to RFC5445/RFC6868.
+ * @sa icalparameter_as_ical_string()
  *
  * @par Error handling
  * If there is any error, the method returns `NULL`. Furthermore,
- * if parameter is `NULL`, it also sets icalerrno to ICAL_BADARG_ERROR. 
- * If it doesn't recognize the kind of the parameter, it sets icalerrno 
- * it ICAL_BADARG_ERROR. If the parameter is otherwise malformed, it 
- * sets icalerrno to ICAL_MALFORMEDDATE_ERROR.
+ * if parameter is `NULL`, it also sets ::icalerrno to ::ICAL_BADARG_ERROR.
+ * If it doesn't recognize the kind of the parameter, it sets ::icalerrno
+ * to ::ICAL_BADARG_ERROR. If the parameter is otherwise malformed, it
+ * sets ::icalerrno to ::ICAL_MALFORMEDDATA_ERROR.
  *
  * @par Ownership
  * Strings returned by this method are owned by the caller, thus they need
  * to be manually free'd after use. A version of this function which returns
  * strings that do not need to be free'd manually is
  * icalparameter_as_ical_string().
+ *
+ * ### Usage
+ * ```c
+ * icalparameter *param = icalparameter_new_from_string("ROLE=CHAIR");
+ *
+ * if(param) {
+ *     char *str = icalparameter_as_ical_string(param);
+ *     printf("%s\n", str);
+ *     free(str);
+ * }
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string_r(icalparameter *parameter);
 
 /**
  * @brief Returns the icalparameter_kind of parameter
- * @param parameter The icalparameter whose kind we want to determine
+ * @param parameter The icalparameter whose kind to determine
  * @return The icalparameter_kind of the parameter
  *
  * @par Error handling
- * Returns ICAL_NO_PARAMETER when passed `NULL`.
+ * Returns ::ICAL_NO_PARAMETER when passed `NULL`.
+ *
+ * ### Usage
+ * ```c
+ * // create parameter
+ * icalparameter *param = icalparameter_new_from_string("ROLE=CHAIR");
+ *
+ * // check what type of parameter this is
+ * assert(icalparameter_isa(param) == ICAL_ROLE_PARAMETER);
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_isa(icalparameter *parameter);
 
@@ -168,171 +274,337 @@ LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_isa(icalparameter *paramete
  *
  * @par Error handling
  * When given a `NULL` object, it returns 0.
+ *
+ * ### Usage
+ * ```c
+ * // create parameter
+ * icalparameter *param = icalparameter_new_from_string("ROLE=CHAIR");
+ *
+ * // check if it's a parameter
+ * assert(icalparameter_isa_parameter(param));
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT int icalparameter_isa_parameter(void *param);
 
 /* Access the name of an X parameter */
 
 /**
- * @brief Sets the X-name of `param` to `v`
- * @param param The icalparameter to change
- * @param v The X-name to set param to
- * 
+ * @brief Sets the X-name of @a param to @a v
+ * @param param The ::icalparameter to change
+ * @param v The X-name to set @a param to
+ * @sa icalparameter_get_xname()
+ *
  * @par Error handling
- * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If either @a param or @a v are `NULL`, it sets ::icalerrno to ::ICAL_BARARG_ERROR.
  * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
  *
  * @par Ownership
- * The passed string `v` stays in the ownership of the caller - libical
+ * The passed string @a v stays in the ownership of the caller - libical
  * creates a copy of it.
+ *
+ * ### Usage
+ * ```c
+ * // creates new parameter
+ * icalparameter *param = icalparameter_new();
+ *
+ * // sets xname
+ * icalparameter_set_xname(param, "X-TEST");
+ *
+ * // compare xname
+ * assert(0 == strcmp(icalparameter_get_xname(param), "X-TEST"));
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT void icalparameter_set_xname(icalparameter *param, const char *v);
 
 /**
- * @brief Returns the X-name of `param`
- * @param param The icalparameter whose X-name is to be returned
- * @return A string representing the X-name of param
+ * @brief Returns the X-name of @a param
+ * @param param The ::icalparameter whose X-name is to be returned
+ * @return A string representing the X-name of @a param
+ * @sa icalparameter_set_xname()
  *
  * @par Error handling
- * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
- * is passed instead of an icalparameter.
+ * Returns `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an ::icalparameter.
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
  * be free'd by the caller.
+ *
+ * ### Usage
+ * ```c
+ * // creates new parameter
+ * icalparameter *param = icalparameter_new();
+ *
+ * // sets xname
+ * icalparameter_set_xname(param, "X-TEST");
+ *
+ * // compare xname
+ * assert(0 == strcmp(icalparameter_get_xname(param), "X-TEST"));
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_xname(icalparameter *param);
 
 /**
- * @brief Sets the X-value of `param` to `v`
- * @param param The icalparameter to change
- * @param v The X-value to set param to
- * 
+ * @brief Sets the X-value of @a param to @a v
+ * @param param The ::icalparameter to change
+ * @param v The X-value to set @a param to
+ * @sa icalparameter_get_xvalue()
+ *
  * @par Error handling
- * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If either @a param or @a v are `NULL`, it sets ::icalerrno to ::ICAL_BARARG_ERROR.
  * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
  *
  * @par Ownership
- * The passed string `v` stays in the ownership of the caller - libical
+ * The passed string @a v stays in the ownership of the caller - libical
  * creates a copy of it.
+ *
+ * ### Usage
+ * ```c
+ * // create new parameter
+ * icalparameter *param = icalparameter_new_from_string("X-TEST=FAIL");
+ *
+ * // set test to success
+ * icalparameter_set_xvalue(param, "SUCCESS");
+ *
+ * // check that it worked
+ * assert(0 == strcmp(icalparameter_get_xvalue(param), "SUCCESS"));
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT void icalparameter_set_xvalue(icalparameter *param, const char *v);
 
 /**
- * @brief Returns the X-value of `param`
- * @param param The icalparameter whose X-value is to be returned
- * @return A string representing the X-value of param
+ * @brief Returns the X-value of @a param
+ * @param param The ::icalparameter whose X-value is to be returned
+ * @return A string representing the X-value of @a param
+ * @sa icalparameter_set_xvalue()
  *
  * @par Error handling
- * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
- * is passed instead of an icalparameter.
+ * Returns `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an ::icalparameter.
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
  * be free'd by the caller.
+ *
+ * ### Usage
+ * ```c
+ * // create new parameter
+ * icalparameter *param = icalparameter_new_from_string("X-TEST=FAIL");
+ *
+ * // set test to success
+ * icalparameter_set_xvalue(param, "SUCCESS");
+ *
+ * // check that it worked
+ * assert(0 == strcmp(icalparameter_get_xvalue(param), "SUCCESS"));
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_xvalue(icalparameter *param);
 
 /* Access the name of an IANA parameter */
 
 /**
- * @brief Sets the IANA name of `param` to `v`
+ * @brief Sets the IANA name of @a param to @a v
  * @param param The icalparameter to change
- * @param v The name to set param to
- * 
+ * @param v The IANA name to set @a param to
+ * @sa icalparameter_get_iana_name()
+ *
  * @par Error handling
- * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If either @a param or @a v are `NULL`, it sets ::icalerrno to ::ICAL_BARARG_ERROR.
  * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
  *
  * @par Ownership
- * The passed string `v` stays in the ownership of the caller - libical
+ * The passed string @a v stays in the ownership of the caller - libical
  * creates a copy of it.
+ *
+ * ### Usage
+ * ```c
+ * // creates new parameter
+ * icalparameter *param = icalparameter_new();
+ *
+ * // sets iana name
+ * icalparameter_set_iana_name(param, "ROLE");
+ *
+ * // compare iana name
+ * assert(0 == strcmp(icalparameter_get_iana_name(param), "X-TEST"));
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT void icalparameter_set_iana_name(icalparameter *param, const char *v);
 
 /**
- * @brief Returns the IANA name of `param`
- * @param param The icalparameter whose name is to be returned
- * @return A string representing the name of param
+ * @brief Returns the IANA name of @a param
+ * @param param The ::icalparameter whose IANA name is to be returned
+ * @return A string representing the IANA name of @a param
+ * @sa icalparameter_set_iana_name()
  *
  * @par Error handling
- * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
- * is passed instead of an icalparameter.
+ * Returns `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an ::icalparameter.
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
  * be free'd by the caller.
+ *
+ * ### Usage
+ * ```c
+ * // creates new parameter
+ * icalparameter *param = icalparameter_new();
+ *
+ * // sets iana name
+ * icalparameter_set_iana_name(param, "X-TEST");
+ *
+ * // compare iana name
+ * assert(0 == strcmp(icalparameter_get_iana_name(param), "X-TEST"));
+ *
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_iana_name(icalparameter *param);
 
 /**
- * @brief Sets the IANA value of `param` to `v`
- * @param param The icalparameter to change
- * @param v The value to set param to
- * 
+ * @brief Sets the IANA value of @a param to @a v
+ * @param param The ::icalparameter to change
+ * @param v The IANA value to set @a param to
+ * @sa icalparameter_get_iana_value()
+ *
  * @par Error handling
- * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If either @a param or @a v are `NULL`, it sets ::icalerrno to ::ICAL_BARARG_ERROR.
  * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
  *
  * @par Ownership
- * The passed string `v` stays in the ownership of the caller - libical
+ * The passed string @a v stays in the ownership of the caller - libical
  * creates a copy of it.
+ *
+ * ### Usage
+ * ```c
+ * // create new parameter
+ * icalparameter *param = icalparameter_new_from_string("ROLE=ATTENDEE");
+ *
+ * // set role to chair
+ * icalparameter_set_iana_value(param, "CHAIR");
+ *
+ * // check that it worked
+ * assert(0 == strcmp(icalparameter_get_iana_value(param), "SUCCESS"));
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT void icalparameter_set_iana_value(icalparameter *param, const char *v);
 
 /**
- * @brief Returns the IANA value of `param`
- * @param param The icalparameter whose value is to be returned
- * @return A string representing the value of param
+ * @brief Returns the IANA value of @a param
+ * @param param The ::icalparameter whose value is to be returned
+ * @return A string representing the value of @a param
+ * @sa icalparameter_set_iana_value()
  *
  * @par Error handling
- * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
- * is passed instead of an icalparameter.
+ * Returns `NULL` and sets ::icalerrno to ::ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an ::icalparameter.
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
  * be free'd by the caller.
+ *
+ * ### Usage
+ * ```c
+ * // create new parameter
+ * icalparameter *param = icalparameter_new_from_string("ROLE=ATTENDEE");
+ *
+ * // set role to chair
+ * icalparameter_set_iana_value(param, "CHAIR");
+ *
+ * // check that it worked
+ * assert(0 == strcmp(icalparameter_get_iana_value(param), "SUCCESS"));
+ *
+ * // release memory
+ * icalparameter_free(param);
+ * ```
  */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_iana_value(icalparameter *param);
 
 /**
  * @brief Determines if two parameters have the same name
- * @param param1
- * @param param2
+ * @param param1 First parameter to compare
+ * @param param2 Second parameter to compare
  * @return 1 if they have the same name, 0 otherwise.
  *
  * @par Error handling
- * If either of param1 or param2 are `NULL`, it returns 0 and sets
- * icalerrno to ICALL_BADARG_ERROR.
+ * If either of @a param1 or @a param2 are `NULL`, it returns 0 and sets
+ * ::icalerrno to ::ICAL_BADARG_ERROR.
+ *
+ * @par Ownership
+ * Does not take ownership of either ::icalparameter.
+ *
+ * ### Example
+ * ```c
+ * icalparameter *param1 = icalparameter_new_from_string("ROLE=CHAIR");
+ * icalparameter *param2 = icalparameter_new_from_string("EMAIL=mailto@example.com");
+ * assert(icalparameter_has_same_name(param1, param2) == 0);
+ *
+ * icalparameter_free(param1);
+ * icalparameter_free(param2);
+ * ```
  */
 LIBICAL_ICAL_EXPORT int icalparameter_has_same_name(icalparameter *param1, icalparameter *param2);
 
 /* Convert enumerations */
 
 /**
- * @brief Returns a string representing the icalparameter_kind
+ * @brief Returns a string representing the given ::icalparameter_kind
  * @param kind The icalparameter_kind
  * @return A string representing kind
  *
  * @par Error handling
- * When passed a nonexisting icalparameter_kind, it returns `NULL`.
+ * When passed a nonexisting ::icalparameter_kind, it returns `NULL`.
  *
  * @par Ownership
  * The string that is returned by this function is owned by libical and
  * must not be free'd by the caller.
+ *
+ * ### Usage
+ * ```c
+ * assert(0 == strcmp(icalparameter_kind_to_string(ICAL_ROLE_PARAMETER), "ROLE"));
+ * assert(0 == strcmp(icalparameter_kind_to_string(ICAL_EMAIL_PARAMETER), "EMAIL));
+ * assert(0 == strcmp(icalparameter_kind_to_string(ICAL_ID_PARAMETER), "ID"));
+ * ```
  */
 LIBICAL_ICAL_EXPORT const char *icalparameter_kind_to_string(icalparameter_kind kind);
 
 /**
- * @brief Returns the icalparameter_kind for a given string
+ * @brief Returns the ::icalparameter_kind for a given string
  * @param string A string describing an icalparameter_kind
  * @return An icalparameter_kind
  *
  * @par Error handling
- * Returns ICAL_NO_PARAMETER if passed `NULL`. 
+ * Returns ::ICAL_NO_PARAMETER if @a string is `NULL`.
  * If it can't find the parameter, depending on
  * the ical_get_unknown_token_handling_setting(), it returns either
- * ICAL_NO_PARAMETER or ICAL_IANA_PARAMETER.
+ * ::ICAL_NO_PARAMETER or ::ICAL_IANA_PARAMETER.
+ *
+ * @par Ownership
+ * Does not take ownership of @a string.
+ *
+ * ### Usage
+ * ```c
+ * assert(icalparameter_string_to_kind("ROLE")  == ICAL_ROLE_PARAMETER);
+ * assert(icalparameter_string_to_kind("EMAIL") == ICAL_EMAIL_PARAMETER);
+ * assert(icalparameter_string_to_kind("ID")    == ICAL_ID_PARAMETER);
+ * ```
  */
 LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_string_to_kind(const char *string);
 

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -17,6 +17,12 @@
     the License at http://www.mozilla.org/MPL/
 ======================================================================*/
 
+/**
+ * @file icalparameter.h
+ *
+ * Functions to work with ical parameter objects.
+ */
+
 #ifndef ICALPARAMETER_H
 #define ICALPARAMETER_H
 
@@ -26,52 +32,308 @@
 /* Declared in icalderivedparameter.h */
 /*typedef struct icalparameter_impl icalparameter;*/
 
+/**
+ * @brief Creates new icalparameter object.
+ * @param kind The kind of icalparameter to create.
+ * @return An icalparameter with the given kind.
+ *
+ * @par Error hadling
+ * If there was an interal error regarding
+ * memory allocation, it returns NULL and sets
+ * icalerrno to ICAL_NEWFAILED_ERROR.
+ *
+ * @par Ownership
+ * Objects created by this method are owned by the caller and
+ * must be released with the icalparameter_free() method.
+ */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new(icalparameter_kind kind);
 
+/**
+ * @brief Creates new icalparameter as a clone of the given one.
+ * @param p The existing, non-NULL parameter to clone.
+ * @return A icalparameter that is a clone of the given one.
+ *
+ * @par Error handling
+ * If p is `NULL`, it returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR.
+ * If there was an internal error cloning the data, it returns `NULL`
+ * without reporting any error in icalerrno.
+ *
+ * @par Ownership
+ * Objects created by this method are owned by the caller and
+ * must be released with the icalparameter_free() method.
+ */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new_clone(icalparameter *p);
 
-/* Create from string of form "PARAMNAME=VALUE" */
+/** 
+ * @brief Create icalparameter object from string 
+ * @param value The string from which to create the icalparameter, in the form "PARAMNAME=VALUE"
+ * @return An icalparameter that corresponds to the given string.
+ *
+ * @par Error handling
+ * If there was an internal error copying data, it returns NULL and sets
+ * icalerrno to `ICAL_NEWFAILED_ERROR`. If value was `NULL`, it returns
+ * `NULL` and sets icalerrno to ICAL_BADARG_ERROR. If value was malformed,
+ * it returns `NULL` and sets icalerrno to ICAL_MALFORMEDDATA_ERROR.
+ *  
+ * @par Ownership
+ * Objects created by this method are owned by the caller and
+ * must be released with the icalparameter_free() method.
+ */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new_from_string(const char *value);
 
-/* Create from just the value, the part after the "=" */
+/**
+ * @brief Create icalparameter of a given kind with a given value
+ * @param kind The kind of icalparameter to create
+ * @param value The value of the parameter
+ * @return An icalparameter with the given kind and value.
+ *
+ * @par Error handling
+ * If value is `NULL`, it returns `NULL` and set icalerrno to ICAL_BADARG_ERROR.
+ *
+ * @par Ownership
+ * Objects created by this method are owned by the caller and
+ * must be released with the icalparameter_free() method.
+ */
 LIBICAL_ICAL_EXPORT icalparameter *icalparameter_new_from_value_string(icalparameter_kind kind,
                                                                        const char *value);
 
+/**
+ * @brief Frees an icalparameter object.
+ * @param parameter The icalparameter to free
+ *
+ * This method needs to be used on all parameter objects returned
+ * from any of the `new` methods including icalparameter_new(), icalparameter_new_clone(),
+ * icalparameter_new_from_string() and icalparameter_new_from_value_string(),
+ * when they are not needed anymore.
+ */
 LIBICAL_ICAL_EXPORT void icalparameter_free(icalparameter *parameter);
 
+/**
+ * @brief Convert icalparameter into an string representation
+ * @param parameter The icalparameter to convert
+ * @return A string representing the parameter according to RFC5445/RFC6868.
+ *
+ * @par Error handling
+ * If there is any error, the method returns `NULL`. Furthermore,
+ * if parameter is `NULL`, it also sets icalerrno to ICAL_BADARG_ERROR. 
+ * If it doesn't recognize the kind of the parameter, it sets icalerrno 
+ * it ICAL_BADARG_ERROR. If the parameter is otherwise malformed, it 
+ * sets icalerrno to ICAL_MALFORMEDDATE_ERROR.
+ *
+ * @par Ownership
+ * Strings returned by this method are owned by libical, they must
+ * not be free'd and they may be reclaimed with the next call into
+ * the library. A version of this function, which returns strings
+ * that are not owned by libical, is icalparameter_as_ical_string_r().
+ */
 LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter);
 
+/**
+ * @brief Convert icalparameter into an string representation
+ * @param parameter The icalparameter to convert
+ * @return A string representing the parameter according to RFC5445/RFC6868.
+ *
+ * @par Error handling
+ * If there is any error, the method returns `NULL`. Furthermore,
+ * if parameter is `NULL`, it also sets icalerrno to ICAL_BADARG_ERROR. 
+ * If it doesn't recognize the kind of the parameter, it sets icalerrno 
+ * it ICAL_BADARG_ERROR. If the parameter is otherwise malformed, it 
+ * sets icalerrno to ICAL_MALFORMEDDATE_ERROR.
+ *
+ * @par Ownership
+ * Strings returned by this method are owned by the caller, thus they need
+ * to be manually free'd after use. A version of this function which returns
+ * strings that do not need to be free'd manually is
+ * icalparameter_as_ical_string().
+ */
 LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string_r(icalparameter *parameter);
 
+/**
+ * @brief Returns the icalparameter_kind of parameter
+ * @param parameter The icalparameter whose kind we want to determine
+ * @return The icalparameter_kind of the parameter
+ *
+ * @par Error handling
+ * Returns ICAL_NO_PARAMETER when passed `NULL`.
+ */
 LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_isa(icalparameter *parameter);
 
+/**
+ * @brief Determine if the given param is an icalparameter
+ * @param param The libical-originated object to check
+ * @return 1 if the object is an icalparameter, 0 otherwise.
+ * @note This function expects to be given an object originating from
+ *  libical - if this function is passed anything that is not from
+ *  libical, it's behaviour is undefined.
+ *
+ * @par Error handling
+ * When given a `NULL` object, it returns 0.
+ */
 LIBICAL_ICAL_EXPORT int icalparameter_isa_parameter(void *param);
 
 /* Access the name of an X parameter */
+
+/**
+ * @brief Sets the X-name of `param` to `v`
+ * @param param The icalparameter to change
+ * @param v The X-name to set param to
+ * 
+ * @par Error handling
+ * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
+ *
+ * @par Ownership
+ * The passed string `v` stays in the ownership of the caller - libical
+ * creates a copy of it.
+ */
 LIBICAL_ICAL_EXPORT void icalparameter_set_xname(icalparameter *param, const char *v);
 
+/**
+ * @brief Returns the X-name of `param`
+ * @param param The icalparameter whose X-name is to be returned
+ * @return A string representing the X-name of param
+ *
+ * @par Error handling
+ * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an icalparameter.
+ *
+ * @par Ownership
+ * The string that is returned stays owned by libical and must not
+ * be free'd by the caller.
+ */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_xname(icalparameter *param);
 
+/**
+ * @brief Sets the X-value of `param` to `v`
+ * @param param The icalparameter to change
+ * @param v The X-value to set param to
+ * 
+ * @par Error handling
+ * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
+ *
+ * @par Ownership
+ * The passed string `v` stays in the ownership of the caller - libical
+ * creates a copy of it.
+ */
 LIBICAL_ICAL_EXPORT void icalparameter_set_xvalue(icalparameter *param, const char *v);
 
+/**
+ * @brief Returns the X-value of `param`
+ * @param param The icalparameter whose X-value is to be returned
+ * @return A string representing the X-value of param
+ *
+ * @par Error handling
+ * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an icalparameter.
+ *
+ * @par Ownership
+ * The string that is returned stays owned by libical and must not
+ * be free'd by the caller.
+ */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_xvalue(icalparameter *param);
 
 /* Access the name of an IANA parameter */
+
+/**
+ * @brief Sets the IANA name of `param` to `v`
+ * @param param The icalparameter to change
+ * @param v The name to set param to
+ * 
+ * @par Error handling
+ * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
+ *
+ * @par Ownership
+ * The passed string `v` stays in the ownership of the caller - libical
+ * creates a copy of it.
+ */
 LIBICAL_ICAL_EXPORT void icalparameter_set_iana_name(icalparameter *param, const char *v);
 
+/**
+ * @brief Returns the IANA name of `param`
+ * @param param The icalparameter whose name is to be returned
+ * @return A string representing the name of param
+ *
+ * @par Error handling
+ * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an icalparameter.
+ *
+ * @par Ownership
+ * The string that is returned stays owned by libical and must not
+ * be free'd by the caller.
+ */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_iana_name(icalparameter *param);
 
+/**
+ * @brief Sets the IANA value of `param` to `v`
+ * @param param The icalparameter to change
+ * @param v The value to set param to
+ * 
+ * @par Error handling
+ * If either param or v are `NULL`, it sets icalerrno to ICAL_BARARG_ERROR.
+ * If there is an error acquiring memory, it sets `errno` to `ENOMEM`.
+ *
+ * @par Ownership
+ * The passed string `v` stays in the ownership of the caller - libical
+ * creates a copy of it.
+ */
 LIBICAL_ICAL_EXPORT void icalparameter_set_iana_value(icalparameter *param, const char *v);
 
+/**
+ * @brief Returns the IANA value of `param`
+ * @param param The icalparameter whose value is to be returned
+ * @return A string representing the value of param
+ *
+ * @par Error handling
+ * Returns `NULL` and sets icalerrno to ICAL_BADARG_ERROR when a `NULL`
+ * is passed instead of an icalparameter.
+ *
+ * @par Ownership
+ * The string that is returned stays owned by libical and must not
+ * be free'd by the caller.
+ */
 LIBICAL_ICAL_EXPORT const char *icalparameter_get_iana_value(icalparameter *param);
 
-/* returns 1 if parameters have same name in ICAL, otherwise 0 */
+/**
+ * @brief Determines if two parameters have the same name
+ * @param param1
+ * @param param2
+ * @return 1 if they have the same name, 0 otherwise.
+ *
+ * @par Error handling
+ * If either of param1 or param2 are `NULL`, it returns 0 and sets
+ * icalerrno to ICALL_BADARG_ERROR.
+ */
 LIBICAL_ICAL_EXPORT int icalparameter_has_same_name(icalparameter *param1, icalparameter *param2);
 
 /* Convert enumerations */
 
+/**
+ * @brief Returns a string representing the icalparameter_kind
+ * @param kind The icalparameter_kind
+ * @return A string representing kind
+ *
+ * @par Error handling
+ * When passed a nonexisting icalparameter_kind, it returns `NULL`.
+ *
+ * @par Ownership
+ * The string that is returned by this function is owned by libical and
+ * must not be free'd by the caller.
+ */
 LIBICAL_ICAL_EXPORT const char *icalparameter_kind_to_string(icalparameter_kind kind);
 
+/**
+ * @brief Returns the icalparameter_kind for a given string
+ * @param string A string describing an icalparameter_kind
+ * @return An icalparameter_kind
+ *
+ * @par Error handling
+ * Returns ICAL_NO_PARAMETER if passed `NULL`. 
+ * If it can't find the parameter, depending on
+ * the ical_get_unknown_token_handling_setting(), it returns either
+ * ICAL_NO_PARAMETER or ICAL_IANA_PARAMETER.
+ */
 LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_string_to_kind(const char *string);
 
 #endif

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -38,8 +38,8 @@
  * @param kind The kind of ::icalparameter to create.
  * @return An ::icalparameter with the given kind.
  *
- * @par Error hadling
- * If there was an interal error regarding
+ * @par Error handling
+ * If there was an internal error regarding
  * memory allocation, it returns `NULL` and sets
  * ::icalerrno to ::ICAL_NEWFAILED_ERROR.
  *
@@ -191,7 +191,7 @@ LIBICAL_ICAL_EXPORT void icalparameter_free(icalparameter *parameter);
  *
  * @par Ownership
  * Strings returned by this method are owned by libical, they must
- * not be free'd and they may be reclaimed with the next call into
+ * not be freed and they may be reclaimed with the next call into
  * the library. A version of this function, which returns strings
  * that are not owned by libical, is icalparameter_as_ical_string_r().
  *
@@ -223,8 +223,8 @@ LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter)
  *
  * @par Ownership
  * Strings returned by this method are owned by the caller, thus they need
- * to be manually free'd after use. A version of this function which returns
- * strings that do not need to be free'd manually is
+ * to be manually `free()`d after use. A version of this function which returns
+ * strings that do not need to be freed manually is
  * icalparameter_as_ical_string().
  *
  * ### Usage
@@ -270,7 +270,7 @@ LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_isa(icalparameter *paramete
  * @return 1 if the object is an icalparameter, 0 otherwise.
  * @note This function expects to be given an object originating from
  *  libical - if this function is passed anything that is not from
- *  libical, it's behaviour is undefined.
+ *  libical, it's behavior is undefined.
  *
  * @par Error handling
  * When given a `NULL` object, it returns 0.
@@ -333,7 +333,7 @@ LIBICAL_ICAL_EXPORT void icalparameter_set_xname(icalparameter *param, const cha
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
- * be free'd by the caller.
+ * be freed by the caller.
  *
  * ### Usage
  * ```c
@@ -394,7 +394,7 @@ LIBICAL_ICAL_EXPORT void icalparameter_set_xvalue(icalparameter *param, const ch
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
- * be free'd by the caller.
+ * be freed by the caller.
  *
  * ### Usage
  * ```c
@@ -457,7 +457,7 @@ LIBICAL_ICAL_EXPORT void icalparameter_set_iana_name(icalparameter *param, const
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
- * be free'd by the caller.
+ * be freed by the caller.
  *
  * ### Usage
  * ```c
@@ -518,7 +518,7 @@ LIBICAL_ICAL_EXPORT void icalparameter_set_iana_value(icalparameter *param, cons
  *
  * @par Ownership
  * The string that is returned stays owned by libical and must not
- * be free'd by the caller.
+ * be freed by the caller.
  *
  * ### Usage
  * ```c
@@ -552,10 +552,14 @@ LIBICAL_ICAL_EXPORT const char *icalparameter_get_iana_value(icalparameter *para
  *
  * ### Example
  * ```c
+ * // create two parameters
  * icalparameter *param1 = icalparameter_new_from_string("ROLE=CHAIR");
  * icalparameter *param2 = icalparameter_new_from_string("EMAIL=mailto@example.com");
+ *
+ * // compare parameter names for equality
  * assert(icalparameter_has_same_name(param1, param2) == 0);
  *
+ * // release memory
  * icalparameter_free(param1);
  * icalparameter_free(param2);
  * ```
@@ -570,11 +574,11 @@ LIBICAL_ICAL_EXPORT int icalparameter_has_same_name(icalparameter *param1, icalp
  * @return A string representing kind
  *
  * @par Error handling
- * When passed a nonexisting ::icalparameter_kind, it returns `NULL`.
+ * When passed a non-existing ::icalparameter_kind, it returns `NULL`.
  *
  * @par Ownership
  * The string that is returned by this function is owned by libical and
- * must not be free'd by the caller.
+ * must not be freed by the caller.
  *
  * ### Usage
  * ```c


### PR DESCRIPTION
This adds doxygen documentation for `icalparameter.h` — should be fairly complete as well. However, I was unable to document a few other icalparameter-related functions that are defined in `icalderivedparameter.h`, because `doxygen` simply doesn't seem to have access to them. Maybe someone should someday look into it. 