### PR TITLE
Cap number of allowed parameters and properties

### DIFF
--- a/scripts/buildtests.sh
+++ b/scripts/buildtests.sh
@@ -329,7 +329,6 @@ SPLINT() {
        -D"strdup"="" \
        -D"strcasecmp"="strcmp" \
        -D"strncasecmp"="strncmp" \
-       -D"strnlen"="" \
        -D"putenv"="" \
        -D"unsetenv"="" \
        -D"tzset()"=";" \

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -45,7 +45,6 @@
 #include <stdlib.h>
 
 #define TMP_BUF_SIZE 80
-#define MAX_LINE_LENGTH 8192 /* the maximum number of chars per parser line */
 
 struct icalparser_impl
 {
@@ -642,15 +641,7 @@ icalcomponent *icalparser_parse(icalparser *parser,
     do {
         line = icalparser_get_line(parser, line_gen_func);
 
-        if (line != 0 && strnlen(line, MAX_LINE_LENGTH) >= MAX_LINE_LENGTH) {
-            // Encountered a line that is longer than is reasonable
-            // RFC 5545 Section 3.1 says lines should not be more than 75 octets
-            // A large maximum length allows for lenient parsing but also prevents unbounded memory usage
-            // when parsing intentionally malformed data
-            icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-            icalmemory_free_buffer(line);
-            line = 0;
-        } else if ((c = icalparser_add_line(parser, line)) != 0) {
+        if ((c = icalparser_add_line(parser, line)) != 0) {
 
             if (icalcomponent_get_parent(c) != 0) {
                 /* This is bad news... assert? */

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -45,6 +45,8 @@
 #include <stdlib.h>
 
 #define TMP_BUF_SIZE 80
+#define MAXIMUM_ALLOWED_PARAMETERS 100
+#define MAXIMUM_ALLOWED_MULTIPLE_VALUES 500
 
 struct icalparser_impl
 {
@@ -689,6 +691,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
 {
     char *str;
     char *end;
+    int pcount = 0;
     int vcount = 0;
     icalproperty *prop;
     icalproperty_kind prop_kind;
@@ -871,7 +874,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
 
     /* Now, add any parameters to the last property */
 
-    while (1) {
+    while (pcount < MAXIMUM_ALLOWED_PARAMETERS) {
         if (*(end - 1) == ':') {
             /* if the last separator was a ":" and the value is a
                URL, icalparser_get_next_parameter will find the
@@ -1103,6 +1106,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
             tail = 0;
             icalmemory_free_buffer(str);
             str = NULL;
+            pcount++;
 
         } else {
             /* str is NULL */
@@ -1120,7 +1124,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
        parameter and add one part of the value to each clone */
 
     vcount = 0;
-    while (1) {
+    while (vcount < MAXIMUM_ALLOWED_MULTIPLE_VALUES) {
         /* Only some properties can have multiple values. This list was taken
            from rfc5545. Also added the x-properties, because the spec actually
            says that commas should be escaped. For x-properties, other apps may

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -43,7 +43,6 @@
 #include <ctype.h>
 #include <stddef.h>     /* for ptrdiff_t */
 #include <stdlib.h>
-#include <string.h>     /* strnlen() */
 
 #define TMP_BUF_SIZE 80
 #define MAX_LINE_LENGTH 8192 /* the maximum number of chars per parser line */
@@ -646,8 +645,8 @@ icalcomponent *icalparser_parse(icalparser *parser,
         if (line != 0 && strnlen(line, MAX_LINE_LENGTH) >= MAX_LINE_LENGTH) {
             // Encountered a line that is longer than is reasonable
             // RFC 5545 Section 3.1 says lines should not be more than 75 octets
-            // A large maximum length allows for lenient parsing but also prevents
-            // unbounded memory usage when parsing intentionally malformed data
+            // A large maximum length allows for lenient parsing but also prevents unbounded memory usage
+            // when parsing intentionally malformed data
             icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
             icalmemory_free_buffer(line);
             line = 0;


### PR DESCRIPTION
Reverted the changes from #381 and trying a different approach.

I set the max parameters to 100 and max multiple values per property to 500. That changed the peak memory usage from 2.4 GB to 47 MB (20 parameters and 100 values as suggested by @ksmurchison was even less at 8 MB — at least for the file I was testing — but 50 MB still seems reasonable for intentionally malformed files).