### PR TITLE
Remove double #include’d headers

### DIFF
--- a/src/libicalss/icalsslexer.c
+++ b/src/libicalss/icalsslexer.c
@@ -557,8 +557,6 @@ char *yytext_ptr;
 #include "icalssyacc.h"
 #include "icalmemory.h"
 
-#include <string.h> /* For strdup() */
-
 const char* input_buffer;
 const char* input_buffer_p;
 

--- a/src/libicalss/icalsslexer.l
+++ b/src/libicalss/icalsslexer.l
@@ -27,8 +27,6 @@
 #include "icalgaugeimpl.h"
 #include "assert.h"
 
-#include <string.h> /* For strdup() */
-
 const char* input_buffer;
 const char* input_buffer_p;
 

--- a/src/libicalvcal/vcc.c
+++ b/src/libicalvcal/vcc.c
@@ -216,9 +216,6 @@ DFARS 252.227-7013 or 48 CFR 52.227-19, as applicable.
 #include <config.h>
 #endif
 
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <ctype.h>
 #include "vcc.h"
 

--- a/src/libicalvcal/vcc.y
+++ b/src/libicalvcal/vcc.y
@@ -117,9 +117,6 @@ DFARS 252.227-7013 or 48 CFR 52.227-19, as applicable.
 #include <config.h>
 #endif
 
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <ctype.h>
 #include "vcc.h"
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4277,7 +4277,7 @@ void test_comma_in_quoted_value(void)
 
 void test_zoneinfo_stuff(void)
 {
- #if defined(HAVE_SETENV)
+#if defined(HAVE_SETENV)
     setenv("TZDIR", TEST_DATADIR, 1);
 #else
     char tzdir[256] = {0};


### PR DESCRIPTION
… as found by deheader.  Some headers are included in generated .c files twice.