### PR TITLE
Fixes to ICalAttach and use the right free function

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,7 +3,7 @@ Release Highlights
 
 Version 3.0.7 (UNRELEASED):
 ---------------------------
- *
+ * libical-glib: Fix ICalAttach handling of the icalattach native structure
 
 Version 3.0.6 (14 Sep 2019):
 ----------------------------

--- a/src/libical-glib/api/i-cal-attach.xml
+++ b/src/libical-glib/api/i-cal-attach.xml
@@ -13,7 +13,7 @@
   You should have received a copy of the GNU Lesser General Public License
   along with this library. If not, see <http://www.gnu.org/licenses/>.
 -->
-<structure namespace="ICal" name="Attach" native="icalattach" destroy_func="icalattach_unref">
+<structure namespace="ICal" name="Attach" native="icalattach" destroy_func="icalattach_unref" new_full_extra_code="if (owner) { icalattach_ref (native); owner = NULL; }">
     <method name="i_cal_attach_new_from_url" corresponds="icalattach_new_from_url" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="url" comment="The url from which the object is created"/>
         <returns type="ICalAttach *" annotation="transfer full" comment="The newly created #ICalAttach from the @url" />

--- a/src/libical-glib/tools/generator.c
+++ b/src/libical-glib/tools/generator.c
@@ -911,6 +911,12 @@ void generate_code_from_template(FILE *in, FILE *out, Structure *structure, GHas
                     val = g_hash_table_lookup(table, buffer);
                     write_str(out, val);
                     val = NULL;
+
+                    if (g_strcmp0(buffer, "new_full_extraCode") == 0)
+                        write_str(out, "\n    ");
+                } else if (g_strcmp0(buffer, "new_full_extraCode") == 0) {
+                    /* For simplicity, after lookup in the 'table', to
+                       not force declaration of it in every .xml file */
                 } else if (g_strcmp0(buffer, "structure_boilerplate") == 0) {
                     if (structure->native != NULL)
                         generate_header_structure_boilerplate(out, structure, table);
@@ -1265,6 +1271,10 @@ GHashTable *get_hash_table_from_structure(Structure *structure)
         if (structure->isBare) {
             (void)g_hash_table_insert(table, (gchar *)"defaultNative",
                                       g_strdup(structure->defaultNative));
+        }
+        if (structure->new_full_extraCode && *structure->new_full_extraCode) {
+            (void)g_hash_table_insert(table, (gchar *)"new_full_extraCode",
+                                      g_strdup(structure->new_full_extraCode));
         }
     }
 

--- a/src/libical-glib/tools/source-structure-boilerplate-template
+++ b/src/libical-glib/tools/source-structure-boilerplate-template
@@ -26,6 +26,7 @@ ${new_full}
     ${native} *clone;^$$^!${isBare}
     if (native == NULL)
         return NULL;^$
+    ${new_full_extraCode}
     $^${isBare}
     clone = g_new (${native}, 1);
     *clone = native;^$

--- a/src/libical-glib/tools/xml-parser.c
+++ b/src/libical-glib/tools/xml-parser.c
@@ -27,6 +27,7 @@ Structure *structure_new()
     structure->methods = NULL;
     structure->isBare = FALSE;
     structure->isPossibleGlobal = FALSE;
+    structure->new_full_extraCode = NULL;
     structure->enumerations = NULL;
     structure->destroyFunc = NULL;
     structure->cloneFunc = NULL;
@@ -68,6 +69,7 @@ void structure_free(Structure * structure)
     g_free(structure->destroyFunc);
     g_free(structure->cloneFunc);
     g_free(structure->defaultNative);
+    g_free(structure->new_full_extraCode);
     g_hash_table_destroy(structure->dependencies);
     g_free(structure);
 }
@@ -249,6 +251,22 @@ void enumeration_free(Enumeration * enumeration)
     g_free(enumeration->defaultNative);
     g_free(enumeration->comment);
     g_free(enumeration);
+}
+
+static gchar *dup_attribute_value(xmlDocPtr doc, const xmlNode * list, int inLine)
+{
+    xmlChar *xml_value;
+    gchar *glib_value;
+
+    xml_value = xmlNodeListGetString(doc, list, inLine);
+    if (!xml_value)
+        return NULL;
+
+    glib_value = g_strdup((const gchar *) xml_value);
+
+    xmlFree(xml_value);
+
+    return glib_value;
 }
 
 GList *get_list_from_string(const gchar * str)
@@ -530,6 +548,8 @@ gboolean parse_structure(xmlNode * node, Structure * structure)
             structure->destroyFunc = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "clone_func") == 0) {
             structure->cloneFunc = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+        } else if (xmlStrcmp(attr->name, (xmlChar *) "new_full_extra_code") == 0) {
+            structure->new_full_extraCode = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "default_native") == 0) {
             structure->defaultNative = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "is_bare") == 0) {

--- a/src/libical-glib/tools/xml-parser.c
+++ b/src/libical-glib/tools/xml-parser.c
@@ -269,6 +269,23 @@ static gchar *dup_attribute_value(xmlDocPtr doc, const xmlNode * list, int inLin
     return glib_value;
 }
 
+static gchar *dup_node_content(xmlNodePtr node)
+{
+    xmlChar *xml_value;
+    gchar *glib_value;
+
+    xml_value = xmlNodeGetContent(node);
+
+    if (!xml_value)
+        return NULL;
+
+    glib_value = g_strdup((const gchar *) xml_value);
+
+    xmlFree(xml_value);
+
+    return glib_value;
+}
+
 GList *get_list_from_string(const gchar * str)
 {
     gchar **ret;
@@ -291,8 +308,6 @@ gboolean parse_parameters(xmlNode * node, Method * method)
 {
     xmlAttr *attr;
     Parameter *para;
-    gchar *anno;
-    gchar *argus;
 
     if (xmlStrcmp(node->name, (xmlChar *) "parameter") != 0)
         return FALSE;
@@ -303,27 +318,31 @@ gboolean parse_parameters(xmlNode * node, Method * method)
 
         for (attr = node->properties; attr != NULL; attr = attr->next) {
             if (xmlStrcmp(attr->name, (xmlChar *) "type") == 0) {
-                para->type = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->type = dup_attribute_value(attr->doc, attr->children, 1);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "name") == 0) {
-                para->name = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->name = dup_attribute_value(attr->doc, attr->children, 1);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "comment") == 0) {
-                para->comment = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->comment = dup_attribute_value(attr->doc, attr->children, 1);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "annotation") == 0) {
-                anno = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-                para->annotations = get_list_from_string((gchar *) anno);
+                xmlChar *anno;
+
+                anno = xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->annotations = get_list_from_string((const gchar *) anno);
                 xmlFree(anno);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "translator_argus") == 0) {
-                argus = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-                para->translatorArgus = get_list_from_string((gchar *) argus);
+                xmlChar *argus;
+
+                argus = xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->translatorArgus = get_list_from_string((const gchar *) argus);
                 xmlFree(argus);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "translator") == 0) {
-                para->translator = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->translator = dup_attribute_value(attr->doc, attr->children, 1);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "autofill") == 0) {
-                para->autofill = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->autofill = dup_attribute_value(attr->doc, attr->children, 1);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "native_op") == 0) {
-                para->native_op = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->native_op = dup_attribute_value(attr->doc, attr->children, 1);
             } else if (xmlStrcmp(attr->name, (xmlChar *) "owner_op") == 0) {
-                para->owner_op = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+                para->owner_op = dup_attribute_value(attr->doc, attr->children, 1);
             } else {
                 fprintf(stderr,
                         "The tag name of %s in parameter cannot be finished\n",
@@ -339,8 +358,6 @@ gboolean parse_parameters(xmlNode * node, Method * method)
 gboolean parse_return(xmlNode * node, Method * method)
 {
     xmlAttr *attr;
-    gchar *anno;
-    gchar *argus;
 
     if (xmlStrcmp(node->name, (xmlChar *) "returns") != 0) {
         return FALSE;
@@ -350,22 +367,25 @@ gboolean parse_return(xmlNode * node, Method * method)
 
     for (attr = node->properties; attr != NULL; attr = attr->next) {
         if (xmlStrcmp(attr->name, (xmlChar *) "type") == 0) {
-            method->ret->type = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->ret->type = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "comment") == 0) {
-            method->ret->comment = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->ret->comment = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "annotation") == 0) {
-            anno = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-            method->ret->annotations = get_list_from_string((gchar *) anno);
+            xmlChar *anno;
+
+            anno = xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->ret->annotations = get_list_from_string((const gchar *) anno);
             xmlFree(anno);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "translator") == 0) {
-            method->ret->translator = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->ret->translator = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "translator_argus") == 0) {
-            argus = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-            method->ret->translatorArgus = get_list_from_string((gchar *) argus);
+            xmlChar *argus;
+
+            argus = xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->ret->translatorArgus = get_list_from_string((const gchar *) argus);
             xmlFree(argus);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "error_return_value") == 0) {
-            method->ret->errorReturnValue =
-                (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->ret->errorReturnValue = dup_attribute_value(attr->doc, attr->children, 1);
         } else {
             fprintf(stderr,
                     "The tag name of '%s' in 'returns' cannot be finished\n",
@@ -382,7 +402,7 @@ gboolean parse_comment(xmlNode * node, Method * method)
     }
 
     g_free(method->comment);
-    method->comment = (gchar *) xmlNodeGetContent(node);
+    method->comment = dup_node_content(node);
     return TRUE;
 }
 
@@ -393,7 +413,7 @@ gboolean parse_custom(xmlNode * node, Method * method)
     }
 
     g_free(method->custom);
-    method->custom = (gchar *) xmlNodeGetContent(node);
+    method->custom = dup_node_content (node);
     return TRUE;
 }
 
@@ -401,7 +421,6 @@ gboolean parse_method(xmlNode * node, Method * method)
 {
     xmlNode *child;
     xmlAttr *attr;
-    gchar *anno;
 
     if (xmlStrcmp(node->name, (xmlChar *) "method") != 0) {
         return FALSE;
@@ -409,16 +428,18 @@ gboolean parse_method(xmlNode * node, Method * method)
 
     for (attr = node->properties; attr != NULL; attr = attr->next) {
         if (xmlStrcmp(attr->name, (xmlChar *) "name") == 0) {
-            method->name = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->name = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "corresponds") == 0) {
-            method->corresponds = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->corresponds = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "kind") == 0) {
-            method->kind = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->kind = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "since") == 0) {
-            method->since = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->since = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "annotation") == 0) {
-            anno = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-            method->annotations = get_list_from_string(anno);
+            xmlChar *anno;
+
+            anno = xmlNodeListGetString(attr->doc, attr->children, 1);
+            method->annotations = get_list_from_string((const gchar *) anno);
             xmlFree(anno);
         } else {
             fprintf(stderr, "The attribute '%s' in method '%s' cannot be parsed",
@@ -452,9 +473,9 @@ gboolean parse_declaration(xmlNode * node, Declaration * declaration)
 
     for (attr = node->properties; attr != NULL; attr = attr->next) {
         if (xmlStrcmp(attr->name, (xmlChar *) "position") == 0) {
-            declaration->position = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            declaration->position = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "content") == 0) {
-            declaration->content = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            declaration->content = dup_attribute_value(attr->doc, attr->children, 1);
         } else {
             fprintf(stderr,
                     "The node named '%s' in declaration cannot be parsed\n",
@@ -463,7 +484,7 @@ gboolean parse_declaration(xmlNode * node, Declaration * declaration)
     }
 
     if (!declaration->content) {
-        declaration->content = (gchar *) xmlNodeGetContent(node);
+        declaration->content = dup_node_content(node);
     }
 
     return TRUE;
@@ -482,14 +503,13 @@ gboolean parse_enumeration(xmlNode * node, Enumeration * enumeration)
 
     for (attr = node->properties; attr != NULL; attr = attr->next) {
         if (xmlStrcmp(attr->name, (xmlChar *) "name") == 0) {
-            enumeration->name = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            enumeration->name = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "native_name") == 0) {
-            enumeration->nativeName = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            enumeration->nativeName = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "default_native") == 0) {
-            enumeration->defaultNative =
-                (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            enumeration->defaultNative = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "comment") == 0) {
-            enumeration->comment = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            enumeration->comment = dup_attribute_value(attr->doc, attr->children, 1);
         } else {
             fprintf(stderr,
                     "The node named '%s' in enum '%s' cannot be parsed\n",
@@ -504,8 +524,7 @@ gboolean parse_enumeration(xmlNode * node, Enumeration * enumeration)
                     (char *)child->name, enumeration->name);
             continue;
         }
-        elementName =
-            (gchar *) xmlNodeListGetString(child->properties->doc, child->properties->children, 1);
+        elementName = dup_attribute_value(child->properties->doc, child->properties->children, 1);
         enumeration->elements = g_list_append(enumeration->elements, elementName);
         elementName = NULL;
     }
@@ -518,9 +537,6 @@ gboolean parse_structure(xmlNode * node, Structure * structure)
     xmlNode *child;
     Method *method;
     Enumeration *enumeration;
-    gchar *strIsPossibleGlobal;
-    gchar *strIsBare;
-    gchar *includes;
     Declaration *declaration;
 
     if (xmlStrcmp(node->name, (xmlChar *) "structure") != 0) {
@@ -529,35 +545,41 @@ gboolean parse_structure(xmlNode * node, Structure * structure)
 
     for (attr = node->properties; attr != NULL; attr = attr->next) {
         if (xmlStrcmp(attr->name, (xmlChar *) "namespace") == 0) {
-            structure->nameSpace = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->nameSpace = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "name") == 0) {
-            structure->name = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->name = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "native") == 0) {
-            structure->native = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->native = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "includes") == 0) {
-            includes = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-            structure->includes = get_list_from_string((gchar *) includes);
+            xmlChar *includes;
+
+            includes = xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->includes = get_list_from_string((const gchar *) includes);
             xmlFree(includes);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "is_possible_global") == 0) {
-            strIsPossibleGlobal = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-            if (g_strcmp0(strIsPossibleGlobal, "true") == 0) {
+            xmlChar *strIsPossibleGlobal;
+
+            strIsPossibleGlobal = xmlNodeListGetString(attr->doc, attr->children, 1);
+            if (g_strcmp0((const gchar *) strIsPossibleGlobal, "true") == 0) {
                 structure->isPossibleGlobal = TRUE;
             }
-            g_free(strIsPossibleGlobal);
+            xmlFree(strIsPossibleGlobal);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "destroy_func") == 0) {
-            structure->destroyFunc = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->destroyFunc = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "clone_func") == 0) {
-            structure->cloneFunc = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->cloneFunc = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "new_full_extra_code") == 0) {
             structure->new_full_extraCode = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "default_native") == 0) {
-            structure->defaultNative = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
+            structure->defaultNative = dup_attribute_value(attr->doc, attr->children, 1);
         } else if (xmlStrcmp(attr->name, (xmlChar *) "is_bare") == 0) {
-            strIsBare = (gchar *) xmlNodeListGetString(attr->doc, attr->children, 1);
-            if (g_strcmp0(strIsBare, "true") == 0) {
+            xmlChar *strIsBare;
+
+            strIsBare = xmlNodeListGetString(attr->doc, attr->children, 1);
+            if (g_strcmp0((const gchar *) strIsBare, "true") == 0) {
                 structure->isBare = TRUE;
             }
-            g_free(strIsBare);
+            xmlFree(strIsBare);
         } else {
             fprintf(stderr,
                     "The attribute of %s in structure '%s' cannot be parsed\n",

--- a/src/libical-glib/tools/xml-parser.h
+++ b/src/libical-glib/tools/xml-parser.h
@@ -61,6 +61,7 @@ typedef struct Structure {
     GList *methods;
     gboolean isBare;
     gboolean isPossibleGlobal;
+    gchar *new_full_extraCode;
     GList *enumerations;
     GHashTable *dependencies;
     gchar *destroyFunc;


### PR DESCRIPTION
(From Milan Crha)
The first commit is a fix for ICalAttach memory handling. The ical.c is a reproducer for it. The first line contains a command how to build & run it. Either it crashes, or rather run it under valgrind as:
```bash
    $ G_SLICE=always-malloc valgrind --show-leak-kinds=definite \
      --num-callers=30 --leak-check=full --aspace-minaddr=0x100000000 \
      ./ical
```

which produces this valgrind claim with unpatched libical:

```valgrind
main: 1st: has 2 attachments
==10531== Memcheck, a memory error detector
==10531== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10531== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==10531== Command: ./ical
==10531== 
==10531== Invalid read of size 4
==10531==    at 0x100AD6F30: icalattach_ref (icalattach.c:85)
==10531==    by 0x100AD6516: icalvalue_set_attach (icalderivedvalue.c:1285)
==10531==    by 0x100AD64C6: icalvalue_new_attach (icalderivedvalue.c:1271)
==10531==    by 0x100AC23D8: icalproperty_set_attach (icalderivedproperty.c:1935)
==10531==    by 0x100AC2390: icalproperty_new_attach (icalderivedproperty.c:1927)
==10531==    by 0x100879D46: i_cal_property_new_attach (i-cal-derived-property.c:282)
==10531==    by 0x40136F: set_attachments (ical.c:56)
==10531==    by 0x401401: main (ical.c:75)
==10531==  Address 0x1031be700 is 0 bytes inside a block of size 40 free'd
==10531==    at 0x100839A0C: free (vg_replace_malloc.c:540)
==10531==    by 0x100AD6FDD: icalattach_unref (icalattach.c:110)
==10531==    by 0x100AF431A: icalvalue_free (icalvalue.c:781)
==10531==    by 0x100AE12F3: icalproperty_free (icalproperty.c:192)
==10531==    by 0x10089D0EC: i_cal_object_finalize (i-cal-object.c:197)
==10531==    by 0x100921F60: g_object_unref (gobject.c:3524)
==10531==    by 0x1009E11B3: g_slist_foreach (gslist.c:864)
==10531==    by 0x1009E0982: g_slist_free_full (gslist.c:177)
==10531==    by 0x40132F: remove_all_attachments (ical.c:42)
==10531==    by 0x40134E: set_attachments (ical.c:51)
==10531==    by 0x401401: main (ical.c:75)
==10531==  Block was alloc'd at
==10531==    at 0x10083880B: malloc (vg_replace_malloc.c:309)
==10531==    by 0x100AD6DC3: icalattach_new_from_url (icalattach.c:36)
==10531==    by 0x100AF358A: icalvalue_new_from_string_with_error (icalvalue.c:448)
==10531==    by 0x100AF4271: icalvalue_new_from_string (icalvalue.c:762)
==10531==    by 0x100AE088A: icalparser_add_line (icalparser.c:1157)
==10531==    by 0x100ADF980: icalparser_parse (icalparser.c:646)
==10531==    by 0x100AE0E6A: icalparser_parse_string (icalparser.c:1356)
==10531==    by 0x100AD7341: icalcomponent_new_from_string (icalcomponent.c:143)
==10531==    by 0x10086F1FC: i_cal_component_new_from_string (i-cal-component.c:164)
==10531==    by 0x4013B8: main (ical.c:65)
==10531== 
main: 2nd: has 2 attachments
==10531== Invalid read of size 4
==10531==    at 0x100AD6F76: icalattach_unref (icalattach.c:93)
==10531==    by 0x100AF431A: icalvalue_free (icalvalue.c:781)
==10531==    by 0x100AE12F3: icalproperty_free (icalproperty.c:192)
==10531==    by 0x100AD74F5: icalcomponent_free (icalcomponent.c:206)
==10531==    by 0x10089D0EC: i_cal_object_finalize (i-cal-object.c:197)
==10531==    by 0x100921F60: g_object_unref (gobject.c:3524)
==10531==    by 0x401461: main (ical.c:82)
==10531==  Address 0x1031be2d0 is 0 bytes inside a block of size 40 free'd
==10531==    at 0x100839A0C: free (vg_replace_malloc.c:540)
==10531==    by 0x100AD6FDD: icalattach_unref (icalattach.c:110)
==10531==    by 0x100AF431A: icalvalue_free (icalvalue.c:781)
==10531==    by 0x100AE12F3: icalproperty_free (icalproperty.c:192)
==10531==    by 0x10089D0EC: i_cal_object_finalize (i-cal-object.c:197)
==10531==    by 0x100921F60: g_object_unref (gobject.c:3524)
==10531==    by 0x1009E11B3: g_slist_foreach (gslist.c:864)
==10531==    by 0x1009E0982: g_slist_free_full (gslist.c:177)
==10531==    by 0x40132F: remove_all_attachments (ical.c:42)
==10531==    by 0x40134E: set_attachments (ical.c:51)
==10531==    by 0x401401: main (ical.c:75)
==10531==  Block was alloc'd at
==10531==    at 0x10083880B: malloc (vg_replace_malloc.c:309)
==10531==    by 0x100AD6DC3: icalattach_new_from_url (icalattach.c:36)
==10531==    by 0x100AF358A: icalvalue_new_from_string_with_error (icalvalue.c:448)
==10531==    by 0x100AF4271: icalvalue_new_from_string (icalvalue.c:762)
==10531==    by 0x100AE088A: icalparser_add_line (icalparser.c:1157)
==10531==    by 0x100ADF980: icalparser_parse (icalparser.c:646)
==10531==    by 0x100AE0E6A: icalparser_parse_string (icalparser.c:1356)
==10531==    by 0x100AD7341: icalcomponent_new_from_string (icalcomponent.c:143)
==10531==    by 0x10086F1FC: i_cal_component_new_from_string (i-cal-component.c:164)
==10531==    by 0x4013B8: main (ical.c:65)
```
After the patch is applied it says:
```valgrind
==12985== Memcheck, a memory error detector
==12985== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12985== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==12985== Command: ./ical
==12985== 
main: 1st: has 2 attachments
main: 2nd: has 2 attachments
==12985== 
==12985== HEAP SUMMARY:
==12985==     in use at exit: 41,532 bytes in 288 blocks
==12985==   total heap usage: 522 allocs, 234 frees, 131,541 bytes allocated
==12985== 
==12985== LEAK SUMMARY:
==12985==    definitely lost: 0 bytes in 0 blocks
==12985==    indirectly lost: 0 bytes in 0 blocks
==12985==      possibly lost: 1,440 bytes in 20 blocks
==12985==    still reachable: 39,492 bytes in 263 blocks
==12985==                       of which reachable via heuristic:
==12985==                         newarray           : 1,536 bytes in 16 blocks
==12985==         suppressed: 0 bytes in 0 blocks
==12985== Reachable blocks (those to which a pointer was found) are not shown.
==12985== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

The important part of this valgrind output is also that there is no definitely lost memory.


The second commit fixes freeing of libxml strings. I noticed that when working on the first commit and it uses a function added there.