### PR TITLE
Make libical reprodicuble

### DIFF
--- a/scripts/mkderivedvalues.pl
+++ b/scripts/mkderivedvalues.pl
@@ -155,7 +155,7 @@ sub insert_code
     my $count = scalar(keys %h) + 1;
     print "static const struct icalvalue_kind_map value_map[$count]={\n";
 
-    foreach $value (keys %h) {
+    foreach $value (sort keys %h) {
 
       next if $value eq 'NO' or $value eq 'ANY';
 


### PR DESCRIPTION
Sort the hash which generates the C struct so that the struct is
identical on every build, since normally this is random. With this
change libical is fully reprodicuble.

See the non-reprodicble output here https://tests.reproducible-builds.org/archlinux/extra/libical/libical-3.0.1-1-x86_64.pkg.tar.xz.html