### PR TITLE
Don't build stow test on Android

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -114,7 +114,7 @@ endforeach()
 
 ########### next target ###############
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT ANDROID)
   #stow is very Unix specific
   set(stow_SRCS stow.c)
   buildme(stow "${stow_SRCS}")


### PR DESCRIPTION
The test fails to build on Android.

getpwent is only available on Android 26+.

Since the test are not vital for using libical on Android I suggest to disable this test on Android