### PR TITLE
icalcomponent_normalize: avoid memory leaks

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -2665,6 +2665,7 @@ void icalcomponent_normalize(icalcomponent *comp)
         case ICAL_CALSCALE_PROPERTY:
             if ((nparams == 0) &&
                 (strcmp("GREGORIAN", icalproperty_get_calscale(prop)) == 0)) {
+                icalproperty_free(prop);
                 continue;
             }
             break;
@@ -2672,12 +2673,14 @@ void icalcomponent_normalize(icalcomponent *comp)
         case ICAL_CLASS_PROPERTY:
             if ((nparams == 0) &&
                 (icalproperty_get_class(prop) == ICAL_CLASS_PUBLIC)) {
+                icalproperty_free(prop);
                 continue;
             }
             break;
 
         case ICAL_PRIORITY_PROPERTY:
             if ((nparams == 0) && (icalproperty_get_priority(prop) == 0)) {
+                icalproperty_free(prop);
                 continue;
             }
             break;
@@ -2685,18 +2688,21 @@ void icalcomponent_normalize(icalcomponent *comp)
         case ICAL_TRANSP_PROPERTY:
             if ((nparams == 0) &&
                 (icalproperty_get_transp(prop) == ICAL_TRANSP_OPAQUE)) {
+                icalproperty_free(prop);
                 continue;
             }
             break;
 
         case ICAL_REPEAT_PROPERTY:
             if ((nparams == 0) && (icalproperty_get_repeat(prop) == 0)) {
+                icalproperty_free(prop);
                 continue;
             }
             break;
 
         case ICAL_SEQUENCE_PROPERTY:
             if ((nparams == 0) && (icalproperty_get_sequence(prop) == 0)) {
+                icalproperty_free(prop);
                 continue;
             }
             break;

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -979,6 +979,7 @@ void icalproperty_normalize(icalproperty *prop)
             switch (prop_kind) {
             case ICAL_ATTACH_PROPERTY:
                 if (icalparameter_get_value(param) == ICAL_VALUE_URI) {
+                    icalparameter_free(param);
                     continue;
                 }
                 break;
@@ -990,12 +991,14 @@ void icalproperty_normalize(icalproperty *prop)
             case ICAL_RDATE_PROPERTY:
             case ICAL_RECURRENCEID_PROPERTY:
                 if (icalparameter_get_value(param) == ICAL_VALUE_DATETIME) {
+                    icalparameter_free(param);
                     continue;
                 }
                 break;
 
             case ICAL_DURATION_PROPERTY:
                 if (icalparameter_get_value(param) == ICAL_VALUE_DURATION) {
+                    icalparameter_free(param);
                     continue;
                 }
                 break;
@@ -1007,54 +1010,63 @@ void icalproperty_normalize(icalproperty *prop)
 
         case ICAL_CUTYPE_PARAMETER:
             if (icalparameter_get_cutype(param) == ICAL_CUTYPE_INDIVIDUAL) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_ENCODING_PARAMETER:
             if (icalparameter_get_encoding(param) == ICAL_ENCODING_8BIT) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_FBTYPE_PARAMETER:
             if (icalparameter_get_fbtype(param) == ICAL_FBTYPE_BUSY) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_PARTSTAT_PARAMETER:
             if (icalparameter_get_partstat(param) == ICAL_PARTSTAT_NEEDSACTION) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_RELATED_PARAMETER:
             if (icalparameter_get_related(param) == ICAL_RELATED_START) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_RELTYPE_PARAMETER:
             if (icalparameter_get_reltype(param) == ICAL_RELTYPE_PARENT) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_ROLE_PARAMETER:
             if (icalparameter_get_role(param) == ICAL_ROLE_REQPARTICIPANT) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_RSVP_PARAMETER:
             if (icalparameter_get_rsvp(param) == ICAL_RSVP_FALSE) {
+                icalparameter_free(param);
                 continue;
             }
             break;
 
         case ICAL_SCHEDULEAGENT_PARAMETER:
             if (icalparameter_get_scheduleagent(param) == ICAL_SCHEDULEAGENT_SERVER) {
+                icalparameter_free(param);
                 continue;
             }
             break;


### PR DESCRIPTION
This was discovered by valgrind on cyrus-imapd.  These properties were being popped, but then not put anywhere else or freed.