### PR TITLE
make memory management configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@
 #  Set to prevent empty properties from being replaced with X-LIC-ERROR properties.
 #  Default=false
 #
+# -DICAL_USE_MALLOC=[true|false]
+#  If set, the standard system functions (malloc, realloc, free) will be used for memory management by default.
+#  If not set, the user must use icalmemory_set_mem_alloc_funcs function to provide the functions to use.
+#  Default=true (use system malloc, etc. by default).
+#
 # -DUSE_BUILTIN_TZDATA=[true|false]
 #  Set to build using our own timezone data.
 #  Default=false (use the system timezone data on non-Windows systems)
@@ -263,6 +268,18 @@ if(ICAL_ALLOW_EMPTY_PROPERTIES)
   set(ICAL_ALLOW_EMPTY_PROPERTIES 1)
 else()
   set(ICAL_ALLOW_EMPTY_PROPERTIES 0)
+endif()
+
+option(ICAL_USE_MALLOC "Make use of the standard system memory management functions (malloc, realloc, free)." True)
+add_feature_info(
+  "Option ICAL_USE_MALLOC"
+  ICAL_USE_MALLOC
+  "the standard system memory management functions will be used by default"
+)
+if(ICAL_USE_MALLOC)
+  set(ICAL_USE_MALLOC 1)
+else()
+  set(ICAL_USE_MALLOC 0)
 endif()
 
 option(USE_BUILTIN_TZDATA "build using our own timezone data, else use the system timezone data on non-Windows systems. ALWAYS true on Windows.")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -175,6 +175,10 @@
 /* Define to prevent empty properties from being replaced with X-LIC-ERROR properties */
 #define ICAL_ALLOW_EMPTY_PROPERTIES ${ICAL_ALLOW_EMPTY_PROPERTIES}
 
+/* Define to 1 to use the standard system functions malloc(), etc. for memory management by default. */
+#define ICAL_USE_MALLOC ${ICAL_USE_MALLOC}
+
+
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "${PROJECT_URL}"
 

--- a/scripts/mkderivedvalues.pl
+++ b/scripts/mkderivedvalues.pl
@@ -227,7 +227,7 @@ $pointer_check_rv\
       if ($union_data eq 'string') {
 
         print
-"    if (impl->data.v_${union_data} != 0) {\n        free((void *)impl->data.v_${union_data});\n    }\n";
+"    if (impl->data.v_${union_data} != 0) {\n        icalmemory_free_buffer((void *)impl->data.v_${union_data});\n    }\n";
       }
 
       print "\

--- a/src/libical/icalattach.c
+++ b/src/libical/icalattach.c
@@ -22,6 +22,7 @@
 
 #include "icalattachimpl.h"
 #include "icalerror.h"
+#include "icalmemory.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -33,13 +34,13 @@ icalattach *icalattach_new_from_url(const char *url)
 
     icalerror_check_arg_rz((url != NULL), "url");
 
-    if ((attach = malloc(sizeof(icalattach))) == NULL) {
+    if ((attach = icalmemory_new_buffer(sizeof(icalattach))) == NULL) {
         errno = ENOMEM;
         return NULL;
     }
 
-    if ((url_copy = strdup(url)) == NULL) {
-        free(attach);
+    if ((url_copy = icalmemory_strdup(url)) == NULL) {
+        icalmemory_free_buffer(attach);
         errno = ENOMEM;
         return NULL;
     }
@@ -59,13 +60,13 @@ icalattach *icalattach_new_from_data(const char *data, icalattach_free_fn_t free
 
     icalerror_check_arg_rz((data != NULL), "data");
 
-    if ((attach = malloc(sizeof(icalattach))) == NULL) {
+    if ((attach = icalmemory_new_buffer(sizeof(icalattach))) == NULL) {
         errno = ENOMEM;
         return NULL;
     }
 
-    if ((data_copy = strdup(data)) == NULL) {
-        free(attach);
+    if ((data_copy = icalmemory_strdup(data)) == NULL) {
+        icalmemory_free_buffer(attach);
         errno = ENOMEM;
         return NULL;
     }
@@ -98,16 +99,16 @@ void icalattach_unref(icalattach *attach)
         return;
 
     if (attach->is_url) {
-        free(attach->u.url.url);
+        icalmemory_free_buffer(attach->u.url.url);
     } else {
-        free(attach->u.data.data);
+        icalmemory_free_buffer(attach->u.data.data);
 /* unused for now
         if (attach->u.data.free_fn)
            (* attach->u.data.free_fn) (attach->u.data.data, attach->u.data.free_fn_data);
 */
     }
 
-    free(attach);
+    icalmemory_free_buffer(attach);
 }
 
 int icalattach_get_is_url(icalattach *attach)

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -90,7 +90,7 @@ static icalcomponent *icalcomponent_new_impl(icalcomponent_kind kind)
     if (!icalcomponent_kind_is_valid(kind))
         return NULL;
 
-    if ((comp = (icalcomponent *) malloc(sizeof(icalcomponent))) == 0) {
+    if ((comp = (icalcomponent *) icalmemory_new_buffer(sizeof(icalcomponent))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -216,7 +216,7 @@ void icalcomponent_free(icalcomponent *c)
         pvl_free(c->components);
 
         if (c->x_name != 0) {
-            free(c->x_name);
+            icalmemory_free_buffer(c->x_name);
         }
 
         if (c->timezones) {
@@ -233,7 +233,7 @@ void icalcomponent_free(icalcomponent *c)
         c->id[0] = 'X';
         c->timezones = NULL;
 
-        free(c);
+        icalmemory_free_buffer(c);
     }
 }
 
@@ -288,7 +288,7 @@ char *icalcomponent_as_ical_string_r(icalcomponent *impl)
         tmp_buf = icalproperty_as_ical_string_r(p);
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, tmp_buf);
-        free(tmp_buf);
+        icalmemory_free_buffer(tmp_buf);
     }
 
     for (itr = pvl_head(impl->components); itr != 0; itr = pvl_next(itr)) {
@@ -297,7 +297,7 @@ char *icalcomponent_as_ical_string_r(icalcomponent *impl)
         tmp_buf = icalcomponent_as_ical_string_r(c);
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, tmp_buf);
-        free(tmp_buf);
+        icalmemory_free_buffer(tmp_buf);
     }
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, "END:");
@@ -2061,7 +2061,7 @@ void icalcomponent_merge_component(icalcomponent *comp, icalcomponent *comp_to_m
 
         /* Now free the tzids_to_rename array. */
         for (i = 0; i < tzids_to_rename->num_elements; i++) {
-            free(icalarray_element_at(tzids_to_rename, i));
+            icalmemory_free_buffer(icalarray_element_at(tzids_to_rename, i));
         }
     }
     icalarray_free(tzids_to_rename);
@@ -2120,7 +2120,7 @@ static void icalcomponent_merge_vtimezone(icalcomponent *comp,
        unique one), so we compare the VTIMEZONE components to see if they are
        the same. If they are, we don't need to do anything. We make a copy of
        the tzid, since the parameter may get modified in these calls. */
-    tzid_copy = strdup(tzid);
+    tzid_copy = icalmemory_strdup(tzid);
     if (!tzid_copy) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return;
@@ -2133,7 +2133,7 @@ static void icalcomponent_merge_vtimezone(icalcomponent *comp,
         icalcomponent_handle_conflicting_vtimezones(comp, vtimezone, tzid_prop,
                                                     tzid_copy, tzids_to_rename);
     }
-    free(tzid_copy);
+    icalmemory_free_buffer(tzid_copy);
 }
 
 static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
@@ -2177,20 +2177,20 @@ static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
             if (icalcomponent_compare_vtimezones(icaltimezone_get_component(zone), vtimezone)) {
                 /* The VTIMEZONEs match, so we can use the existing VTIMEZONE. But
                    we have to rename TZIDs to this TZID. */
-                tzid_copy = strdup(tzid);
+                tzid_copy = icalmemory_strdup(tzid);
                 if (!tzid_copy) {
                     icalerror_set_errno(ICAL_NEWFAILED_ERROR);
                     return;
                 }
-                existing_tzid_copy = strdup(existing_tzid);
+                existing_tzid_copy = icalmemory_strdup(existing_tzid);
                 if (!existing_tzid_copy) {
                     icalerror_set_errno(ICAL_NEWFAILED_ERROR);
-                    free(tzid_copy);
+                    icalmemory_free_buffer(tzid_copy);
                 } else {
                     icalarray_append(tzids_to_rename, tzid_copy);
-                    free(tzid_copy);
+                    icalmemory_free_buffer(tzid_copy);
                     icalarray_append(tzids_to_rename, existing_tzid_copy);
-                    free(existing_tzid_copy);
+                    icalmemory_free_buffer(existing_tzid_copy);
                 }
                 return;
             } else {
@@ -2207,17 +2207,17 @@ static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
 
     /* We didn't find a VTIMEZONE that matched, so we have to rename the TZID,
        using the maximum numerical suffix found + 1. */
-    tzid_copy = strdup(tzid);
+    tzid_copy = icalmemory_strdup(tzid);
     if (!tzid_copy) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return;
     }
 
     snprintf(suffix_buf, sizeof(suffix_buf), "%i", max_suffix + 1);
-    new_tzid = malloc(tzid_len + strlen(suffix_buf) + 1);
+    new_tzid = icalmemory_new_buffer(tzid_len + strlen(suffix_buf) + 1);
     if (!new_tzid) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
-        free(tzid_copy);
+        icalmemory_free_buffer(tzid_copy);
         return;
     }
 
@@ -2225,8 +2225,8 @@ static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
     strcpy(new_tzid + tzid_len, suffix_buf);
     icalarray_append(tzids_to_rename, tzid_copy);
     icalarray_append(tzids_to_rename, new_tzid);
-    free(tzid_copy);
-    free(new_tzid);
+    icalmemory_free_buffer(tzid_copy);
+    icalmemory_free_buffer(new_tzid);
 }
 
 /* Returns the length of the TZID, without any trailing digits. */
@@ -2406,7 +2406,7 @@ static int icalcomponent_compare_vtimezones(icalcomponent *vtimezone1, icalcompo
 
     /* Copy the second TZID, and set the property to the same as the first
        TZID, since we don't care if these match of not. */
-    tzid2_copy = strdup(tzid2);
+    tzid2_copy = icalmemory_strdup(tzid2);
     if (!tzid2_copy) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
@@ -2417,25 +2417,25 @@ static int icalcomponent_compare_vtimezones(icalcomponent *vtimezone1, icalcompo
     /* Now convert both VTIMEZONEs to strings and compare them. */
     string1 = icalcomponent_as_ical_string_r(vtimezone1);
     if (!string1) {
-        free(tzid2_copy);
+        icalmemory_free_buffer(tzid2_copy);
         return -1;
     }
 
     string2 = icalcomponent_as_ical_string_r(vtimezone2);
     if (!string2) {
-        free(string1);
-        free(tzid2_copy);
+        icalmemory_free_buffer(string1);
+        icalmemory_free_buffer(tzid2_copy);
         return -1;
     }
 
     cmp = strcmp(string1, string2);
 
-    free(string1);
-    free(string2);
+    icalmemory_free_buffer(string1);
+    icalmemory_free_buffer(string2);
 
     /* Now reset the second TZID. */
     icalproperty_set_tzid(prop2, tzid2_copy);
-    free(tzid2_copy);
+    icalmemory_free_buffer(tzid2_copy);
 
     return (cmp == 0) ? 1 : 0;
 }

--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -101,7 +101,7 @@ void icalvalue_set_x(icalvalue *impl, const char *v)
     icalerror_check_arg_rv((v != 0), "v");
 
     if (impl->x_value != 0) {
-        free((void *)impl->x_value);
+        icalmemory_free_buffer((void *)impl->x_value);
     }
 
     impl->x_value = icalmemory_strdup(v);
@@ -134,12 +134,12 @@ void icalvalue_set_recur(icalvalue *impl, struct icalrecurrencetype v)
     icalerror_check_value_type(value, ICAL_RECUR_VALUE);
 
     if (impl->data.v_recur != 0) {
-        free(impl->data.v_recur->rscale);
-        free(impl->data.v_recur);
+        icalmemory_free_buffer(impl->data.v_recur->rscale);
+        icalmemory_free_buffer(impl->data.v_recur);
         impl->data.v_recur = 0;
     }
 
-    impl->data.v_recur = malloc(sizeof(struct icalrecurrencetype));
+    impl->data.v_recur = icalmemory_new_buffer(sizeof(struct icalrecurrencetype));
 
     if (impl->data.v_recur == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);

--- a/src/libical/icalduration.h
+++ b/src/libical/icalduration.h
@@ -107,7 +107,7 @@ LIBICAL_ICAL_EXPORT int icaldurationtype_as_int(struct icaldurationtype duration
  *
  * @par Ownership
  * The string returned by this function is owned by the caller and needs to be
- * released with `free()` after it's no longer needed.
+ * released with `icalmemory_free_buffer()` after it's no longer needed.
  *
  * ### Usage
  * ```c
@@ -120,7 +120,7 @@ LIBICAL_ICAL_EXPORT int icaldurationtype_as_int(struct icaldurationtype duration
  * printf("%s\n", ical);
  *
  * // release string
- * free(ical);
+ * icalmemory_free_buffer(ical);
  * ```
  */
 LIBICAL_ICAL_EXPORT char *icaldurationtype_as_ical_string(struct icaldurationtype d);

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -24,6 +24,7 @@
 #endif
 
 #include "icalerror.h"
+#include "icalmemory.h"
 
 #include <stdlib.h>
 
@@ -39,7 +40,7 @@ static pthread_once_t icalerrno_key_once = PTHREAD_ONCE_INIT;
 
 static void icalerrno_destroy(void *buf)
 {
-    free(buf);
+    icalmemory_free_buffer(buf);
     pthread_setspecific(icalerrno_key, NULL);
 }
 
@@ -57,7 +58,7 @@ icalerrorenum *icalerrno_return(void)
     _errno = (icalerrorenum *) pthread_getspecific(icalerrno_key);
 
     if (!_errno) {
-        _errno = malloc(sizeof(icalerrorenum));
+        _errno = icalmemory_new_buffer(sizeof(icalerrorenum));
         *_errno = ICAL_NO_ERROR;
         pthread_setspecific(icalerrno_key, _errno);
     }
@@ -276,6 +277,6 @@ void ical_bt(void)
             fprintf(stderr, "%p\n", stack_frames[i]);
         }
     }
-    free(strings);
+    icalmemory_free_buffer(strings);
 #endif
 }

--- a/src/libical/icallangbind.c
+++ b/src/libical/icallangbind.c
@@ -30,14 +30,14 @@
 
 int *icallangbind_new_array(int size)
 {
-    int *p = (int *)malloc(size * sizeof(int));
+    int *p = (int *)icalmemory_new_buffer(size * sizeof(int));
 
     return p;   /* Caller handles failures */
 }
 
 void icallangbind_free_array(int *array)
 {
-    free(array);
+    icalmemory_free_buffer(array);
 }
 
 int icallangbind_access_array(int *array, int index)
@@ -196,7 +196,7 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
         default:
             {
                 char *str = icalvalue_as_ical_string_r(value);
-                char *copy = (char *)malloc(strlen(str) + 1);
+                char *copy = (char *)icalmemory_new_buffer(strlen(str) + 1);
 
                 const char *i;
                 char *j;
@@ -222,8 +222,8 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
                 APPENDS(copy);
                 APPENDC('\'');
 
-                free(copy);
-                free(str);
+                icalmemory_free_buffer(copy);
+                icalmemory_free_buffer(str);
                 break;
             }
         }
@@ -245,7 +245,7 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
         v = strchr(copy, '=');
 
         if (v == 0) {
-            free(copy);
+            icalmemory_free_buffer(copy);
             continue;
         }
 
@@ -261,7 +261,7 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
         APPENDC('\'');
         APPENDS(v);
         APPENDC('\'');
-        free(copy);
+        icalmemory_free_buffer(copy);
     }
 
     APPENDC('}');

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -79,10 +79,10 @@ static void icalmemory_free_ring_byval(buffer_ring * br)
 
     for (i = 0; i < BUFFER_RING_SIZE; i++) {
         if (br->ring[i] != 0) {
-            free(br->ring[i]);
+            icalmemory_free_buffer(br->ring[i]);
         }
     }
-    free(br);
+    icalmemory_free_buffer(br);
 }
 
 #if defined(HAVE_PTHREAD)
@@ -114,7 +114,7 @@ static void icalmemory_free_tmp_buffer(void *buf)
         return;
     }
 
-    free(buf);
+    icalmemory_free_buffer(buf);
 }
 
 #endif
@@ -127,7 +127,7 @@ static buffer_ring *buffer_ring_new(void)
     buffer_ring *br;
     int i;
 
-    br = (buffer_ring *) malloc(sizeof(buffer_ring));
+    br = (buffer_ring *) icalmemory_new_buffer(sizeof(buffer_ring));
 
     for (i = 0; i < BUFFER_RING_SIZE; i++) {
         br->ring[i] = 0;
@@ -195,7 +195,7 @@ void icalmemory_add_tmp_buffer(void *buf)
 
     /* Free buffers as their slots are overwritten */
     if (br->ring[br->pos] != 0) {
-        free(br->ring[br->pos]);
+        icalmemory_free_buffer(br->ring[br->pos]);
     }
 
     /* Assign the buffer to a slot */
@@ -216,7 +216,7 @@ void *icalmemory_tmp_buffer(size_t size)
         size = MIN_BUFFER_SIZE;
     }
 
-    buf = (void *)malloc(size);
+    buf = (void *)icalmemory_new_buffer(size);
 
     if (buf == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
@@ -247,16 +247,36 @@ void icalmemory_free_ring()
 /* Like strdup, but the buffer is on the ring. */
 char *icalmemory_tmp_copy(const char *str)
 {
-    char *b = icalmemory_tmp_buffer(strlen(str) + 1);
+	char *b;
+	
+	if (!str)
+		return NULL;
 
-    strcpy(b, str);
+	b = icalmemory_tmp_buffer(strlen(str) + 1);
 
+	if (!b)
+		return NULL;
+
+	strcpy(b, str);
     return b;
 }
 
 char *icalmemory_strdup(const char *s)
 {
-    return strdup(s);
+	size_t l;
+	char *res;
+
+	if (!s)
+		return NULL;
+
+	l = strlen(s) + sizeof(char);
+	res = (char *) icalmemory_new_buffer(l);
+	if (res == NULL)
+		return NULL;
+
+	memcpy(res, s, l);
+
+	return res;
 }
 
 /*
@@ -320,7 +340,7 @@ void icalmemory_append_string(char **buf, char **pos, size_t *buf_size, const ch
 
         *buf_size = (*buf_size) * 2 + final_length;
 
-        new_buf = realloc(*buf, *buf_size);
+        new_buf = icalmemory_resize_buffer(*buf, *buf_size);
 
         new_pos = (void *)((size_t) new_buf + data_length);
 
@@ -357,7 +377,7 @@ void icalmemory_append_char(char **buf, char **pos, size_t *buf_size, char ch)
 
         *buf_size = (*buf_size) * 2 + final_length + 1;
 
-        new_buf = realloc(*buf, *buf_size);
+        new_buf = icalmemory_resize_buffer(*buf, *buf_size);
 
         new_pos = (void *)((size_t) new_buf + data_length);
 

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -128,6 +128,8 @@ static buffer_ring *buffer_ring_new(void)
     int i;
 
     br = (buffer_ring *) icalmemory_new_buffer(sizeof(buffer_ring));
+    if (!br)
+        return NULL;
 
     for (i = 0; i < BUFFER_RING_SIZE; i++) {
         br->ring[i] = 0;
@@ -187,6 +189,8 @@ static buffer_ring *get_buffer_ring(void)
 void icalmemory_add_tmp_buffer(void *buf)
 {
     buffer_ring *br = get_buffer_ring();
+    if (!br)
+        return;
 
     /* Wrap around the ring */
     if (++(br->pos) == BUFFER_RING_SIZE) {
@@ -235,6 +239,8 @@ void icalmemory_free_ring()
     buffer_ring *br;
 
     br = get_buffer_ring();
+    if (!br)
+        return;
 
     icalmemory_free_ring_byval(br);
 #if defined(HAVE_PTHREAD)

--- a/src/libical/icalmemory.h
+++ b/src/libical/icalmemory.h
@@ -143,7 +143,7 @@ LIBICAL_ICAL_EXPORT void icalmemory_add_tmp_buffer(void *buf);
 LIBICAL_ICAL_EXPORT void icalmemory_free_ring(void);
 
 /* Non-tmp buffers must be freed. These are mostly wrappers around
- * malloc, etc, but are used so the caller can change the memory
+ * icalmemory_new_buffer, etc, but are used so the caller can change the memory
  * allocators in a future version of the library */
 
 /**
@@ -324,17 +324,19 @@ LIBICAL_ICAL_EXPORT void icalmemory_append_char(char **buf, char **pos, size_t *
  *
  * @par Ownership
  * The returned string is owned by the caller and needs to be released with the
- * appropriate `free()` method.
+ * `icalmemory_free_buffer()` method.
  *
- * A wrapper around `strdup()`.  Partly to trap calls to `strdup()`, partly
- * because in `-ansi`, `gcc` on Red Hat claims that `strdup()` is undeclared.
+ * Replaces `strdup()`. The function uses icalmemory_new_buffer() for memory
+ * allocation. It also helps trapping calls to `strdup()` and solves the
+ * problem that in `-ansi`, `gcc` on Red Hat claims that `strdup()` is
+ * undeclared.
  *
  * ### Usage
  * ```c
  * const char *my_str = "LibIcal";
  * char *dup = icalmemory_strdup(my_str);
  * printf("%s\n", dup);
- * free(dup);
+ * icalmemory_free_buffer(dup);
  * ```
  */
 LIBICAL_ICAL_EXPORT char *icalmemory_strdup(const char *s);

--- a/src/libical/icalmemory.h
+++ b/src/libical/icalmemory.h
@@ -104,7 +104,11 @@ LIBICAL_ICAL_EXPORT char *icalmemory_tmp_copy(const char *str);
  * Adds an externally allocated buffer to the ring. This ensures that libical
  * will `free()` the buffer automatically, either after ::BUFFER_RING_SIZE other
  * buffers have been created or added, or after ::icalmemory_free_ring() has
- * been called.
+ * been called. Note that freeing the buffers is done using the
+ * icalmemory_free_buffer() function, which by default is a wrapper around the
+ * standard free() function. However, if the memory management functions are
+ * customized by the user, the user has to take care to only pass in buffers
+ * that have been allocated accordingly.
  *
  * @par Error handling
  * No error is raised if @a buf is `NULL`.
@@ -142,10 +146,45 @@ LIBICAL_ICAL_EXPORT void icalmemory_add_tmp_buffer(void *buf);
  */
 LIBICAL_ICAL_EXPORT void icalmemory_free_ring(void);
 
-/* Non-tmp buffers must be freed. These are mostly wrappers around
- * icalmemory_new_buffer, etc, but are used so the caller can change the memory
- * allocators in a future version of the library */
 
+typedef void* (*icalmemory_malloc_f)(size_t);
+typedef void* (*icalmemory_realloc_f)(void*, size_t);
+typedef void (*icalmemory_free_f)(void*);
+
+/**
+ * @brief Configures the functions to use for memory management.
+ * 
+ * @param f_malloc The function to use for memory allocation.
+ * @param f_realloc The function to use for memory reallocation.
+ * @param f_free The function to use for memory deallocation.
+ * 
+ * This function configures the library to use the specified functions for
+ * memory management. By default the standard system memory management
+ * functions malloc(), realloc() and free() are used.
+ * 
+ * Note on compatibility: The memory management functions configured via this
+ * functions are used throughout the core libical component but not within
+ * other components like libicalvcal yet. In future versions of the library,
+ * use might be extended to other components too. In order to avoid
+ * compatibility issues with future versions, it's recommended either not to
+ * use this functionality when using not only the core libical component but
+ * also other components like libicalvcal or to recheck whether use has been
+ * extended before upgrading to a newer version.
+ */
+LIBICAL_ICAL_EXPORT void icalmemory_set_mem_alloc_funcs(icalmemory_malloc_f f_malloc, icalmemory_realloc_f f_realloc, icalmemory_free_f f_free);
+
+/**
+ * @brief Returns the functions used for memory management.
+ * 
+ * @param f_malloc A pointer to the function to use for memory allocation.
+ * @param f_realloc A pointer to the function to use for memory reallocation.
+ * @param f_free A pointer to the function to use for memory deallocation.
+ *
+ * Retrieves the functions used by the library for memory management.
+ */
+LIBICAL_ICAL_EXPORT void icalmemory_get_mem_alloc_funcs(icalmemory_malloc_f* f_malloc, icalmemory_realloc_f* f_realloc, icalmemory_free_f* f_free);
+
+ 
 /**
  * @brief Creates new buffer with the specified size.
  * @param size The size of the buffer that is to be created.
@@ -157,11 +196,14 @@ LIBICAL_ICAL_EXPORT void icalmemory_free_ring(void);
  * ::ICAL_NEWFAILED_ERROR and returns `NULL`.
  *
  * @par Ownership
- * Buffers created with this method are owned by the caller. The must be
- * released with the appropriate icalmemory_free_buffer() method.
+ * Buffers created with this method are owned by the caller. They must be
+ * released with the icalmemory_free_buffer() method.
  *
  * This creates a new (non-temporary) buffer of the specified @a size. All
  * buffers returned by this method are zeroed-out.
+ *
+ * By default this function is a wrapper around the system malloc() function but
+ * the used function can be configured using icalmemory_set_mem_alloc_funcs().
  *
  * ### Usage
  * ```c
@@ -195,6 +237,9 @@ LIBICAL_ICAL_EXPORT void *icalmemory_new_buffer(size_t size);
  * appropriate icalmemory_free_buffer() method. The old buffer, @a buf, can not
  * be used anymore after calling this method.
  *
+ * By default this function is a wrapper around the system realloc() function but
+ * the used function can be configured using icalmemory_set_mem_alloc_funcs().
+ *
  * ### Usage
  * ```c
  * // create new buffer
@@ -221,6 +266,9 @@ LIBICAL_ICAL_EXPORT void *icalmemory_resize_buffer(void *buf, size_t size);
  * @sa icalmemory_new_buffer()
  *
  * Releases the memory of the buffer.
+ *
+ * By default this function is a wrapper around the system free() function but
+ * the used function can be configured using icalmemory_set_mem_alloc_funcs().
  */
 LIBICAL_ICAL_EXPORT void icalmemory_free_buffer(void *buf);
 

--- a/src/libical/icalmime.c
+++ b/src/libical/icalmime.c
@@ -50,7 +50,7 @@ static void *icalmime_text_new_part(void)
 
     struct text_part *impl;
 
-    if ((impl = (struct text_part *)malloc(sizeof(struct text_part))) == 0) {
+    if ((impl = (struct text_part *)icalmemory_new_buffer(sizeof(struct text_part))) == 0) {
         return 0;
     }
 
@@ -78,7 +78,7 @@ static void *icalmime_textcalendar_end_part(void *part)
     icalcomponent *c = icalparser_parse_string(impl->buf);
 
     icalmemory_free_buffer(impl->buf);
-    free(impl);
+    icalmemory_free_buffer(impl);
 
     return c;
 }
@@ -89,7 +89,7 @@ static void *icalmime_text_end_part_r(void *part)
     struct text_part *impl = (struct text_part *)part;
 
     buf = impl->buf;
-    free(impl);
+    icalmemory_free_buffer(impl);
 
     return buf;
 }
@@ -167,7 +167,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
     int i, last_level = 0;
     icalcomponent *root = 0, *parent = 0, *comp = 0, *last = 0;
 
-    if ((parts = (struct sspm_part *)malloc(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
+    if ((parts = (struct sspm_part *)icalmemory_new_buffer(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -246,7 +246,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
             icalcomponent_add_property(
                 comp,
                 icalproperty_new_xlicmimecontenttype(mimeTypeCopy));
-            free(mimeTypeCopy);
+            icalmemory_free_buffer(mimeTypeCopy);
         }
 
         if (parts[i].header.encoding != SSPM_NO_ENCODING) {
@@ -289,7 +289,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
             icalcomponent_add_property(
                 comp,
                 icalproperty_new_description(descStr));
-            free(descStr);
+            icalmemory_free_buffer(descStr);
             parts[i].data = 0;
         }
 
@@ -332,7 +332,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
     }
 
     sspm_free_parts(parts, NUM_PARTS);
-    free(parts);
+    icalmemory_free_buffer(parts);
 
     return root;
 }
@@ -343,7 +343,7 @@ int icalmime_test(char *(*get_string) (char *s, size_t size, void *d), void *dat
     struct sspm_part *parts;
     int i;
 
-    if ((parts = (struct sspm_part *)malloc(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
+    if ((parts = (struct sspm_part *)icalmemory_new_buffer(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -364,7 +364,7 @@ int icalmime_test(char *(*get_string) (char *s, size_t size, void *d), void *dat
     sspm_write_mime(parts, NUM_PARTS, &out, "To: bob@bob.org");
 
     printf("%s\n", out);
-    free(out);
+    icalmemory_free_buffer(out);
 
     return 0;
 }

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -37,7 +37,7 @@ LIBICAL_ICAL_EXPORT struct icalparameter_impl *icalparameter_new_impl(icalparame
 {
     struct icalparameter_impl *v;
 
-    if ((v = (struct icalparameter_impl *)malloc(sizeof(struct icalparameter_impl))) == 0) {
+    if ((v = (struct icalparameter_impl *)icalmemory_new_buffer(sizeof(struct icalparameter_impl))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -68,18 +68,18 @@ void icalparameter_free(icalparameter *param)
     }
 
     if (param->string != 0) {
-        free((void *)param->string);
+        icalmemory_free_buffer((void *)param->string);
     }
 
     if (param->x_name != 0) {
-        free((void *)param->x_name);
+        icalmemory_free_buffer((void *)param->x_name);
     }
 
     memset(param, 0, sizeof(icalparameter));
 
     param->parent = 0;
     param->id[0] = 'X';
-    free(param);
+    icalmemory_free_buffer(param);
 }
 
 icalparameter *icalparameter_new_clone(icalparameter *old)
@@ -137,7 +137,7 @@ icalparameter *icalparameter_new_from_string(const char *str)
 
     if (eq == 0) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        free(cpy);
+        icalmemory_free_buffer(cpy);
         return 0;
     }
 
@@ -149,7 +149,7 @@ icalparameter *icalparameter_new_from_string(const char *str)
 
     if (kind == ICAL_NO_PARAMETER) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        free(cpy);
+        icalmemory_free_buffer(cpy);
         return 0;
     }
 
@@ -161,7 +161,7 @@ icalparameter *icalparameter_new_from_string(const char *str)
         icalparameter_set_iana_name(param, cpy);
     }
 
-    free(cpy);
+    icalmemory_free_buffer(cpy);
 
     return param;
 }
@@ -295,7 +295,7 @@ char *icalparameter_as_ical_string_r(icalparameter *param)
         if (param->kind == ICAL_NO_PARAMETER ||
             param->kind == ICAL_ANY_PARAMETER || kind_string == 0) {
             icalerror_set_errno(ICAL_BADARG_ERROR);
-            free(buf);
+            icalmemory_free_buffer(buf);
             return 0;
         }
 
@@ -313,7 +313,7 @@ char *icalparameter_as_ical_string_r(icalparameter *param)
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, str);
     } else {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        free(buf);
+        icalmemory_free_buffer(buf);
         return 0;
     }
 
@@ -350,7 +350,7 @@ void icalparameter_set_xname(icalparameter *param, const char *v)
     icalerror_check_arg_rv((v != 0), "v");
 
     if (param->x_name != 0) {
-        free((void *)param->x_name);
+        icalmemory_free_buffer((void *)param->x_name);
     }
 
     param->x_name = icalmemory_strdup(v);
@@ -373,7 +373,7 @@ void icalparameter_set_xvalue(icalparameter *param, const char *v)
     icalerror_check_arg_rv((v != 0), "v");
 
     if (param->string != 0) {
-        free((void *)param->string);
+        icalmemory_free_buffer((void *)param->string);
     }
 
     param->string = icalmemory_strdup(v);

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -223,9 +223,9 @@ LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter)
  *
  * @par Ownership
  * Strings returned by this method are owned by the caller, thus they need
- * to be manually `free()`d after use. A version of this function which returns
- * strings that do not need to be freed manually is
- * icalparameter_as_ical_string().
+ * to be manually `icalmemory_free_buffer()`d after use.
+ * A version of this function which returns strings that do not
+ * need to be freed manually is icalparameter_as_ical_string().
  *
  * ### Usage
  * ```c
@@ -234,7 +234,7 @@ LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter)
  * if(param) {
  *     char *str = icalparameter_as_ical_string(param);
  *     printf("%s\n", str);
- *     free(str);
+ *     icalmemory_free_buffer(str);
  * }
  *
  * icalparameter_free(param);

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -99,7 +99,7 @@ icalparser *icalparser_new(void)
 {
     struct icalparser_impl *impl = 0;
 
-    if ((impl = (struct icalparser_impl *)malloc(sizeof(struct icalparser_impl))) == 0) {
+    if ((impl = (struct icalparser_impl *)icalmemory_new_buffer(sizeof(struct icalparser_impl))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -131,7 +131,7 @@ void icalparser_free(icalparser *parser)
 
     pvl_free(parser->components);
 
-    free(parser);
+    icalmemory_free_buffer(parser);
 }
 
 void icalparser_set_gen_data(icalparser *parser, void *data)
@@ -311,7 +311,7 @@ static char *parser_get_param_name_heap(char *line, char **end)
         *end = *end + 1;
         next = parser_get_next_char('"', *end, 0);
         if (next == 0) {
-            free(str);
+            icalmemory_free_buffer(str);
             *end = NULL;
             return 0;
         }
@@ -549,7 +549,7 @@ char *icalparser_get_line(icalparser *parser,
                 } else {
                     /* No data in output; return and signal that there
                        is no more input */
-                    free(line);
+                    icalmemory_free_buffer(line);
                     return 0;
                 }
             }

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1325,6 +1325,9 @@ icalcomponent *icalparser_parse_string(const char *str)
     d.str = str;
 
     p = icalparser_new();
+    if (!p)
+        return NULL;
+
     icalparser_set_gen_data(p, &d);
 
     icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, ICAL_ERROR_NONFATAL);

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -67,7 +67,7 @@ icalproperty *icalproperty_new_impl(icalproperty_kind kind)
     if (!icalproperty_kind_is_valid(kind))
         return NULL;
 
-    if ((prop = (icalproperty *) malloc(sizeof(icalproperty))) == 0) {
+    if ((prop = (icalproperty *) icalmemory_new_buffer(sizeof(icalproperty))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -155,7 +155,7 @@ icalproperty *icalproperty_new_from_string(const char *str)
 
     if (comp == 0) {
         icalerror_set_errno(ICAL_PARSE_ERROR);
-        free(buf);
+        icalmemory_free_buffer(buf);
         return 0;
     }
 
@@ -166,7 +166,7 @@ icalproperty *icalproperty_new_from_string(const char *str)
     icalcomponent_remove_property(comp, prop);
 
     icalcomponent_free(comp);
-    free(buf);
+    icalmemory_free_buffer(buf);
 
     if (errors > 0) {
         icalproperty_free(prop);
@@ -198,7 +198,7 @@ void icalproperty_free(icalproperty *p)
     pvl_free(p->parameters);
 
     if (p->x_name != 0) {
-        free(p->x_name);
+        icalmemory_free_buffer(p->x_name);
     }
 
     p->kind = ICAL_NO_PROPERTY;
@@ -208,7 +208,7 @@ void icalproperty_free(icalproperty *p)
     p->x_name = 0;
     p->id[0] = 'X';
 
-    free(p);
+    icalmemory_free_buffer(p);
 }
 
 /* This returns where the start of the next line should be. chars_left does
@@ -417,13 +417,13 @@ char *icalproperty_as_ical_string_r(icalproperty *prop)
         }
 
         if (kind == ICAL_VALUE_PARAMETER) {
-            free((char *)kind_string);
+            icalmemory_free_buffer((char *)kind_string);
             continue;
         }
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, ";");
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, kind_string);
-        free((char *)kind_string);
+        icalmemory_free_buffer((char *)kind_string);
     }
 
     /* Append value */
@@ -442,7 +442,7 @@ char *icalproperty_as_ical_string_r(icalproperty *prop)
             icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
 #endif
         }
-        free(str);
+        icalmemory_free_buffer(str);
     } else {
 #if ICAL_ALLOW_EMPTY_PROPERTIES == 0
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
@@ -595,13 +595,13 @@ char *icalproperty_get_parameter_as_string_r(icalproperty *prop, const char *nam
 
     if (t == 0) {
         icalerror_set_errno(ICAL_INTERNAL_ERROR);
-        free(str);
+        icalmemory_free_buffer(str);
         return 0;
     }
 
     /* Strip the property name and the equal sign */
     pv = icalmemory_strdup(t + 1);
-    free(str);
+    icalmemory_free_buffer(str);
 
     /* Is the string quoted? */
     pvql = strchr(pv, '"');
@@ -611,13 +611,13 @@ char *icalproperty_get_parameter_as_string_r(icalproperty *prop, const char *nam
 
     /* Strip everything up to the first quote */
     str = icalmemory_strdup(pvql + 1);
-    free(pv);
+    icalmemory_free_buffer(pv);
 
     /* Search for the end quote */
     pvqr = strrchr(str, '"');
     if (pvqr == 0) {
         icalerror_set_errno(ICAL_INTERNAL_ERROR);
-        free(str);
+        icalmemory_free_buffer(str);
         return 0;
     }
 
@@ -866,7 +866,7 @@ void icalproperty_set_x_name(icalproperty *prop, const char *name)
     icalerror_check_arg_rv((prop != 0), "prop");
 
     if (prop->x_name != 0) {
-        free(prop->x_name);
+        icalmemory_free_buffer(prop->x_name);
     }
 
     prop->x_name = icalmemory_strdup(name);

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -496,7 +496,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
         icalrecurrencetype_weekday wd;
 
         if (i == ICAL_BY_DAY_SIZE) {
-            free(vals_copy);
+            icalmemory_free_buffer(vals_copy);
             return -1;
         }
 
@@ -527,7 +527,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
 
         /* Sanity check value */
         if (wd == ICAL_NO_WEEKDAY || weekno >= ICAL_BY_WEEKNO_SIZE) {
-            free(vals_copy);
+            icalmemory_free_buffer(vals_copy);
             return -1;
         }
 
@@ -535,7 +535,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
         array[i] = ICAL_RECURRENCE_ARRAY_MAX;
     }
 
-    free(vals_copy);
+    icalmemory_free_buffer(vals_copy);
 
     sort_bydayrules(parser);
 
@@ -641,13 +641,13 @@ struct icalrecurrencetype icalrecurrencetype_from_string(const char *str)
 
         if (r) {
             icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-            free(parser.rt.rscale);
+            icalmemory_free_buffer(parser.rt.rscale);
             icalrecurrencetype_clear(&parser.rt);
             break;
         }
     }
 
-    free(parser.copy);
+    icalmemory_free_buffer(parser.copy);
 
     return parser.rt;
 }
@@ -1823,7 +1823,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype rule,
         return 0;
     }
 
-    if (!(impl = (icalrecur_iterator *)malloc(sizeof(icalrecur_iterator)))) {
+    if (!(impl = (icalrecur_iterator *)icalmemory_new_buffer(sizeof(icalrecur_iterator)))) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -1878,7 +1878,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype rule,
         if (expand_map[freq].map[byrule] == ILLEGAL &&
             impl->by_ptrs[byrule][0] != ICAL_RECURRENCE_ARRAY_MAX) {
             icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-            free(impl);
+            icalmemory_free_buffer(impl);
             return 0;
         }
     }
@@ -1921,7 +1921,7 @@ void icalrecur_iterator_free(icalrecur_iterator *i)
     }
 #endif
 
-    free(i);
+    icalmemory_free_buffer(i);
 }
 
 /* Calculate the number of days between 2 dates */
@@ -3074,7 +3074,7 @@ int icalrecur_expand_recurrence(const char *rule,
         }
         icalrecur_iterator_free(ritr);
     }
-    free(recur.rscale);
+    icalmemory_free_buffer(recur.rscale);
 
     return 1;
 }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -24,6 +24,7 @@
 #include "icaltz-util.h"
 #include "icalerror.h"
 #include "icaltimezone.h"
+#include "icalmemory.h"
 
 #include <stdlib.h>
 
@@ -165,7 +166,7 @@ static char *zname_from_stridx(char *str, size_t idx)
 
     size = i - idx;
     str += idx;
-    ret = (char *)malloc(size + 1);
+    ret = (char *)icalmemory_new_buffer(size + 1);
     ret = strncpy(ret, str, size);
     ret[size] = '\0';
 
@@ -284,7 +285,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
 
     size = strlen(zonedir) + strlen(location) + 2;
-    full_path = (char *)malloc(size);
+    full_path = (char *)icalmemory_new_buffer(size);
     if (full_path == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -309,12 +310,12 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     num_isstd = (size_t)decode(type_cnts.ttisstdcnt);
     num_types = (size_t)decode(type_cnts.typecnt);
 
-    transitions = calloc(num_trans, sizeof(time_t));
+    transitions = icalmemory_new_buffer(num_trans * sizeof(time_t));
     if (transitions == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
     }
-    r_trans = calloc(num_trans, 4);
+    r_trans = icalmemory_new_buffer(num_trans * 4);
     if (r_trans == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -323,7 +324,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     EFREAD(r_trans, 4, num_trans, f);
     temp = r_trans;
     if (num_trans) {
-        trans_idx = calloc(num_trans, sizeof(int));
+        trans_idx = icalmemory_new_buffer(num_trans * sizeof(int));
         if (trans_idx == NULL) {
             icalerror_set_errno(ICAL_NEWFAILED_ERROR);
             goto error;
@@ -336,7 +337,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
     r_trans = temp;
 
-    types = calloc(num_types, sizeof(ttinfo));
+    types = icalmemory_new_buffer(num_types * sizeof(ttinfo));
     if (types == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -355,7 +356,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         types[i].gmtoff = decode(a);
     }
 
-    znames = (char *)malloc(num_chars);
+    znames = (char *)icalmemory_new_buffer(num_chars);
     if (znames == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -364,7 +365,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     /* We got all the information which we need */
 
-    leaps = calloc(num_leaps, sizeof(leap));
+    leaps = icalmemory_new_buffer(num_leaps * sizeof(leap));
     if (leaps == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -409,7 +410,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     /* Add tzid property */
     size = strlen(icaltimezone_tzid_prefix()) + strlen(location) + 1;
-    tzid = (char *)malloc(size);
+    tzid = (char *)icalmemory_new_buffer(size);
     if (tzid == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -631,34 +632,34 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         fclose(f);
 
     if (full_path)
-        free(full_path);
+        icalmemory_free_buffer(full_path);
 
     if (transitions)
-        free(transitions);
+        icalmemory_free_buffer(transitions);
 
     if (r_trans)
-        free(r_trans);
+        icalmemory_free_buffer(r_trans);
 
     if (trans_idx)
-        free(trans_idx);
+        icalmemory_free_buffer(trans_idx);
 
     if (types) {
         for (i = 0; i < num_types; i++) {
             if (types[i].zname) {
-                free(types[i].zname);
+                icalmemory_free_buffer(types[i].zname);
             }
         }
-        free(types);
+        icalmemory_free_buffer(types);
     }
 
     if (znames)
-        free(znames);
+        icalmemory_free_buffer(znames);
 
     if (leaps)
-        free(leaps);
+        icalmemory_free_buffer(leaps);
 
     if (tzid)
-        free(tzid);
+        icalmemory_free_buffer(tzid);
 
     return tz_comp;
 }

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -23,6 +23,8 @@
 
 #include "pvl.h"
 
+#include "icalmemory.h"
+
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -62,7 +64,7 @@ pvl_list pvl_newlist()
 {
     struct pvl_list_t *L;
 
-    if ((L = (struct pvl_list_t *)malloc(sizeof(struct pvl_list_t))) == 0) {
+    if ((L = (struct pvl_list_t *)icalmemory_new_buffer(sizeof(struct pvl_list_t))) == 0) {
         errno = ENOMEM;
         return 0;
     }
@@ -83,7 +85,7 @@ void pvl_free(pvl_list l)
 
     pvl_clear(l);
 
-    free(L);
+    icalmemory_free_buffer(L);
 }
 
 /**
@@ -105,7 +107,7 @@ pvl_elem pvl_new_element(void *d, pvl_elem next, pvl_elem prior)
 {
     struct pvl_elem_t *E;
 
-    if ((E = (struct pvl_elem_t *)malloc(sizeof(struct pvl_elem_t))) == 0) {
+    if ((E = (struct pvl_elem_t *)icalmemory_new_buffer(sizeof(struct pvl_elem_t))) == 0) {
         errno = ENOMEM;
         return 0;
     }
@@ -363,7 +365,7 @@ void *pvl_remove(pvl_list L, pvl_elem E)
     E->next = 0;
     E->d = 0;
 
-    free(E);
+    icalmemory_free_buffer(E);
 
     return data;
 }

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -978,7 +978,7 @@ icalrequeststatus VAlarm::getTriggerTime(VComponent &c, struct icaltriggertype *
         }
 
         if (related_param != NULL) {
-            free(related_param);
+            icalmemory_free_buffer(related_param);
         }
 
         // malformed? encapsulating VEVENT or VTODO MUST have DTSTART/DTEND

--- a/src/libicalss/icalclassify.c
+++ b/src/libicalss/icalclassify.c
@@ -50,7 +50,7 @@ char *icalclassify_lowercase(const char *str)
         return 0;
     }
 
-    xnew = icalmemory_strdup(str);
+    xnew = strdup(str);
     for (p = xnew; *p != 0; p++) {
         *p = tolower((int)*p);
     }
@@ -293,8 +293,8 @@ int icalssutil_is_rescheduled(icalcomponent *a, icalcomponent *b)
         temp1 = icalproperty_as_ical_string_r(p1);
         temp2 = icalproperty_as_ical_string_r(p2);
         cmp = strcmp(temp1, temp2);
-        free(temp1);
-        free(temp2);
+        icalmemory_free_buffer(temp1);
+		icalmemory_free_buffer(temp2);
 
         if (p1 && cmp != 0) {
             return 1;

--- a/src/libicalss/icalfileset.c
+++ b/src/libicalss/icalfileset.c
@@ -27,6 +27,7 @@
 #include "icalfilesetimpl.h"
 #include "icalparser.h"
 #include "icalvalue.h"
+#include "icalmemory.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -398,11 +399,11 @@ icalerrorenum icalfileset_commit(icalset *set)
         if (sz != (IO_SSIZE_T) strlen(str)) {
             perror("write");
             icalerror_set_errno(ICAL_FILE_ERROR);
-            free(str);
+            icalmemory_free_buffer(str);
             return ICAL_FILE_ERROR;
         }
 
-        free(str);
+		icalmemory_free_buffer(str);
         write_size += sz;
     }
 

--- a/src/libicalss/icalfileset.c
+++ b/src/libicalss/icalfileset.c
@@ -180,11 +180,14 @@ icalerrorenum icalfileset_read_file(icalfileset *set, int mode)
     _unused(mode);
 
     parser = icalparser_new();
-
-    icalparser_set_gen_data(parser, set);
-    set->cluster = icalparser_parse(parser, icalfileset_read_from_file);
-    icalparser_free(parser);
-
+    if (parser) {
+        icalparser_set_gen_data(parser, set);
+        set->cluster = icalparser_parse(parser, icalfileset_read_from_file);
+        icalparser_free(parser);
+    }
+    else {
+        set->cluster = 0;
+    }
     if (set->cluster == 0 || icalerrno != ICAL_NO_ERROR) {
         icalerror_set_errno(ICAL_PARSE_ERROR);
         /*return ICAL_PARSE_ERROR; */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -93,6 +93,8 @@ set(regression_SRCS
   regression-utils.c
   regression-recur.c
   regression-storage.c
+  regression-malloc.c
+  regression-malloc.h
 )
 if(WITH_CXX_BINDINGS)
   list(APPEND regression_SRCS regression-cxx.cpp)

--- a/src/test/builtin_timezones.c
+++ b/src/test/builtin_timezones.c
@@ -31,6 +31,10 @@ int main()
     int dd, hh, zz, tried = 0;
     long zz2 = -1;
 
+#if ICAL_USE_MALLOC == 0
+    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
+#endif
+
     set_zone_directory("../../zoneinfo");
     icaltimezone_set_tzid_prefix("/softwarestudio.org/");
 

--- a/src/test/icaltestparser.c
+++ b/src/test/icaltestparser.c
@@ -84,7 +84,13 @@ int main(int argc, char *argv[])
     char *line;
     FILE *stream;
     icalcomponent *c;
-    icalparser *parser = icalparser_new();
+    icalparser *parser;
+
+#if ICAL_USE_MALLOC == 0
+    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
+#endif
+
+    parser = icalparser_new();
 
     if (argc != 2) {
         fprintf(stderr, "Usage: parser [file.ics]\n");

--- a/src/test/process.c
+++ b/src/test/process.c
@@ -35,16 +35,25 @@ int main(int argc, char *argv[])
     int i = 0;
     int dont_remove;
     icalfileset_options options = { O_RDONLY, 0644, 0, NULL };
-
-    icalset *f = icalset_new(ICAL_FILE_SET, TEST_DATADIR "/process-incoming.ics", &options);
-    icalset *trash = icalset_new_file("trash.ics");
-    icalset *cal = icalset_new(ICAL_FILE_SET, TEST_DATADIR "/process-calendar.ics", &options);
-    icalset *out = icalset_new_file("outgoing.ics");
-
-    const char *this_user = "alice@cal.softwarestudio.org";
+    icalset *f;
+    icalset *trash;
+    icalset *cal;
+    icalset *out;
+    const char *this_user;
 
     _unused(argc);
     _unused(argv);
+
+#if ICAL_USE_MALLOC == 0
+    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
+#endif
+
+    f = icalset_new(ICAL_FILE_SET, TEST_DATADIR "/process-incoming.ics", &options);
+    trash = icalset_new_file("trash.ics");
+    cal    = icalset_new(ICAL_FILE_SET, TEST_DATADIR "/process-calendar.ics", &options);
+    out = icalset_new_file("outgoing.ics");
+
+    this_user = "alice@cal.softwarestudio.org";
 
     assert(f != 0);
     assert(cal != 0);

--- a/src/test/recur.c
+++ b/src/test/recur.c
@@ -61,6 +61,10 @@ int main(int argc, char *argv[])
     time_t tt;
     const char *file;
 
+#if ICAL_USE_MALLOC == 0
+    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
+#endif
+
     icalerror_set_error_state(ICAL_PARSE_ERROR, ICAL_ERROR_NONFATAL);
 
 #if defined(HAVE_SIGNAL) && defined(HAVE_ALARM)

--- a/src/test/regression-malloc.c
+++ b/src/test/regression-malloc.c
@@ -1,0 +1,157 @@
+/*======================================================================
+FILE: regression-malloc.c
+
+(C) COPYRIGHT 2018, Markus Minichmayr
+
+This library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+The LGPL as published by the Free Software Foundation, version
+2.1, available at: http://www.gnu.org/licenses/lgpl-2.1.html
+
+Or:
+
+The Mozilla Public License Version 2.0. You may obtain a copy of
+the License at http://www.mozilla.org/MPL/
+======================================================================*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "libical/ical.h"
+
+#include "regression.h"
+#include "regression-malloc.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+
+
+struct testmalloc_statistics global_testmalloc_statistics;
+static int global_testmalloc_remainint_attempts = -1;
+
+#define TESTMALLOC_MAGIC_NO 0x1234abcd
+struct testmalloc_hdr {
+	uint32_t magic_no;
+	size_t size;
+};
+
+void *test_malloc(size_t size) {
+
+	void* block;
+	struct testmalloc_hdr* hdr;
+
+	global_testmalloc_statistics.malloc_cnt++;
+	if (global_testmalloc_remainint_attempts == 0) {
+		global_testmalloc_statistics.malloc_failed_cnt++;
+		return NULL;
+	}
+
+	block = malloc(size + sizeof(struct testmalloc_hdr));
+	if (block == NULL) {
+		global_testmalloc_statistics.malloc_failed_cnt++;
+		return NULL;
+	}
+
+	hdr = (struct testmalloc_hdr*) block;
+	hdr->magic_no = TESTMALLOC_MAGIC_NO;
+	hdr->size = size;
+
+	global_testmalloc_statistics.mem_allocated_current += size;
+	if (global_testmalloc_statistics.mem_allocated_current > global_testmalloc_statistics.mem_allocated_max)
+		global_testmalloc_statistics.mem_allocated_max = global_testmalloc_statistics.mem_allocated_current;
+
+	global_testmalloc_statistics.blocks_allocated++;
+
+	if (global_testmalloc_remainint_attempts > 0)
+		global_testmalloc_remainint_attempts--;
+
+	return (void*) (hdr + 1);
+}
+
+void *test_realloc(void* p, size_t size) {
+
+	struct testmalloc_hdr* hdr;
+	size_t old_size;
+
+	global_testmalloc_statistics.realloc_cnt++;
+	if (global_testmalloc_remainint_attempts == 0) {
+		global_testmalloc_statistics.realloc_failed_cnt++;
+		return NULL;
+	}
+
+	if (p == NULL) {
+		global_testmalloc_statistics.realloc_failed_cnt++;
+		return NULL;
+	}
+
+	hdr = ((struct testmalloc_hdr*) p) - 1;
+	if (hdr->magic_no != TESTMALLOC_MAGIC_NO) {
+		global_testmalloc_statistics.realloc_failed_cnt++;
+		return NULL;
+	}
+
+	old_size = hdr->size;
+	hdr->magic_no = 0;
+	hdr = (struct testmalloc_hdr*) realloc(hdr, size + sizeof(struct testmalloc_hdr));
+	if (hdr == NULL) {
+		global_testmalloc_statistics.realloc_failed_cnt++;
+		return NULL;
+	}
+
+	hdr->magic_no = TESTMALLOC_MAGIC_NO;
+	hdr->size = size;
+
+	global_testmalloc_statistics.mem_allocated_current += size - old_size;
+	if (global_testmalloc_statistics.mem_allocated_current > global_testmalloc_statistics.mem_allocated_max)
+		global_testmalloc_statistics.mem_allocated_max = global_testmalloc_statistics.mem_allocated_current;
+
+	if (global_testmalloc_remainint_attempts > 0)
+		global_testmalloc_remainint_attempts--;
+
+	return (void*) (hdr + 1);
+}
+
+void test_free(void* p) {
+
+	struct testmalloc_hdr* hdr;
+	size_t old_size;
+
+	if (p == NULL)
+		return;
+
+	global_testmalloc_statistics.free_cnt++;
+
+	hdr = ((struct testmalloc_hdr*) p) - 1;
+	if (hdr->magic_no != TESTMALLOC_MAGIC_NO) {
+        // assert may not have any effect in release mode
+        assert(hdr->magic_no == TESTMALLOC_MAGIC_NO);
+        ok("free consistent", hdr->magic_no == TESTMALLOC_MAGIC_NO);
+		global_testmalloc_statistics.free_failed_cnt++;
+		return;
+	}
+
+	old_size = hdr->size;
+	hdr->magic_no = 0;
+
+	free(hdr);
+
+	global_testmalloc_statistics.mem_allocated_current -= old_size;
+	global_testmalloc_statistics.blocks_allocated--;
+}
+
+
+
+void testmalloc_reset() {
+	memset(&global_testmalloc_statistics, 0, sizeof(global_testmalloc_statistics));
+	global_testmalloc_remainint_attempts = -1;
+}
+
+/** Sets the maximum number of malloc or realloc attemts that will succeed. If
+* the number is negative, no limit will be applied. */
+void testmalloc_set_max_successful_allocs(int n) {
+	global_testmalloc_remainint_attempts = n;
+}

--- a/src/test/regression-malloc.h
+++ b/src/test/regression-malloc.h
@@ -1,0 +1,49 @@
+/*======================================================================
+FILE: regression-malloc.h
+
+(C) COPYRIGHT 2018, Markus Minichmayr
+
+This library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+The LGPL as published by the Free Software Foundation, version
+2.1, available at: http://www.gnu.org/licenses/lgpl-2.1.html
+
+Or:
+
+The Mozilla Public License Version 2.0. You may obtain a copy of
+the License at http://www.mozilla.org/MPL/
+======================================================================*/
+
+#include <stdint.h>
+
+
+struct testmalloc_statistics {
+	int malloc_cnt;
+	int realloc_cnt;
+	int free_cnt;
+
+	int malloc_failed_cnt;
+	int realloc_failed_cnt;
+	int free_failed_cnt;
+
+	size_t mem_allocated_max;
+	size_t mem_allocated_current;
+	int blocks_allocated;
+};
+
+extern struct testmalloc_statistics global_testmalloc_statistics;
+
+void *test_malloc(size_t size);
+void *test_realloc(void* p, size_t size);
+void test_free(void* p);
+
+/** Resets the memory management statistics and sets the number of successful
+  * allocations limit to infinite.
+  */
+void testmalloc_reset();
+
+/** Sets the maximum number of malloc or realloc attemts that will succeed. If 
+  * the number is negative, no limit will be applied.
+  */
+void testmalloc_set_max_successful_allocs(int n);

--- a/src/test/regression-utils.c
+++ b/src/test/regression-utils.c
@@ -24,6 +24,8 @@
 
 #include "libical/ical.h"
 
+#include "regression-malloc.h"
+
 #include <stdlib.h>
 
 int QUIET = 0;
@@ -213,9 +215,21 @@ void test_run(const char *test_name, void (*test_fcn) (void), int do_test, int h
         test_header(test_name, test_set);
 
     if (!headeronly && (do_test == 0 || do_test == test_set)) {
+        testmalloc_reset();
         (*test_fcn) ();
+
+        /* TODO: Check for memory leaks here. We could do a check like the
+        following but we would have to implement the test-cases in a way
+        that all memory is freed at the end of each test. This would include
+        freeing built in and cached timezones.
+
+            ok("no memory leaked",
+                (global_testmalloc_statistics.mem_allocated_current == 0)
+                && (global_testmalloc_statistics.blocks_allocated == 0));
+        */
+
         if (!QUIET)
             printf("\n");
-    }
+	}
     test_set++;
 }

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4046,6 +4046,107 @@ void test_comma_in_quoted_value(void)
     icalcomponent_free(c);
 }
 
+static int do_test_out_of_memory(const char* cal_str, struct icaltimetype t_start, struct icaltimetype t_end, int allocAttemptLimit) {
+
+    int foundExpectedCnt = 0;
+    icalcomponent *calendar;
+    int attempts0;
+
+    printf("starting out of memory test; memory allocation will fail after %d successful attempts.\n", allocAttemptLimit);
+    testmalloc_reset();
+
+    calendar = icalparser_parse_string(cal_str);
+    assert((calendar != NULL) || (allocAttemptLimit >= 0));
+
+    attempts0 = global_testmalloc_statistics.malloc_cnt + global_testmalloc_statistics.realloc_cnt;
+    testmalloc_set_max_successful_allocs(allocAttemptLimit);
+
+    if (calendar) {
+        icalcomponent *event = icalcomponent_get_first_component(calendar, ICAL_VEVENT_COMPONENT);
+
+        /* we expect exactly one callback, namely on tu, 20th. */
+        icalcomponent_foreach_recurrence(event, t_start, t_end, test_component_foreach_callback, &foundExpectedCnt);
+        icalcomponent_free(calendar);
+    }
+    return global_testmalloc_statistics.malloc_cnt + global_testmalloc_statistics.realloc_cnt - attempts0;
+}
+
+void test_out_of_memory() {
+
+    const char* t_start_str = "20180201T000000Z";
+    const char* t_end_str = "20190201T000000Z";
+
+    /* use a rather complex calendar to increase code coverage. */
+    static const char* cal_str =
+        "BEGIN:VCALENDAR\n"
+        "BEGIN:VTIMEZONE\n"
+        "TZID:Custom/Custom\n"
+        "BEGIN:DAYLIGHT\n"
+        "TZOFFSETFROM:+0100\n"
+        "TZOFFSETTO:+0200\n"
+        "TZNAME:CEST\n"
+        "DTSTART:19700329T020000\n"
+        "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\n"
+        "END:DAYLIGHT\n"
+        "BEGIN:STANDARD\n"
+        "TZOFFSETFROM:+0200\n"
+        "TZOFFSETTO:+0100\n"
+        "TZNAME:CET\n"
+        "DTSTART:19701025T030000\n"
+        "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\n"
+        "END:STANDARD\n"
+        "END:VTIMEZONE\n"
+        "BEGIN:VEVENT\n"
+        "DTSTART;TZID=Custom/Custom:20180218T020000\n"
+        "DTEND;TZID=Custom/Custom:20180218T040000\n"
+        "RRULE:FREQ=MONTHLY;BYSECOND=1,2;BYMINUTE=3,4;BYHOUR=5,6;BYDAY=MO,TU;BYMONTHDAY=17,18;BYMONTH=3,4,5,6,7,8,9,10;BYSETPOS=1,2,3\n"
+        "RRULE:FREQ=YEARLY;BYYEARDAY=1,2,3,8,9,10,11\n"
+        "RDATE:20180306T180600,20180307T150000\n"
+        "EXDATE:20180306T180600,20180307T150000\n"
+        "EXRULE:FREQ=YEARLY;BYWEEKNO=1,2,3,4,5,6,7,8,9,10\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n";
+
+    int allocations;
+    int i, ef;
+
+    struct icaltimetype t_start = icaltime_from_string(t_start_str);
+    struct icaltimetype t_end = icaltime_from_string(t_end_str);
+
+    ef = icalerror_get_errors_are_fatal();
+    icalerror_set_errors_are_fatal(1);
+
+    allocations = do_test_out_of_memory(cal_str, t_start, t_end, -1);
+
+    // A preassumption for this test is, that the number of allocations is
+    // deterministic.
+    assert(allocations == do_test_out_of_memory(cal_str, t_start, t_end, -1));
+
+    icalerror_set_errors_are_fatal(0);
+
+    printf("testing failure of %d individual memory allocations.\n", allocations);
+
+    for (i = 0; i < allocations; i++) {
+        // We run the test multiple times and limit the number of successful memory
+        // allocations, so each memory allocation fails once. No memory faults
+        // may occur and no leaks should occur.
+        do_test_out_of_memory(cal_str, t_start, t_end, i);
+    }
+
+    testmalloc_reset();
+    icalerror_clear_errno();
+    icalerror_set_errors_are_fatal(ef);
+
+    // The most important thing to note here is that we reached this point
+    // without any access violation.
+    ok("tests ran and didn't abort unexpectedly", i > 0);
+
+    // We could easily test for memory leaks by testing the number of allocated
+    // blocks for 0 in the testmalloc statistics, but sometimes memory
+    // is allocated and cached as side effect (e.g. in the icalmemory ring
+    // buffer) that makes this kind of test hard to implement.
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -4174,6 +4275,7 @@ int main(int argc, char *argv[])
              do_header);
     test_run("Test comma in quoted value of x property", test_comma_in_quoted_value, do_test,
              do_header);
+    test_run("Test out of memory", test_out_of_memory, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -25,6 +25,7 @@
 #endif
 
 #include "regression.h"
+#include "regression-malloc.h"
 #include "libical/ical.h"
 #include "libicalss/icalss.h"
 #include "libicalvcal/icalvcal.h"
@@ -760,7 +761,7 @@ void test_memory()
 
     ok("final buffer size == 806", (bufsize == 806));
 
-    free(f);
+    icalmemory_free_buffer(f);
 
     bufsize = 4;
 
@@ -849,7 +850,7 @@ void test_memory()
     if (VERBOSE)
         printf("Char-by-Char buffer: %s\n", f);
 
-    free(f);
+    icalmemory_free_buffer(f);
 
     for (i = 0; i < 100; i++) {
         f = icalmemory_tmp_buffer(bufsize);

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4061,6 +4061,9 @@ int main(int argc, char *argv[])
     int do_header = 0;
     int failed_count = 0;
 
+#if ICAL_USE_MALLOC == 0
+    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
+#endif
     set_zone_directory("../../zoneinfo");
     icaltimezone_set_tzid_prefix("/softwarestudio.org/");
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4061,9 +4061,7 @@ int main(int argc, char *argv[])
     int do_header = 0;
     int failed_count = 0;
 
-#if ICAL_USE_MALLOC == 0
-    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
-#endif
+    icalmemory_set_mem_alloc_funcs(&test_malloc, &test_realloc, &test_free);
     set_zone_directory("../../zoneinfo");
     icaltimezone_set_tzid_prefix("/softwarestudio.org/");
 

--- a/src/test/testvcal.c
+++ b/src/test/testvcal.c
@@ -50,6 +50,10 @@ int main(int argc, char *argv[])
         file = argv[1];
     }
 
+#if ICAL_USE_MALLOC == 0
+    icalmemory_set_mem_alloc_funcs(&malloc, &realloc, &free);
+#endif
+
     vcal = Parse_MIME_FromFileName(file);
 
     assert(vcal != 0);


### PR DESCRIPTION
This PR adds functionality that gives users more control over memory management within libical. Today malloc, realloc and free are used to allocate and deallocate memory but this might not always be suitable, especially in resource-constrained environments. The possibility of replacing these functions also allows implementing test cases that test for the correctness and robusness of memory management. The `icalmemory_new_buffer()` and related functions have already been present in preparation for these scenarios but have not yet been configurable and not been used consistently. This PR replaces calls to malloc, realloc, free and strdup with the corresponding preexisting wrapper functions throughout the libical core component. It makes the wrapper functions themselfes configurable, so custom memory management functions can be used instead of malloc & co.

## Test
This PR extends the regression tests with some basic functionality that tests for consistency and robusnes against out of memory errors. Regarding consistency, the extension ensures, that memory allocated with `icalmemory_new_buffer()` is not freed with the standard system `free()` function and that on the other hand `icalmemory_free_buffer()` is only used to free memory that has been allocated using `icalmemory_new_buffer()`. No tests have been added that test for memory leaks (i.e. verifying that all memory that has been allocated is freed too) but adding such tests would be trivial with the functionality introduced by this PR. However, it would require consideration of how to handle cached components like timezones that are not necessarily freed at the end of each test and would therefore look like memory leaks to naive test cases.

Tests have been added that make sure, that out of memory errors (where `icalmemory_new_buffer()` returns NULL) are handled gracefully in certain situations. These tests cover only a limited set of functionality and brought up some issues in icalarray and icalrecur that were fixed as part of this PR. Experiments with e.g. the icalparser component (which are not included in this PR) showed little robustness against out of memory errors there. Making all components robust against out of memory errors would be improtant for use especially in resource-constrained environments but is out of the scope of this PR and should be considered for future work.

## Compatibility
This change is fully backwards compatible because by default still the standard malloc, realloc, free functions are used, just like before. So users can free() memory just as before, even if the freed memory was allocated using libcalmemory_new_buffer. However, the change is not fully forwards compatible once people start using `icalmemory_set_mem_alloc_funcs()` if the use of icalmemory is introduced in more components. I therefore added a note to `icalmemory_set_mem_alloc_funcs()`, discouraging its use if using more than just the core libical component until introduction in all components has been completed.

## CMAKE Flag ICAL_USE_MALLOC
The CMAKE flag `ICAL_USE_MALLOC` was introduced, controlling whether or not the standard system memory allocation functions should be used by default. It makes sense to have this explicit flag rather than introducing something like a `HAVING_MALLOC` flag (which would only indicate whether malloc is present) because it can make sense to avoid linking malloc, etc., even if they are present. This is especially true in resource constrained environments where linking malloc would inacceptably increase the size of the compiled binary.

## Future work
* Use libcalmemory_new_buffer throughout other components (libicalvcal, etc.) too.
* Produce compile errors when using malloc, etc. withing components where libcalmemory_new_buffer should be used to avoid unintended reintroduction of former functions. This could be achieved by undefining malloc, etc.
* Add more tests that test for out of memory errors (libcalmemory_new_buffer returns NULL) similar to the tests introduced with this PR. However, such tests will bring up issues that need to be fixed in order to succeed (e.g. in the icalparser component).
* Add more tests that test for memory leaks.

[Edit] No tests for memory leaks.