### PR TITLE
libical-glib: install src-generator to CMAKE_INSTALL_LIBEXECDIR

### DIFF
--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -1,20 +1,20 @@
 add_definitions(-Dlibical_ical_EXPORTS)
 
-# build ical-glib-src-generator
-add_executable(ical-glib-src-generator
+# build glib-src-generator
+add_executable(glib-src-generator
   tools/generator.c
   tools/generator.h
   tools/xml-parser.c
   tools/xml-parser.h
 )
 
-target_compile_options(ical-glib-src-generator PUBLIC ${GLIB_CFLAGS} ${LIBXML_CFLAGS} -DG_LOG_DOMAIN=\"src-generator\")
-target_link_libraries(ical-glib-src-generator ${GLIB_LIBRARIES} ${LIBXML_LIBRARIES})
+target_compile_options(glib-src-generator PUBLIC ${GLIB_CFLAGS} ${LIBXML_CFLAGS} -DG_LOG_DOMAIN=\"src-generator\")
+target_link_libraries(glib-src-generator ${GLIB_LIBRARIES} ${LIBXML_LIBRARIES})
 
 install(
-  TARGETS ical-glib-src-generator
+  TARGETS glib-src-generator
   EXPORT GlibSrcGenerator
-  DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/ical
 )
 install(
   EXPORT GlibSrcGenerator
@@ -76,18 +76,18 @@ if(CMAKE_CROSSCOMPILING)
   # import native ical-glib-src-generator when cross-compiling
   set(IMPORT_GLIB_SRC_GENERATOR "GLIB_SRC_GENERATOR-NOTFOUND"
     CACHE FILEPATH
-    "Path to exported ical-glib-src-generator target from native build"
+    "Path to exported glib-src-generator target from native build"
   )
   include(${IMPORT_GLIB_SRC_GENERATOR})
-  set(ical-glib-src-generator_EXE native-ical-glib-src-generator)
+  set(glib-src-generator_EXE native-glib-src-generator)
 else()
-  set(ical-glib-src-generator_EXE ical-glib-src-generator)
+  set(glib-src-generator_EXE glib-src-generator)
 endif()
 
 add_custom_command (
   OUTPUT ${LIBICAL_GLIB_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/libical-glib-private.h ${CMAKE_CURRENT_BINARY_DIR}/i-cal-forward-declarations.h
-  COMMAND ${ical-glib-src-generator_EXE} "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${CMAKE_CURRENT_SOURCE_DIR}/api"
-  DEPENDS ${ical-glib-src-generator_EXE} ${xml_files}
+  COMMAND ${glib-src-generator_EXE} "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${CMAKE_CURRENT_SOURCE_DIR}/api"
+  DEPENDS ${glib-src-generator_EXE} ${xml_files}
 )
 
 configure_file(


### PR DESCRIPTION
Follow-up to #439. The src-generator binary is not useful to end-users, so it really shouldn't be on `PATH`. `libexec` is the standard location for this kind of executable.