### PR TITLE
ical_file.cmake: Fix ICAL_CHECK_VERSION macro

### DIFF
--- a/src/libical/ical_file.cmake
+++ b/src/libical/ical_file.cmake
@@ -37,7 +37,7 @@ file(APPEND ${ICAL_FILE_H_FILE} "extern \"C\" {\n")
 file(APPEND ${ICAL_FILE_H_FILE} "#endif\n")
 
 foreach(_current_FILE ${COMBINEDHEADERSICAL})
-  file(STRINGS ${_current_FILE} _lines)
+  file(STRINGS ${_current_FILE} _lines NEWLINE_CONSUME)
   foreach(_currentLINE ${_lines})
     string(REGEX REPLACE "#include \"ical.*\\.h\"" "" _currentLINE "${_currentLINE}")
     string(REGEX REPLACE "#include \"config.*\\.h\"" "" _currentLINE "${_currentLINE}")


### PR DESCRIPTION
The inclusion of the icalversion.h header in ical.h breaks the
ICAL_CHECK_VERSION macro because all the \ line continuation characters
are converted to ;. This makes the macro useless. Wrapping for the sake
of readability, it currently looks like this:

  #define ICAL_CHECK_VERSION(major,minor,micro) ; (ICAL_MAJOR_VERSION >
  (major) || ; (ICAL_MAJOR_VERSION == (major) && ICAL_MINOR_VERSION >
  (minor)) || ; (ICAL_MAJOR_VERSION == (major) && ICAL_MINOR_VERSION ==
  (minor) && ; ICAL_MICRO_VERSION >= (micro)))

Setting the STRINGS NEWLINE_CONSUME option keeps the original structure
instead of terminating the lines.