### PR TITLE
Fixed incorrect handling of a weekly RRULE at the beginning of the year

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -1959,6 +1959,17 @@ static int __day_diff(icalrecur_iterator *impl, icaltimetype a, icaltimetype b)
         diff = get_day_of_year(impl, b.year, b.month, b.day, NULL) -
             get_day_of_year(impl, a.year, a.month, a.day, NULL);
     } else {
+        /* Swap a and b if a is greater than b */
+        int flipped = 0;
+
+        if (a.year > b.year) {
+            icaltimetype temp = a;
+
+            a = b;
+            b = temp;
+            flipped = 1;
+        }
+
         /* Count days in each year to account for leap days/months */
         int year = a.year;
 
@@ -1966,6 +1977,11 @@ static int __day_diff(icalrecur_iterator *impl, icaltimetype a, icaltimetype b)
             get_day_of_year(impl, a.year, a.month, a.day, NULL);
         while (++year < b.year) diff += get_days_in_year(impl, year);
         diff += get_day_of_year(impl, b.year, b.month, b.day, NULL);
+
+        if (flipped) {
+            /* The difference is negative because a was greater than b */
+            diff = -diff;
+        }
     }
 
     return diff;

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -1961,6 +1961,7 @@ static int __day_diff(icalrecur_iterator *impl, icaltimetype a, icaltimetype b)
     } else {
         /* Swap a and b if a is greater than b */
         int flipped = 0;
+        int year;
 
         if (a.year > b.year) {
             icaltimetype temp = a;
@@ -1971,7 +1972,7 @@ static int __day_diff(icalrecur_iterator *impl, icaltimetype a, icaltimetype b)
         }
 
         /* Count days in each year to account for leap days/months */
-        int year = a.year;
+        year = a.year;
 
         diff = get_days_in_year(impl, year) -
             get_day_of_year(impl, a.year, a.month, a.day, NULL);

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -709,6 +709,20 @@ void test_recur_iterator_set_start()
     icalrecur_iterator_free(iterator);
 }
 
+void test_recur_iterator_on_jan_1()
+{
+    icaltimetype start = icaltime_from_string("20190101");
+    struct icalrecurrencetype recurrence = icalrecurrencetype_from_string("FREQ=WEEKLY;WKST=SU;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR");
+    icalrecur_iterator *iterator = icalrecur_iterator_new(recurrence, start);
+
+    icaltimetype next = icalrecur_iterator_next(iterator);
+    ok("Next recurrence iterator result should be January 1", next.year == 2019 && next.month == 1 && next.day == 1);
+
+    next = icalrecur_iterator_next(iterator);
+    ok("Next recurrence iterator result should be January 2", next.year == 2019 && next.month == 1 && next.day == 2);
+    icalrecur_iterator_free(iterator);
+}
+
 void test_memory()
 {
     size_t bufsize = 256;
@@ -4546,6 +4560,7 @@ int main(int argc, char *argv[])
     test_run("Test Components", test_components, do_test, do_header);
     test_run("Test icalcomponent_foreach_recurrence", test_component_foreach, do_test, do_header);
     test_run("Test icalrecur_iterator_set_start with date", test_recur_iterator_set_start, do_test, do_header);
+    test_run("Test weekly icalrecur_iterator on January 1", test_recur_iterator_on_jan_1, do_test, do_header);
     test_run("Test Convenience", test_convenience, do_test, do_header);
     test_run("Test classify ", test_classify, do_test, do_header);
     test_run("Test Iterators", test_iterators, do_test, do_header);


### PR DESCRIPTION
Found an edge case for weekly recurrences at the beginning of the year. Regression test included.

---

This RRULE on January 1 would result in the second occurrence being January 7 rather than January 2.

FREQ=WEEKLY;WKST=SU;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR

The problem is that day_diff wasn't handling cases where a > b and would count days of the year incorrectly. Temporarily swaping a and b and then performing the day_diff calculation avoids the issue.