### PR TITLE
Update juldat() and caldat() functions to avoid floating point types.

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -8,6 +8,9 @@ Version 3.1.0:
      + icalrecurrencetype_encode_month
      + icaltzutil_set_zone_directory
  * icaltzutil_get_zone_directory() can use the TZDIR environment to find system zoneinfo
+ * Deprecated functions:
+     + caldat
+     + juldat
 
 Version 3.0.4:
 --------------

--- a/src/libical/astime.h
+++ b/src/libical/astime.h
@@ -1,3 +1,7 @@
+/* 
+ * This work is based on work from Hiram Clawson and has been modified to the
+ * needs of the libical project. The original copyright notice is as follows:
+ */
 /*
  *      Copyright (c) 1986-2000, Hiram Clawson
  *      All rights reserved.
@@ -33,6 +37,27 @@
  *      IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *      THE POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * The modifications made are licensed as follows (to distinguish between
+ * the original code and the modifications made, refer to the source code
+ * history):
+ */
+ /*======================================================================
+
+  (C) COPYRIGHT 2018, Markus Minichmayr
+      https://tapkey.com
+
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of either:
+
+     The LGPL as published by the Free Software Foundation, version
+     2.1, available at: http://www.gnu.org/licenses/lgpl-2.1.html
+
+  Or:
+
+     The Mozilla Public License Version 2.0. You may obtain a copy of
+     the License at http://www.mozilla.org/MPL/
+ ========================================================================*/
 
 /**
  *      @file astime.h
@@ -62,8 +87,33 @@ typedef struct ut_instant
 
 /*      Functions in caldate.c  */
 
-LIBICAL_ICAL_EXPORT long caldat(UTinstantPtr);      /** converts julian date to year,mo,da */
+/** converts julian date to year,mo,da
+ *  @deprecated use caldat_int() instead
+ */
+LIBICAL_ICAL_EXPORT long caldat(UTinstantPtr);
 
-LIBICAL_ICAL_EXPORT double juldat(UTinstantPtr);    /** returns julian day from year,mo,da */
+/** returns julian day from year,mo,da
+ *  @deprecated use juldat_int() instead
+ */
+LIBICAL_ICAL_EXPORT double juldat(UTinstantPtr);
+
+
+typedef struct ut_instant_int
+{
+    long j_date0;      /**< julian decimal date, 0 = 01 Jan 4713 BC */
+    long year;          /**< year, valid range [-4,713, +32,767] */
+    int month;          /**<    [1-12]  */
+    int day;            /**<    [1-31]  */
+    int weekday;                /**<    [0-6]   */
+    int day_of_year;            /**<    [1-366] */
+} UTinstantInt, *UTinstantIntPtr;
+
+/*      Functions in caldate.c  */
+
+/** converts julian date to year,mo,da */
+void caldat_int(UTinstantIntPtr);
+
+/** returns julian day from year,mo,da */
+void juldat_int(UTinstantIntPtr);
 
 #endif

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -526,18 +526,15 @@ int icaltime_days_in_month(const int month, const int year)
 /* 1-> Sunday, 7->Saturday */
 int icaltime_day_of_week(const struct icaltimetype t)
 {
-    UTinstant jt;
+    UTinstantInt jt;
 
-    memset(&jt, 0, sizeof(UTinstant));
+    memset(&jt, 0, sizeof(UTinstantInt));
 
     jt.year = t.year;
     jt.month = t.month;
     jt.day = t.day;
-    jt.i_hour = 0;
-    jt.i_minute = 0;
-    jt.i_second = 0;
 
-    (void)juldat(&jt);
+    (void)juldat_int(&jt);
 
     return jt.weekday + 1;
 }
@@ -546,20 +543,17 @@ int icaltime_day_of_week(const struct icaltimetype t)
  */
 int icaltime_start_doy_week(const struct icaltimetype t, int fdow)
 {
-    UTinstant jt;
+    UTinstantInt jt;
     int delta;
 
-    memset(&jt, 0, sizeof(UTinstant));
+    memset(&jt, 0, sizeof(UTinstantInt));
 
     jt.year = t.year;
     jt.month = t.month;
     jt.day = t.day;
-    jt.i_hour = 0;
-    jt.i_minute = 0;
-    jt.i_second = 0;
 
-    (void)juldat(&jt);
-    (void)caldat(&jt);
+    (void)juldat_int(&jt);
+    (void)caldat_int(&jt);
 
     delta = jt.weekday - (fdow - 1);
     if (delta < 0) {
@@ -574,19 +568,16 @@ int icaltime_start_doy_week(const struct icaltimetype t, int fdow)
  */
 int icaltime_week_number(const struct icaltimetype ictt)
 {
-    UTinstant jt;
+    UTinstantInt jt;
 
-    memset(&jt, 0, sizeof(UTinstant));
+    memset(&jt, 0, sizeof(UTinstantInt));
 
     jt.year = ictt.year;
     jt.month = ictt.month;
     jt.day = ictt.day;
-    jt.i_hour = 0;
-    jt.i_minute = 0;
-    jt.i_second = 0;
 
-    (void)juldat(&jt);
-    (void)caldat(&jt);
+    (void)juldat_int(&jt);
+    (void)caldat_int(&jt);
 
     return (jt.day_of_year - jt.weekday) / 7;
 }


### PR DESCRIPTION
This PR updates the juldat() and caldat() functions to avoid the use of floating point types. It also removes functionality that is not used in context of libical (i.e. time-related computations). This improves portability to (i.e. embedded, resource constrained) platforms not supporting FP-arithmetics natively, e.g. ARM Cortext M. The change is intended to improve performance and reduce code size.

## Test
Tests have been added that compare the new implementation against the old one. It compares the application to some selected border case values and randomly selected ones.