### PR TITLE
Add "MSEC" recurrence rule type for millisecond precision intervals

### DIFF
--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -15,6 +15,7 @@
 -->
 <structure namespace="ICal" name="Recurrence" native="struct icalrecurrencetype" is_bare="true" default_native="i_cal_recurrence_new_default ()">
      <enum name="ICalRecurrenceFrequency" native_name="icalrecurrencetype_frequency" default_native="I_CAL_NO_RECURRENCE">
+        <element name="ICAL_MSEC_RECURRENCE"/>
         <element name="ICAL_SECONDLY_RECURRENCE"/>
         <element name="ICAL_MINUTELY_RECURRENCE"/>
         <element name="ICAL_HOURLY_RECURRENCE"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -164,6 +164,7 @@
         <parameter type="const gint" name="hours" comment="difference of hours adjusted"/>
         <parameter type="const gint" name="minutes" comment="difference of minutes adjusted"/>
         <parameter type="const gint" name="seconds" comment="difference of seconds adjusted"/>
+        <parameter type="const gint" name="msecs" comment="difference of milliseconds adjusted"/>
         <comment xml:space="preserve">like icaltime_compare_tz, but only use the date parts.</comment>
     </method>
     <method name="i_cal_time_normalize" corresponds="icaltime_normalize" since="1.0">

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -953,7 +953,7 @@ void icalcomponent_foreach_recurrence(icalcomponent *comp,
             icaltimetype mystart = start;
 
             /* make sure we include any recurrence that ends in timespan */
-            icaltime_adjust(&mystart, 0, 0, 0, -(int)dtduration);
+            icaltime_adjust(&mystart, 0, 0, 0, -(int)dtduration, 0);
             icalrecur_iterator_set_start(rrule_itr, mystart);
         }
 

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -80,14 +80,15 @@ typedef enum icalrecurrencetype_frequency
     /* These enums are used to index an array, so don't change the
        order or the integers */
 
-    ICAL_SECONDLY_RECURRENCE = 0,
-    ICAL_MINUTELY_RECURRENCE = 1,
-    ICAL_HOURLY_RECURRENCE = 2,
-    ICAL_DAILY_RECURRENCE = 3,
-    ICAL_WEEKLY_RECURRENCE = 4,
-    ICAL_MONTHLY_RECURRENCE = 5,
-    ICAL_YEARLY_RECURRENCE = 6,
-    ICAL_NO_RECURRENCE = 7
+    ICAL_MSEC_RECURRENCE = 0,
+    ICAL_SECONDLY_RECURRENCE = 1,
+    ICAL_MINUTELY_RECURRENCE = 2,
+    ICAL_HOURLY_RECURRENCE = 3,
+    ICAL_DAILY_RECURRENCE = 4,
+    ICAL_WEEKLY_RECURRENCE = 5,
+    ICAL_MONTHLY_RECURRENCE = 6,
+    ICAL_YEARLY_RECURRENCE = 7,
+    ICAL_NO_RECURRENCE = 8
 } icalrecurrencetype_frequency;
 
 typedef enum icalrecurrencetype_weekday
@@ -138,6 +139,7 @@ LIBICAL_ICAL_EXPORT icalrecurrencetype_weekday icalrecur_string_to_weekday(const
  *
  * The maximums below are based on lunisolar leap years (13 months)
  */
+#define ICAL_BY_MSEC_SIZE     1002    /* 0 to 1000 */
 #define ICAL_BY_SECOND_SIZE     62      /* 0 to 60 */
 #define ICAL_BY_MINUTE_SIZE     61      /* 0 to 59 */
 #define ICAL_BY_HOUR_SIZE       25      /* 0 to 23 */
@@ -170,6 +172,7 @@ struct icalrecurrencetype
      * ICAL_RECURRENCE_ARRAY_MAX unless the list is full.
      */
 
+    short by_msec[ICAL_BY_MSEC_SIZE];
     short by_second[ICAL_BY_SECOND_SIZE];
     short by_minute[ICAL_BY_MINUTE_SIZE];
     short by_hour[ICAL_BY_HOUR_SIZE];

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -72,7 +72,7 @@
  *      - icaltime_compare_date_only(struct icaltimetype a,
  *              struct icaltimetype b)
  *      - icaltime_adjust(struct icaltimetype *tt, int days, int hours,
- *              int minutes, int seconds);
+ *              int minutes, int seconds, int msecs);
  *      - icaltime_normalize(struct icaltimetype t);
  *      - icaltime_convert_to_zone(const struct icaltimetype tt,
  *              icaltimezone *zone);
@@ -110,6 +110,7 @@ struct icaltimetype
     int hour;
     int minute;
     int second;
+    int msec;
 
     int is_date;        /**< 1 -> interpret this as date. */
 
@@ -161,6 +162,11 @@ LIBICAL_ICAL_EXPORT time_t icaltime_as_timet_with_zone(const struct icaltimetype
 LIBICAL_ICAL_EXPORT const char *icaltime_as_ical_string(const struct icaltimetype tt);
 
 LIBICAL_ICAL_EXPORT char *icaltime_as_ical_string_r(const struct icaltimetype tt);
+
+/** Return a string represention of the time, in ISO 8601 format. */
+LIBICAL_ICAL_EXPORT const char *icaltime_as_iso_string(const struct icaltimetype tt);
+
+LIBICAL_ICAL_EXPORT char *icaltime_as_iso_string_r(const struct icaltimetype tt);
 
 /** @brief Return the timezone */
 LIBICAL_ICAL_EXPORT const icaltimezone *icaltime_get_timezone(const struct icaltimetype t);
@@ -214,7 +220,8 @@ LIBICAL_ICAL_EXPORT int icaltime_compare_date_only_tz(const struct icaltimetype 
 /** Adds or subtracts a number of days, hours, minutes and seconds. */
 LIBICAL_ICAL_EXPORT void icaltime_adjust(struct icaltimetype *tt,
                                          const int days, const int hours,
-                                         const int minutes, const int seconds);
+                                         const int minutes, const int seconds,
+                                         const int msecs);
 
 /** Normalize the icaltime, so that all fields are within the normal range. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_normalize(const struct icaltimetype t);

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -675,7 +675,7 @@ void icaltimezone_expand_vtimezone(icalcomponent *comp, int end_year, icalarray 
                 /* To convert from UTC to a local time, we use the TZOFFSETFROM
                    since that is the offset from UTC that will be in effect
                    when each of the RRULE occurrences happens. */
-                icaltime_adjust(&rrule.until, 0, 0, 0, change.prev_utc_offset);
+                icaltime_adjust(&rrule.until, 0, 0, 0, change.prev_utc_offset, 0);
                 rrule.until.zone = NULL;
             }
 
@@ -788,13 +788,13 @@ void icaltimezone_convert_time(struct icaltimetype *tt,
 
     /* Convert the time to UTC by getting the UTC offset and subtracting it. */
     utc_offset = icaltimezone_get_utc_offset(from_zone, tt, NULL);
-    icaltime_adjust(tt, 0, 0, 0, -utc_offset);
+    icaltime_adjust(tt, 0, 0, 0, -utc_offset, 0);
 
     /* Now we convert the time to the new timezone by getting the UTC offset
        of our UTC time and adding it. */
     utc_offset = icaltimezone_get_utc_offset_of_utc_time(to_zone, tt, &is_daylight);
     tt->is_daylight = is_daylight;
-    icaltime_adjust(tt, 0, 0, 0, utc_offset);
+    icaltime_adjust(tt, 0, 0, 0, utc_offset, 0);
 }
 
 /* Calculates the UTC offset of a given local time in the given

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -480,7 +480,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                         daylight_recur.by_day[0] != by_day ||
                         types[prev_idx].gmtoff != prev_daylight_gmtoff) {
                     // Set UNTIL of the previous component's recurrence
-                    icaltime_adjust(&prev_daylight_time, 0, 0, 0, -types[prev_idx].gmtoff);
+                    icaltime_adjust(&prev_daylight_time, 0, 0, 0, -types[prev_idx].gmtoff, 0);
                     prev_daylight_time.zone = icaltimezone_get_utc_timezone();
 
                     daylight_recur.until = prev_daylight_time;
@@ -513,7 +513,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 if (standard_recur.by_month[0] != icaltime.month ||
                         standard_recur.by_day[0] != by_day ||
                         types[prev_idx].gmtoff != prev_standard_gmtoff) {
-                    icaltime_adjust(&prev_standard_time, 0, 0, 0, -types[prev_idx].gmtoff);
+                    icaltime_adjust(&prev_standard_time, 0, 0, 0, -types[prev_idx].gmtoff, 0);
                     prev_standard_time.zone = icaltimezone_get_utc_timezone();
 
                     standard_recur.until = prev_standard_time;
@@ -527,7 +527,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     // We need to set UNTIL for the daylight component
                     if (cur_daylight_comp && daylight_recur.by_month[0] == icaltime.month &&
                             daylight_recur.by_day[0] == by_day) {
-                        icaltime_adjust(&prev_daylight_time, 0, 0, 0, -types[prev_idx].gmtoff);
+                        icaltime_adjust(&prev_daylight_time, 0, 0, 0, -types[prev_idx].gmtoff, 0);
                         prev_daylight_time.zone = icaltimezone_get_utc_timezone();
 
                         daylight_recur.until = prev_daylight_time;
@@ -586,7 +586,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     // If so, set the UNTIL date to the second-to-last transition date
     // and then insert a new component to indicate the time zone doesn't transition anymore
     if (cur_daylight_comp && icaltime_as_timet(prev_daylight_time) < now) {
-        icaltime_adjust(&prev_prev_daylight_time, 0, 0, 0, -prev_daylight_gmtoff);
+        icaltime_adjust(&prev_prev_daylight_time, 0, 0, 0, -prev_daylight_gmtoff, 0);
         prev_prev_daylight_time.zone = icaltimezone_get_utc_timezone();
 
         daylight_recur.until = prev_prev_daylight_time;
@@ -605,7 +605,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
 
     if (cur_standard_comp && icaltime_as_timet(prev_standard_time) < now) {
-        icaltime_adjust(&prev_prev_standard_time, 0, 0, 0, -prev_standard_gmtoff);
+        icaltime_adjust(&prev_prev_standard_time, 0, 0, 0, -prev_standard_gmtoff, 0);
         prev_prev_standard_time.zone = icaltimezone_get_utc_timezone();
 
         standard_recur.until = prev_prev_standard_time;

--- a/src/test/builtin_timezones.c
+++ b/src/test/builtin_timezones.c
@@ -70,7 +70,7 @@ int main()
             for (hh = 0; hh < 60 * 60 * 24; hh += 567) {
                 int zz2cnt;
 
-                icaltime_adjust(&tt, 0, 0, 0, 1);
+                icaltime_adjust(&tt, 0, 0, 0, 1, 0);
 
                 for (zz2cnt = 0; zz2cnt < 15; zz2cnt++) {
                     icaltimezone *zone2;

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -582,8 +582,8 @@ int test_component_foreach_parameterized(int startOffsSec, int endOffsSec, int e
     struct icaltimetype it_end = dtstart;
     int foundCnt = 0;
 
-    icaltime_adjust(&it_start, 0, 0, 0, startOffsSec);
-    icaltime_adjust(&it_end, 0, 0, 0, endOffsSec);
+    icaltime_adjust(&it_start, 0, 0, 0, startOffsSec, 0);
+    icaltime_adjust(&it_end, 0, 0, 0, endOffsSec, 0);
 
     icalcomponent_foreach_recurrence(event, it_start, it_end, test_component_foreach_callback, &foundCnt);
     icalcomponent_free(calendar);


### PR DESCRIPTION
Usage example: "FREQ=MSEC;INTERVAL=250" - repeat event each 250ms.