### PR TITLE
Fix inconsistencies and typos in icaltime docs

### DIFF
--- a/src/Net-ICal-Libical/netical.i
+++ b/src/Net-ICal-Libical/netical.i
@@ -221,7 +221,7 @@ struct icaltimetype icaltime_as_zone(struct icaltimetype tt,
 /* Return a null time, which indicates no time has been set. This time represent the beginning of the epoch */
 struct icaltimetype icaltime_null_time(void);
 
-/* Return true of the time is null. */
+/* Return true if the time is null. */
 int icaltime_is_null_time(struct icaltimetype t);
 
 /* Returns false if the time is clearly invalid, but is not null. This
@@ -255,10 +255,10 @@ char* icaltime_as_ctime(struct icaltimetype);
 /* Return the week number for the week the given time is within */
 short icaltime_week_number(struct icaltimetype t);
 
-/* Return -1, 0, or 1 to indicate that a<b, a==b or a>b */
+/* Return -1, 0, or 1 to indicate that a is less than b, a equals b, or a is greater than b. */
 int icaltime_compare(struct icaltimetype a,struct icaltimetype b);
 
-/* like icaltime_compare, but only use the date parts. */
+/* Like icaltime_compare, but only use the date parts. */
 int icaltime_compare_date_only(struct icaltimetype a, struct icaltimetype b);
 
 /* Return the number of days in the given month */

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -48,7 +48,7 @@
     </method>
     <method name="i_cal_time_new_today" corresponds="icaltime_today" kind="others" since="1.0">
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
-        <comment xml:space="preserve">Create a #ICalTime representing today</comment>
+        <comment xml:space="preserve">Create a #ICalTime representing today, with #ICalTime.is_date set.</comment>
     </method>
     <method name="i_cal_time_new_from_timet_with_zone" corresponds="icaltime_from_timet_with_zone" kind="others" since="1.0">
         <parameter type="const time_t" name="v" comment="The seconds past since epoch time"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -158,7 +158,7 @@
         <parameter type="const ICalTime *" name="b" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
 	<parameter type="ICalTimezone *" name="zone" annotation="nullable" comment="The target timezone"/>
         <returns type="gint" comment="-1, 0, or 1 to indicate that a less than b, a==b or a larger than b." />
-        <comment xml:space="preserve">Like icaltime_compare, but only use the date parts; accepts timezone.</comment>
+        <comment xml:space="preserve">Like i_cal_time_compare(), but only use the date parts; accepts timezone.</comment>
     </method>
     <method name="i_cal_time_adjust" corresponds="icaltime_adjust" since="1.0">
         <parameter type="ICalTime *" name="tt" native_op="POINTER" comment="The #ICalTime to be set"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -166,7 +166,7 @@
         <parameter type="const gint" name="hours" comment="difference of hours adjusted"/>
         <parameter type="const gint" name="minutes" comment="difference of minutes adjusted"/>
         <parameter type="const gint" name="seconds" comment="difference of seconds adjusted"/>
-        <comment xml:space="preserve">Add or subtract a number of days, hours, minutes and seconds from an icaltimetype.</comment>
+        <comment xml:space="preserve">Add or subtract a number of days, hours, minutes and seconds from the @timetype.</comment>
     </method>
     <method name="i_cal_time_normalize" corresponds="icaltime_normalize" since="1.0">
         <parameter type="const ICalTime *" name="t" annotation="in, transfer none" comment="The #ICalTime to be normalized"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -60,6 +60,7 @@
     <method name="i_cal_time_new_from_string" corresponds="icaltime_from_string" kind="others" since="1.0">
         <parameter type="const gchar *" name="str" comment="The ISO format string"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
+        <comment xml:space="preserve">Create a time from an ISO format string</comment>
     </method>
     <method name="i_cal_time_new_from_day_of_year" corresponds="icaltime_from_day_of_year" kind="constructor" since="1.0">
         <parameter type="const gint" name="day" comment="The day of a year"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -256,105 +256,105 @@
     <method name="i_cal_time_get_year" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gint" comment="The year."/>
-        <comment xml:space="preserve">Get the year of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the year of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->year;</custom>
     </method>
     <method name="i_cal_time_set_year" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gint" name="year" comment="The year."/>
-        <comment>Set the year of #ICalTime.</comment>
+        <comment>Set the year of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->year = year;</custom>
     </method>
     <method name="i_cal_time_get_month" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gint" comment="The month." />
-        <comment xml:space="preserve">Get the month of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the month of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->month;</custom>
     </method>
     <method name="i_cal_time_set_month" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gint" name="month" comment="The month."/>
-        <comment>Set the month of #ICalTime.</comment>
+        <comment>Set the month of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->month = month;</custom>
     </method>
     <method name="i_cal_time_get_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gint" comment="The day." />
-        <comment xml:space="preserve">Get the day of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the day of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->day;</custom>
     </method>
     <method name="i_cal_time_set_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gint" name="day" comment="The day."/>
-        <comment>Set the day of #ICalTime.</comment>
+        <comment>Set the day of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->day = day;</custom>
     </method>
     <method name="i_cal_time_get_hour" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gint" comment="The hour." />
-        <comment xml:space="preserve">Get the hour of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the hour of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->hour;</custom>
     </method>
     <method name="i_cal_time_set_hour" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gint" name="hour" comment="The hour."/>
-        <comment>Set the hour of #ICalTime.</comment>
+        <comment>Set the hour of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->hour = hour;</custom>
     </method>
     <method name="i_cal_time_get_minute" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gint" comment="The minute." />
-        <comment xml:space="preserve">Get the minute of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the minute of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->minute;</custom>
     </method>
     <method name="i_cal_time_set_minute" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gint" name="minute" comment="The minute."/>
-        <comment>Set the minute of #ICalTime.</comment>
+        <comment>Set the minute of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->minute = minute;</custom>
     </method>
     <method name="i_cal_time_get_second" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gint" comment="The second." />
-        <comment xml:space="preserve">Get the second of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the second of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->second;</custom>
     </method>
     <method name="i_cal_time_set_second" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gint" name="second" comment="The second."/>
-        <comment>Set the second of #ICalTime.</comment>
+        <comment>Set the second of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->second = second;</custom>
     </method>
     <method name="i_cal_time_set_is_date" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gboolean" name="is_date" comment="The is_date."/>
-        <comment>Set the is_date of #ICalTime.</comment>
+        <comment>Set the is_date of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->is_date = is_date ? 1 : 0;</custom>
     </method>
     <method name="i_cal_time_is_daylight" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>
         <returns type="gboolean" comment="The is_daylight." />
-        <comment xml:space="preserve">Get the is_daylight of #ICalTime.</comment>
+        <comment xml:space="preserve">Get the is_daylight of @timetype.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->is_daylight;</custom>
     </method>
     <method name="i_cal_time_set_is_daylight" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set."/>
         <parameter type="gboolean" name="is_daylight" comment="The is_daylight."/>
-        <comment>Set the is_daylight of #ICalTime.</comment>
+        <comment>Set the is_daylight of @timetype.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->is_daylight = is_daylight ? 1 : 0;</custom>
     </method>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -34,11 +34,12 @@
     </method>
     <method name="i_cal_time_new_null_time" corresponds="icaltime_null_time" kind="constructor" since="1.0">
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
-        <comment xml:space="preserve">Create a default time which is an epoch time</comment>
+        <comment xml:space="preserve">Create a null time, which indicates no time has been set.
+            This time represents the beginning of the epoch.</comment>
     </method>
     <method name="i_cal_time_new_null_date" corresponds="icaltime_null_date" kind="constructor" since="1.0">
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
-        <comment xml:space="preserve">Create a null date, which indicates no time has been set</comment>
+        <comment xml:space="preserve">Create a null date, which indicates no time has been set.</comment>
     </method>
     <method name="i_cal_time_new_current_with_zone" corresponds="icaltime_current_time_with_zone" kind="others" since="1.0">
         <parameter type="ICalTimezone *" name="zone" annotation="nullable" comment="The timezone used to create a #ICalTime according to the current time"/>
@@ -76,7 +77,7 @@
         <parameter type="const ICalTime *" name="tt" comment="The #ICalTime to be converted"/>
         <parameter type="const ICalTimezone *" name="zone" annotation="nullable" comment="The timezone"/>
         <returns type="time_t" comment="the time as seconds past the UNIX epoch" />
-        <comment xml:space="preserve">Return the time as seconds past the UNIX epoch, using timezones.</comment>
+        <comment xml:space="preserve">Return the time as seconds past the UNIX epoch, using the given timezone.</comment>
     </method>
     <method name="i_cal_time_as_ical_string" corresponds="icaltime_as_ical_string_r" since="1.0">
         <parameter type="const ICalTime *" name="tt" comment="The #ICalTime to be converted"/>
@@ -122,12 +123,13 @@
     <method name="i_cal_time_is_null_time" corresponds="icaltime_is_null_time" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be checked"/>
         <returns type="gboolean" comment="Whether @tt is null_time. 1 if yes, 0 if not." />
-        <comment xml:space="preserve">Return true of the time is null.</comment>
+        <comment xml:space="preserve">Return true if the time is null.</comment>
     </method>
     <method name="i_cal_time_is_valid_time" corresponds="icaltime_is_valid_time" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be checked"/>
         <returns type="gboolean" comment="Whether @tt is null_time. 1 if yes, 0 if not." />
-        <comment xml:space="preserve">Return true of the time is null.</comment>
+        <comment xml:space="preserve">Returns false if the time is clearly invalid, but is not null. 
+            This is usually the result of creating a new time type buy not clearing it, or setting one of the flags to an illegal value.</comment>
     </method>
     <method name="i_cal_time_is_date" corresponds="icaltime_is_date" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be checked"/>
@@ -143,20 +145,20 @@
         <parameter type="const ICalTime *" name="a" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <parameter type="const ICalTime *" name="b" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <returns type="gint" comment="-1, 0, or 1 to indicate that a less than b, a==b or a larger than b." />
-        <comment xml:space="preserve">Return -1, 0, or 1 to indicate that a less than b, a==b or a larger than b.</comment>
+        <comment xml:space="preserve">Return -1, 0, or 1 to indicate that a is less than b, a equals b, or a is greater than b.</comment>
     </method>
     <method name="i_cal_time_compare_date_only" corresponds="icaltime_compare_date_only" since="1.0">
         <parameter type="const ICalTime *" name="a" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <parameter type="const ICalTime *" name="b" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <returns type="gint" comment="-1, 0, or 1 to indicate that a less than b, a==b or a larger than b." />
-        <comment xml:space="preserve">like i_cal_time_compare, but only use the date parts.</comment>
+        <comment xml:space="preserve">Like i_cal_time_compare, but only use the date parts.</comment>
     </method>
     <method name="i_cal_time_compare_date_only_tz" corresponds="icaltime_compare_date_only_tz" since="1.0">
         <parameter type="const ICalTime *" name="a" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <parameter type="const ICalTime *" name="b" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
 	<parameter type="ICalTimezone *" name="zone" annotation="nullable" comment="The target timezone"/>
         <returns type="gint" comment="-1, 0, or 1 to indicate that a less than b, a==b or a larger than b." />
-        <comment xml:space="preserve">like i_cal_time_compare_tz, but only use the date parts.</comment>
+        <comment xml:space="preserve">Like icaltime_compare, but only use the date parts; accepts timezone.</comment>
     </method>
     <method name="i_cal_time_adjust" corresponds="icaltime_adjust" since="1.0">
         <parameter type="ICalTime *" name="tt" native_op="POINTER" comment="The #ICalTime to be set"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -166,7 +166,7 @@
         <parameter type="const gint" name="hours" comment="difference of hours adjusted"/>
         <parameter type="const gint" name="minutes" comment="difference of minutes adjusted"/>
         <parameter type="const gint" name="seconds" comment="difference of seconds adjusted"/>
-        <comment xml:space="preserve">Add or subtract a number of days, hours, minutes and seconds from the @timetype.</comment>
+        <comment xml:space="preserve">Add or subtract a number of days, hours, minutes and seconds from @tt.</comment>
     </method>
     <method name="i_cal_time_normalize" corresponds="icaltime_normalize" since="1.0">
         <parameter type="const ICalTime *" name="t" annotation="in, transfer none" comment="The #ICalTime to be normalized"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -60,7 +60,6 @@
     <method name="i_cal_time_new_from_string" corresponds="icaltime_from_string" kind="others" since="1.0">
         <parameter type="const gchar *" name="str" comment="The ISO format string"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
-        <comment xml:space="preserve">create a time from an ISO format string</comment>
     </method>
     <method name="i_cal_time_new_from_day_of_year" corresponds="icaltime_from_day_of_year" kind="constructor" since="1.0">
         <parameter type="const gint" name="day" comment="The day of a year"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -44,7 +44,7 @@
     <method name="i_cal_time_new_current_with_zone" corresponds="icaltime_current_time_with_zone" kind="others" since="1.0">
         <parameter type="ICalTimezone *" name="zone" annotation="nullable" comment="The timezone used to create a #ICalTime according to the current time"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
-        <comment xml:space="preserve">Create a #ICalTime according to the timezone and current time</comment>
+        <comment xml:space="preserve">Create a #ICalTime according to the timezone and current time.</comment>
     </method>
     <method name="i_cal_time_new_today" corresponds="icaltime_today" kind="others" since="1.0">
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
@@ -60,7 +60,7 @@
     <method name="i_cal_time_new_from_string" corresponds="icaltime_from_string" kind="others" since="1.0">
         <parameter type="const gchar *" name="str" comment="The ISO format string"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime" />
-        <comment xml:space="preserve">Create a time from an ISO format string</comment>
+        <comment xml:space="preserve">Create a time from an ISO format string.</comment>
     </method>
     <method name="i_cal_time_new_from_day_of_year" corresponds="icaltime_from_day_of_year" kind="constructor" since="1.0">
         <parameter type="const gint" name="day" comment="The day of a year"/>
@@ -71,7 +71,7 @@
     <method name="i_cal_time_as_timet" corresponds="icaltime_as_timet" since="1.0">
         <parameter type="const ICalTime *" name="tt" comment="The #ICalTime to be converted"/>
         <returns type="time_t" comment="the time as seconds past the UNIX epoch" />
-        <comment xml:space="preserve">Return the time as seconds past the UNIX epoch</comment>
+        <comment xml:space="preserve">Return the time as seconds past the UNIX epoch.</comment>
     </method>
     <method name="i_cal_time_as_timet_with_zone" corresponds="icaltime_as_timet_with_zone" since="1.0">
         <parameter type="const ICalTime *" name="tt" comment="The #ICalTime to be converted"/>
@@ -87,27 +87,27 @@
     <method name="i_cal_time_get_timezone" corresponds="(void *)icaltime_get_timezone" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
         <returns type="ICalTimezone *" annotation="transfer none" translator_argus="(GObject *)tt, TRUE" comment="The timezone information" />
-        <comment xml:space="preserve">Return the timezone</comment>
+        <comment xml:space="preserve">Return the timezone.</comment>
     </method>
     <method name="i_cal_time_set_timezone" corresponds="icaltime_set_timezone" kind="set" since="1.0">
         <parameter type="ICalTime *" name="tt" native_op="POINTER" comment="The #ICalTime"/>
         <parameter type="const ICalTimezone *" name="zone" annotation="nullable" comment="The timezone"/>
-        <comment xml:space="preserve">Set the timezone of @tt</comment>
+        <comment xml:space="preserve">Set the timezone of @tt.</comment>
     </method>
     <method name="i_cal_time_get_tzid" corresponds="icaltime_get_tzid" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
         <returns type="const gchar *" annotation="allow-none, transfer none" comment="The tzid of #ICalTime, or NULL if floating type" />
-        <comment xml:space="preserve">Return the tzid, or NULL for a floating time</comment>
+        <comment xml:space="preserve">Return the tzid, or NULL for a floating time.</comment>
     </method>
     <method name="i_cal_time_day_of_year" corresponds="icaltime_day_of_year" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="the day of the year of the given time" />
-        <comment xml:space="preserve">Return the day of the year of the given time</comment>
+        <comment xml:space="preserve">Return the day of the year of the given time.</comment>
     </method>
     <method name="i_cal_time_day_of_week" corresponds="icaltime_day_of_week" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="the day of the week of the given time. Sunday is 1." />
-        <comment xml:space="preserve">Return the day of the week of the given time. Sunday is 1</comment>
+        <comment xml:space="preserve">Return the day of the week of the given time. Sunday is 1.</comment>
     </method>
     <method name="i_cal_time_start_doy_week" corresponds="icaltime_start_doy_week" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -166,7 +166,7 @@
         <parameter type="const gint" name="hours" comment="difference of hours adjusted"/>
         <parameter type="const gint" name="minutes" comment="difference of minutes adjusted"/>
         <parameter type="const gint" name="seconds" comment="difference of seconds adjusted"/>
-        <comment xml:space="preserve">like i_cal_time_compare_tz, but only use the date parts.</comment>
+        <comment xml:space="preserve">Add or subtract a number of days, hours, minutes and seconds from an icaltimetype.</comment>
     </method>
     <method name="i_cal_time_normalize" corresponds="icaltime_normalize" since="1.0">
         <parameter type="const ICalTime *" name="t" annotation="in, transfer none" comment="The #ICalTime to be normalized"/>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -92,7 +92,7 @@
     <method name="i_cal_time_set_timezone" corresponds="icaltime_set_timezone" kind="set" since="1.0">
         <parameter type="ICalTime *" name="tt" native_op="POINTER" comment="The #ICalTime"/>
         <parameter type="const ICalTimezone *" name="zone" annotation="nullable" comment="The timezone"/>
-        <comment xml:space="preserve">Set the timezone of the @tt</comment>
+        <comment xml:space="preserve">Set the timezone of @tt</comment>
     </method>
     <method name="i_cal_time_get_tzid" corresponds="icaltime_get_tzid" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
@@ -169,13 +169,13 @@
         <comment xml:space="preserve">Add or subtract a number of days, hours, minutes and seconds from @tt.</comment>
     </method>
     <method name="i_cal_time_normalize" corresponds="icaltime_normalize" since="1.0">
-        <parameter type="const ICalTime *" name="t" annotation="in, transfer none" comment="The #ICalTime to be normalized"/>
+        <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be normalized"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The #ICalTime normalized"/>
-        <comment xml:space="preserve">Normalize the icaltime, so that all fields are within the normal range.</comment>
+        <comment xml:space="preserve">Normalize @tt, so that all fields are within the normal range.</comment>
     </method>
     <method name="i_cal_time_normalize_inplace" corresponds="CUSTOM" since="3.0.5">
         <parameter type="ICalTime *" name="tt" comment="The #ICalTime to be normalized"/>
-        <comment xml:space="preserve">Normalize the @tt, so that all fields are within the normal range.</comment>
+        <comment xml:space="preserve">Normalize @tt, so that all fields are within the normal range.</comment>
 	<custom xml:space="preserve">    icaltimetype *itt;
 
     g_return_if_fail(I_CAL_IS_TIME (tt));
@@ -363,7 +363,7 @@
         <parameter type="gint *" name="year" annotation="out caller-allocates, optional" comment="Out parameter for the 'year' part of the date."/>
         <parameter type="gint *" name="month" annotation="out caller-allocates, optional" comment="Out parameter for the 'month' part of the date."/>
         <parameter type="gint *" name="day" annotation="out caller-allocates, optional" comment="Out parameter for the 'day' part of the date."/>
-        <comment xml:space="preserve">Get the year/month/date parts of the @timetype in one call.</comment>
+        <comment xml:space="preserve">Get the year/month/date parts of @timetype in one call.</comment>
         <custom>    icaltimetype *itt;
     g_return_if_fail(timetype != NULL);
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);
@@ -380,7 +380,7 @@
         <parameter type="gint" name="year" comment="The 'year' part of the date." />
         <parameter type="gint" name="month" comment="The 'month' part of the date." />
         <parameter type="gint" name="day" comment="The 'day' part of the date." />
-        <comment xml:space="preserve">Set the year/month/date parts of the @timetype in one call. This doesn't verify validity of the given date.</comment>
+        <comment xml:space="preserve">Set the year/month/date parts of @timetype in one call. This doesn't verify validity of the given date.</comment>
         <custom>    icaltimetype *itt;
     g_return_if_fail(timetype != NULL);
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);
@@ -394,7 +394,7 @@
         <parameter type="gint *" name="hour" annotation="out caller-allocates, optional" comment="Out parameter for the 'hour' part of the time."/>
         <parameter type="gint *" name="minute" annotation="out caller-allocates, optional" comment="Out parameter for the 'minute' part of the time."/>
         <parameter type="gint *" name="second" annotation="out caller-allocates, optional" comment="Out parameter for the 'second' part of the time."/>
-        <comment xml:space="preserve">Get the hour/minute/second parts of the @timetype in one call.</comment>
+        <comment xml:space="preserve">Get the hour/minute/second parts of @timetype in one call.</comment>
         <custom>    icaltimetype *itt;
     g_return_if_fail(timetype != NULL);
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);
@@ -411,7 +411,7 @@
         <parameter type="gint" name="hour" comment="The 'hour' part of the time." />
         <parameter type="gint" name="minute" comment="The 'minute' part of the time." />
         <parameter type="gint" name="second" comment="The 'second' part of the time." />
-        <comment xml:space="preserve">Set the hour/minute/second parts of the @timetype in one call. This doesn't verify validity of the given time.</comment>
+        <comment xml:space="preserve">Set the hour/minute/second parts of @timetype in one call. This doesn't verify validity of the given time.</comment>
         <custom>    icaltimetype *itt;
     g_return_if_fail(timetype != NULL);
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -145,13 +145,13 @@
         <parameter type="const ICalTime *" name="a" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <parameter type="const ICalTime *" name="b" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <returns type="gint" comment="-1, 0, or 1 to indicate that a less than b, a==b or a larger than b." />
-        <comment xml:space="preserve">Return -1, 0, or 1 to indicate that a is less than b, a equals b, or a is greater than b.</comment>
+        <comment xml:space="preserve">Return -1, 0, or 1 to indicate that @a is less than @b, @a equals @b, or @a is greater than @b.</comment>
     </method>
     <method name="i_cal_time_compare_date_only" corresponds="icaltime_compare_date_only" since="1.0">
         <parameter type="const ICalTime *" name="a" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <parameter type="const ICalTime *" name="b" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
         <returns type="gint" comment="-1, 0, or 1 to indicate that a less than b, a==b or a larger than b." />
-        <comment xml:space="preserve">Like i_cal_time_compare, but only use the date parts.</comment>
+        <comment xml:space="preserve">Like i_cal_time_compare(), but only use the date parts.</comment>
     </method>
     <method name="i_cal_time_compare_date_only_tz" corresponds="icaltime_compare_date_only_tz" since="1.0">
         <parameter type="const ICalTime *" name="a" annotation="in, transfer none" comment="The #ICalTime to be compared"/>
@@ -189,7 +189,7 @@
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be converted"/>
         <parameter type="ICalTimezone *" name="zone" annotation="nullable" comment="The target timezone"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The converted #ICalTime" />
-        <comment xml:space="preserve">Convert @tt to @zone and return new %ICalTime object.</comment>
+        <comment xml:space="preserve">Convert @tt to @zone and return new #ICalTime object.</comment>
     </method>
     <method name="i_cal_time_convert_to_zone_inplace" corresponds="CUSTOM" since="3.0.5">
         <parameter type="ICalTime *" name="tt" comment="The #ICalTime to be converted"/>
@@ -233,7 +233,7 @@
         <parameter type="ICalTimeSpan *" name="s1" native_op="POINTER" comment="The first #ICalTimeSpan"/>
         <parameter type="ICalTimeSpan *" name="s2" native_op="POINTER" comment="The second #ICalTimeSpan"/>
         <returns type="gint" comment="Whether these two span are overlapped."/>
-        <comment xml:space="preserve">Check whether two spans overlap.</comment>
+        <comment xml:space="preserve">Check whether two #ICalTimeSpan overlap.</comment>
     </method>
     <method name="i_cal_time_span_contains" corresponds="icaltime_span_contains" kind="other" since="1.0">
         <parameter type="ICalTimeSpan *" name="s" native_op="POINTER" comment="The test #ICalTimeSpan"/>
@@ -245,13 +245,13 @@
         <parameter type="ICalTime *" name="t" comment="A #ICalTime to be operated on."/>
         <parameter type="ICalDuration *" name="d" comment="A #ICalDuration as the difference."/>
         <returns type="ICalTime *" annotation="transfer full" comment="The #ICalTime results. The native object is the same. But since it is a bare object, so it won't cause segmentation."/>
-        <comment xml:space="preserve">Add a time duration on the time.</comment>
+        <comment xml:space="preserve">Add a time duration on @tt.</comment>
     </method>
     <method name="i_cal_time_subtract" corresponds="icaltime_subtract" kind="other" since="2.0">
         <parameter type="ICalTime *" name="t1" comment="The subtracted #ICalTime."/>
         <parameter type="ICalTime *" name="t2" comment="The subtracting #ICalTime."/>
         <returns type="ICalDuration *" annotation="transfer full" comment="The #ICalDuration between two #ICalTime."/>
-        <comment xml:space="preserve">Get the duration between two time.</comment>
+        <comment xml:space="preserve">Get the duration between two #ICalTime.</comment>
 	</method>
     <method name="i_cal_time_get_year" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried."/>

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -582,7 +582,7 @@ int icaltime_week_number(const struct icaltimetype ictt)
 }
 
 /**
- *      Returns the day of the year, counting from 1 (Jan 1st).
+ *      Return the day of the year of the given time, counting from 1 (Jan 1st).
  */
 int icaltime_day_of_year(const struct icaltimetype t)
 {
@@ -711,7 +711,8 @@ int icaltime_is_null_time(const struct icaltimetype t)
 }
 
 /**
- *      Return -1, 0, or 1 to indicate that a<b, a==b, or a>b.
+ *      Return -1, 0, or 1 to indicate that a is less than b, a equals b, or 
+ *      a is greater than b.
  *      This calls icaltime_compare function after converting them to the utc
  *      timezone.
  */
@@ -772,7 +773,7 @@ int icaltime_compare(const struct icaltimetype a_in, const struct icaltimetype b
 }
 
 /**
- *      like icaltime_compare, but only use the date parts.
+ *      Like icaltime_compare, but only use the date parts.
  */
 
 int icaltime_compare_date_only(const struct icaltimetype a_in,
@@ -806,7 +807,7 @@ int icaltime_compare_date_only(const struct icaltimetype a_in,
 }
 
 /**
- *      like icaltime_compare, but only use the date parts; accepts timezone.
+ *      Like icaltime_compare, but only use the date parts; accepts timezone.
  */
 
 int icaltime_compare_date_only_tz(const struct icaltimetype a_in,
@@ -1013,7 +1014,7 @@ struct icaltimetype icaltime_set_timezone(struct icaltimetype *t, const icaltime
 }
 
 /**
- *  @brief builds an icaltimespan given a start time, end time and busy value.
+ *  @brief Builds an icaltimespan given a start time, end time and busy value.
  *
  *  @param dtstart   The beginning time of the span, can be a date-time
  *                   or just a date.

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -849,7 +849,7 @@ struct icaldurationtype  icaltime_subtract(struct icaltimetype t1,
 
 /**     @brief Internal, shouldn't be part of the public API
  *
- *      Adds (or subtracts) a time from a icaltimetype.
+ *      Add or subtract a number of days, hours, minutes and seconds from an icaltimetype.
  *      NOTE: This function is exactly the same as icaltimezone_adjust_change()
  *      except for the type of the first parameter.
  */

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -144,7 +144,7 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_string(const char *str);
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_day_of_year(const int doy, const int year);
 
 /**
- * Returns the time as seconds past the UNIX epoch
+ * Returns the time as seconds past the UNIX epoch.
  *
  * This function probably won't do what you expect.  In particular, you should
  * only pass an icaltime in UTC, since no conversion is done.  Even in that case,
@@ -161,20 +161,20 @@ LIBICAL_ICAL_EXPORT const char *icaltime_as_ical_string(const struct icaltimetyp
 
 LIBICAL_ICAL_EXPORT char *icaltime_as_ical_string_r(const struct icaltimetype tt);
 
-/** @brief Return the timezone */
+/** @brief Return the timezone. */
 LIBICAL_ICAL_EXPORT const icaltimezone *icaltime_get_timezone(const struct icaltimetype t);
 
-/** @brief Return the tzid, or NULL for a floating time */
+/** @brief Return the tzid, or NULL for a floating time. */
 LIBICAL_ICAL_EXPORT const char *icaltime_get_tzid(const struct icaltimetype t);
 
-/** @brief Set the timezone */
+/** @brief Set the timezone. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_set_timezone(struct icaltimetype *t,
                                                               const icaltimezone *zone);
 
 /** Return the day of the year of the given time, counting from 1 (Jan 1st). */
 LIBICAL_ICAL_EXPORT int icaltime_day_of_year(const struct icaltimetype t);
 
-/** Return the day of the week of the given time. Sunday is 1 */
+/** Return the day of the week of the given time. Sunday is 1. */
 LIBICAL_ICAL_EXPORT int icaltime_day_of_week(const struct icaltimetype t);
 
 /** Return the day of the year for the first day of the week that the

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -120,10 +120,10 @@ struct icaltimetype
 typedef struct icaltimetype icaltimetype;
 
 /** Return a null time, which indicates no time has been set.
-    This time represent the beginning of the epoch */
+    This time represents the beginning of the epoch. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_null_time(void);
 
-/** Return a null date */
+/** Return a null date, which indicates no time has been set. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_null_date(void);
 
 /** Returns the current time in the given timezone, as an icaltimetype. */
@@ -137,7 +137,7 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_timet_with_zone(const time
                                                                       const int is_date,
                                                                       const icaltimezone *zone);
 
-/** create a time from an ISO format string */
+/** Create a time from an ISO format string. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_string(const char *str);
 
 /** Create a new time, given a day of year and a year. */
@@ -152,11 +152,11 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_day_of_year(const int doy,
  */
 LIBICAL_ICAL_EXPORT time_t icaltime_as_timet(const struct icaltimetype);
 
-/** Return the time as seconds past the UNIX epoch, using timezones. */
+/** Return the time as seconds past the UNIX epoch, using the given timezone. */
 LIBICAL_ICAL_EXPORT time_t icaltime_as_timet_with_zone(const struct icaltimetype tt,
                                                        const icaltimezone *zone);
 
-/** Return a string represention of the time, in RFC5545 format. */
+/** Return a string represention of the time, in RFC5545 format. The string is owned by libical. */
 LIBICAL_ICAL_EXPORT const char *icaltime_as_ical_string(const struct icaltimetype tt);
 
 LIBICAL_ICAL_EXPORT char *icaltime_as_ical_string_r(const struct icaltimetype tt);
@@ -171,7 +171,7 @@ LIBICAL_ICAL_EXPORT const char *icaltime_get_tzid(const struct icaltimetype t);
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_set_timezone(struct icaltimetype *t,
                                                               const icaltimezone *zone);
 
-/** Return the day of the year of the given time */
+/** Return the day of the year of the given time, counting from 1 (Jan 1st). */
 LIBICAL_ICAL_EXPORT int icaltime_day_of_year(const struct icaltimetype t);
 
 /** Return the day of the week of the given time. Sunday is 1 */
@@ -184,7 +184,7 @@ LIBICAL_ICAL_EXPORT int icaltime_start_doy_week(const struct icaltimetype t, int
 /** Return the week number for the week the given time is within */
 LIBICAL_ICAL_EXPORT int icaltime_week_number(const struct icaltimetype t);
 
-/** Return true of the time is null. */
+/** Return true if the time is null. */
 LIBICAL_ICAL_EXPORT int icaltime_is_null_time(const struct icaltimetype t);
 
 /** Returns false if the time is clearly invalid, but is not null. This
@@ -198,14 +198,16 @@ LIBICAL_ICAL_EXPORT int icaltime_is_date(const struct icaltimetype t);
 /** @brief Returns true if time is relative to UTC zone */
 LIBICAL_ICAL_EXPORT int icaltime_is_utc(const struct icaltimetype t);
 
-/** Return -1, 0, or 1 to indicate that a is less than b, a equals b, or a is greater than b */
+/** Return -1, 0, or 1 to indicate that a is less than b, a equals b, or a is 
+    greater than b. This calls icaltime_compare function after converting 
+    them to the utc timezone. */
 LIBICAL_ICAL_EXPORT int icaltime_compare(const struct icaltimetype a, const struct icaltimetype b);
 
-/** like icaltime_compare, but only use the date parts. */
+/** Like icaltime_compare, but only use the date parts. */
 LIBICAL_ICAL_EXPORT int icaltime_compare_date_only(const struct icaltimetype a,
                                                    const struct icaltimetype b);
 
-/** like icaltime_compare, but only use the date parts. */
+/** Like icaltime_compare, but only use the date parts; accepts timezone. */
 LIBICAL_ICAL_EXPORT int icaltime_compare_date_only_tz(const struct icaltimetype a,
                                                       const struct icaltimetype b,
                                                       icaltimezone *tz);
@@ -218,8 +220,13 @@ LIBICAL_ICAL_EXPORT void icaltime_adjust(struct icaltimetype *tt,
 /** Normalize the icaltime, so that all fields are within the normal range. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_normalize(const struct icaltimetype t);
 
-/** convert tt, of timezone tzid, into a utc time. Does nothing if the
-   time is already UTC.  */
+/** Convert a time from its native timezone to a given timezone.
+
+    If tt is a date, the returned time is an exact
+    copy of the input. If it's a floating time, the returned object
+    represents the same time translated to the given timezone.
+    Otherwise the time will be converted to the new
+    time zone, and its native timezone set to the right timezone. */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_convert_to_zone(const struct icaltimetype tt,
                                                                  icaltimezone *zone);
 
@@ -232,7 +239,7 @@ LIBICAL_ICAL_EXPORT int icaltime_is_leap_year(const int year);
 /** Return the number of days in this year */
 LIBICAL_ICAL_EXPORT int icaltime_days_in_year(const int year);
 
-/** @brief calculate an icaltimespan given a start and end time. */
+/** @brief Builds an icaltimespan given a start time, end time and busy value. */
 LIBICAL_ICAL_EXPORT struct icaltime_span icaltime_span_new(struct icaltimetype dtstart,
                                                            struct icaltimetype dtend, int is_busy);
 

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -212,7 +212,9 @@ LIBICAL_ICAL_EXPORT int icaltime_compare_date_only_tz(const struct icaltimetype 
                                                       const struct icaltimetype b,
                                                       icaltimezone *tz);
 
-/** Adds or subtracts a number of days, hours, minutes and seconds. */
+/** Add or subtract a number of days, hours, minutes and seconds from an icaltimetype. 
+    NOTE: This function is exactly the same as icaltimezone_adjust_change()
+    except for the type of the first parameter.*/
 LIBICAL_ICAL_EXPORT void icaltime_adjust(struct icaltimetype *tt,
                                          const int days, const int hours,
                                          const int minutes, const int seconds);

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -181,7 +181,7 @@ LIBICAL_ICAL_EXPORT int icaltime_day_of_week(const struct icaltimetype t);
    given time is within. */
 LIBICAL_ICAL_EXPORT int icaltime_start_doy_week(const struct icaltimetype t, int fdow);
 
-/** Return the week number for the week the given time is within */
+/** Return the week number for the week the given time is within. */
 LIBICAL_ICAL_EXPORT int icaltime_week_number(const struct icaltimetype t);
 
 /** Return true if the time is null. */
@@ -232,13 +232,13 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_normalize(const struct icaltime
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_convert_to_zone(const struct icaltimetype tt,
                                                                  icaltimezone *zone);
 
-/** Return the number of days in the given month */
+/** Return the number of days in the given month. */
 LIBICAL_ICAL_EXPORT int icaltime_days_in_month(const int month, const int year);
 
 /** Return whether you've specified a leapyear or not. */
 LIBICAL_ICAL_EXPORT int icaltime_is_leap_year(const int year);
 
-/** Return the number of days in this year */
+/** Return the number of days in this year. */
 LIBICAL_ICAL_EXPORT int icaltime_days_in_year(const int year);
 
 /** @brief Builds an icaltimespan given a start time, end time and busy value. */


### PR DESCRIPTION
There are many inconsistencies in the documentation of icaltime that I have found, and tried to fix. Some are between the main `icaltime.c` and `icaltime.h` files, which led to duplicate sentences in the main documentation. Others are with bindings, in particular `libical-glib`. When there were conflicts, I tried to pick the most descriptive, and adhere to a consistent style with the rest of the documentation.