### PR TITLE
In parser_get_next_char, check first character

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -152,7 +152,7 @@ static char *parser_get_next_char(char c, char *str, int qm)
     char prev_char = 0;
 
     while (next_char != '\0') {
-        if ((prev_char != '\0') && (prev_char != '\\')) {
+        if (prev_char != '\\') {
             if (qm == 1 && next_char == '"') {
                 /* Encountered a quote, toggle quote mode */
                 quote_mode = !quote_mode;


### PR DESCRIPTION
Checking `prev_char` is not `\0` immediately after making it `\0` means the block is never run for the first character in `str`, thus `quote_mode` might be wrong or the return value might be wrong.