### PR TITLE
GtkDoc.cmake - include CFLAGS in gtkdoc-scangobj command line as well

### DIFF
--- a/cmake/modules/GtkDoc.cmake
+++ b/cmake/modules/GtkDoc.cmake
@@ -96,6 +96,7 @@ macro(add_gtkdoc _module _namespace _deprecated_guards _srcdirsvar _depsvar _ign
 
   # Add it as the last, thus in-tree headers have precedence
   list(APPEND _scangobj_cflags_list -I${INCLUDE_INSTALL_DIR})
+  list(APPEND _scangobj_cflags_list ${CMAKE_C_FLAGS})
 
   if(_scangobj_deps)
     list(REMOVE_DUPLICATES _scangobj_deps)


### PR DESCRIPTION
Sync the follow-up change from evolution-data-server:
https://gitlab.gnome.org/GNOME/evolution-data-server/commit/78dc64008f1312a97eaa56b5c12f93a2bfa3b096