### PR TITLE
FIX: `icalparser_line_gen_func` is not declared as a pointer.

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -477,7 +477,7 @@ static char *parser_get_next_parameter(char *line, char **end)
  * final new line, and include any continuation lines
  */
 char *icalparser_get_line(icalparser *parser, 
-                          icalparser_line_gen_func *line_gen_func)
+                          icalparser_line_gen_func line_gen_func)
 {
     char *line;
     char *line_p;
@@ -626,7 +626,7 @@ static int line_is_blank(char *line)
 }
 
 icalcomponent *icalparser_parse(icalparser *parser,
-                                icalparser_line_gen_func *line_gen_func)
+                                icalparser_line_gen_func line_gen_func)
 {
     char *line;
     icalcomponent *c = 0;

--- a/src/libical/icalparser.h
+++ b/src/libical/icalparser.h
@@ -71,7 +71,7 @@ typedef enum icalparser_state
     ICALPARSER_IN_PROGRESS
 } icalparser_state;
 
-typedef char *(icalparser_line_gen_func) (char *s, size_t size, void *d);
+typedef char *(*icalparser_line_gen_func) (char *s, size_t size, void *d);
 
 /**
  * @brief Creates a new ::icalparser.
@@ -270,7 +270,7 @@ LIBICAL_ICAL_EXPORT void icalparser_free(icalparser *parser);
  * ```
  */
 LIBICAL_ICAL_EXPORT icalcomponent *icalparser_parse(icalparser *parser,
-                                                    icalparser_line_gen_func *line_gen_func);
+                                                    icalparser_line_gen_func line_gen_func);
 
 /**
  * @brief Sets the data that icalparser_parse will give to the line_gen_func
@@ -331,7 +331,7 @@ LIBICAL_ICAL_EXPORT icalcomponent *icalparser_parse_string(const char *str);
  * call icalparser_set_gen_data().
  */
 LIBICAL_ICAL_EXPORT char *icalparser_get_line(icalparser *parser,
-                                              icalparser_line_gen_func *line_gen_func);
+                                              icalparser_line_gen_func line_gen_func);
 
 LIBICAL_ICAL_EXPORT char *icalparser_string_line_generator(char *out, size_t buf_size, void *d);
 


### PR DESCRIPTION
A new function `typedef` recently merged in `master`

     typedef char *(icalparser_line_gen_func) (char *s, size_t size, void *d);

is not declared as a pointer, unlike other `typedef` for the functions in the API, e.g. `icalattach_free_fn_t`, `pvl_comparef`, etc.
This difference confuses API users and need to give `*` when using it.