### PR TITLE
glib: free trueType in is_enum_type

### DIFF
--- a/src/libical-glib/tools/generator.c
+++ b/src/libical-glib/tools/generator.c
@@ -1446,6 +1446,7 @@ static gboolean is_enum_type(const gchar *type)
         structureKind = g_hash_table_lookup(type2kind, trueType);
         res = g_strcmp0(structureKind, "enum") == 0;
     }
+    g_free (trueType);
 
     return res;
 }


### PR DESCRIPTION
get_true_type allocates memory through a g_new.  LeakSanitizer is complaining about the lost memory.

```
Direct leak of 11949 byte(s) in 837 object(s) allocated from:
    #0 0x7fe5cf91aae0 in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cc:86
    #1 0x7fe5cf3150e8 in g_malloc (/lib/libglib-2.0.so.0+0x510e8)
    #2 0x5614a3f4475d in is_enum_type /run/build/libical/src/libical-glib/tools/generator.c:1438
    #3 0x5614a3f45dc9 in get_inline_parameter /run/build/libical/src/libical-glib/tools/generator.c:1602
    #4 0x5614a3f44564 in get_source_method_code /run/build/libical/src/libical-glib/tools/generator.c:1416
    #5 0x5614a3f47081 in get_source_method_body /run/build/libical/src/libical-glib/tools/generator.c:1720
    #6 0x5614a3f40258 in generate_code_from_template /run/build/libical/src/libical-glib/tools/generator.c:891
    #7 0x5614a3f42608 in generate_source /run/build/libical/src/libical-glib/tools/generator.c:1192
    #8 0x5614a3f49316 in generate_header_and_source /run/build/libical/src/libical-glib/tools/generator.c:1918
    #9 0x5614a3f4cd97 in generate_library /run/build/libical/src/libical-glib/tools/generator.c:2274
    #10 0x5614a3f4d998 in main /run/build/libical/src/libical-glib/tools/generator.c:2401
    #11 0x7fe5cdece290 in __libc_start_main (/lib/libc.so.6+0x3130820290)
```

In other places, the result of get_true_type is freed unconditionally, too, so this is just copying the behaviour from there.