### PR TITLE
Fixed leaks when encountering END before BEGIN

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -783,8 +783,15 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
         icalmemory_free_buffer(str);
         str = NULL;
 
-        /* Return the component if we are back to the 0th level */
-        if (parser->level == 0) {
+        if (parser->level < 0) {
+            // Encountered an END before any BEGIN, this must be invalid data
+            icalerror_warn("Encountered END before BEGIN");
+
+            parser->state = ICALPARSER_ERROR;
+            parser->level = 0;
+            return 0;
+        } else if (parser->level == 0) {
+            /* Return the component if we are back to the 0th level */
             icalcomponent *rtrn;
 
             if (pvl_count(parser->components) != 0) {


### PR DESCRIPTION
Fixes memory leaks caused by the parser behaving incorrectly when the level is negative.
oss-fuzz issue 14480, 14151, 14152, 14153, 14155.

It'll print a warning and then continue parsing. Any lines before a BEGIN will get ignored, so this is pretty lenient and will still parse anything after a valid BEGIN (this is the current behavior as well). No change in behavior, just fixes the leaks.