### PR TITLE
Include invalid parameters in the maximum number of allowed parameters

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1098,6 +1098,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
 
                     icalmemory_free_buffer(str);
                     str = NULL;
+                    pcount++;
                     continue;
                 }
             }


### PR DESCRIPTION
Fixes hangs when iterating lots of invalid parameters (valid parameters already have a cap from f6c64896988644a7c6d4d5060f6ab574c2a62fbf)
oss-fuzz issue 14809