### PR TITLE
Set a maximum length per line before calling icalparser_add_line

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -45,6 +45,7 @@
 #include <stdlib.h>
 
 #define TMP_BUF_SIZE 80
+#define MAX_LINE_LENGTH 8192 /* the maximum number of chars per parser line */
 
 struct icalparser_impl
 {
@@ -641,7 +642,15 @@ icalcomponent *icalparser_parse(icalparser *parser,
     do {
         line = icalparser_get_line(parser, line_gen_func);
 
-        if ((c = icalparser_add_line(parser, line)) != 0) {
+        if (line != 0 && strnlen(line, MAX_LINE_LENGTH) >= MAX_LINE_LENGTH) {
+            // Encountered a line that is longer than is reasonable
+            // RFC 5545 Section 3.1 says lines should not be more than 75 octets
+            // A large maximum length allows for lenient parsing but also prevents unbounded memory usage
+            // when parsing intentionally malformed data
+            icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
+            icalmemory_free_buffer(line);
+            line = 0;
+        } else if ((c = icalparser_add_line(parser, line)) != 0) {
 
             if (icalcomponent_get_parent(c) != 0) {
                 /* This is bad news... assert? */


### PR DESCRIPTION
This provides a hard limit on parsing to prevent unbounded memory usage or hanging when expanding parameters or properties.
RFC 5545 says lines should not exceed 75 octets, so this still provides a pretty large buffer (8192 bytes) for files to be non-conformant and still parse successfully.
oss-fuzz issue 14180, 14171, and 14591.

There are alternate ways that we could allow successfully parsing crazy situations with large numbers of parameters and properties (such as referencing counting parameters to avoid unnecessarily duplicating icalparameter structs), but this seems like a fairly reasonable solution. The only drawback that it would fail to parse data that doesn't conform to the SHOULD NOT in the spec, and only by a very large margin.