### PR TITLE
Include <limits.h> in files that use INT_MAX or CHAR_BIT

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -30,6 +30,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <limits.h>
 
 struct icalcomponent_impl
 {

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -36,6 +36,7 @@
 #include <ctype.h>
 #include <stddef.h>     /* for ptrdiff_t */
 #include <stdlib.h>
+#include <limits.h>
 
 #if defined(HAVE_PTHREAD)
 #include <pthread.h>

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -26,6 +26,7 @@
 #include "icaltimezone.h"
 
 #include <stdlib.h>
+#include <limits.h>
 
 #if defined(sun) && defined(__SVR4)
 #include <sys/types.h>


### PR DESCRIPTION
Portability fix for various systems that don't include limits.h via stdlib or another header, e.g. illumos.