### PR TITLE
Improve thread safety of icaltimezone_load_builtin_timezone()

### DIFF
--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -1800,6 +1800,12 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
 
     icaltimezone_builtin_lock();
 
+    /* Try again, maybe it had been set by other thread while waiting for the lock */
+    if (zone->component) {
+        icaltimezone_builtin_unlock();
+        return;
+    }
+
     /* If the location isn't set, it isn't a builtin timezone. */
     if (!zone->location || !zone->location[0]) {
         icaltimezone_builtin_unlock();

--- a/src/test/builtin_timezones.c
+++ b/src/test/builtin_timezones.c
@@ -20,9 +20,59 @@
 #include <config.h>
 #endif
 
+#ifdef HAVE_PTHREAD_H
+#include <pthread.h>
+#include <assert.h>
+#endif
+
 #include "libical/ical.h"
 
 #include <stdio.h>
+
+#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD) && defined(HAVE_PTHREAD_CREATE)
+
+#define N_THREADS 20
+
+static const void *thread_comp = NULL;
+
+static void *
+thread_func(void *user_data)
+{
+    icaltimezone *zone = user_data;
+    icalcomponent *icalcomp;
+
+    if(!zone)
+        return NULL;
+
+    icalcomp = icaltimezone_get_component(zone);
+    if(!thread_comp)
+        thread_comp = icalcomp;
+    else
+        assert(thread_comp == icalcomp);
+    icalcomp = icalcomponent_new_clone(icalcomp);
+    icalcomponent_free(icalcomp);
+
+    return NULL;
+}
+
+static void
+test_get_component_threadsafety(void)
+{
+    pthread_t thread[N_THREADS];
+    icaltimezone *zone;
+    int ii;
+
+    zone = icaltimezone_get_builtin_timezone("Europe/London");
+
+    for(ii = 0; ii < N_THREADS; ii++) {
+        pthread_create(&thread[ii], NULL, thread_func, zone);
+    }
+
+    for(ii = 0; ii < N_THREADS; ii++) {
+        pthread_join(thread[ii], NULL);
+    }
+}
+#endif
 
 int main()
 {
@@ -33,6 +83,10 @@ int main()
 
     set_zone_directory("../../zoneinfo");
     icaltimezone_set_tzid_prefix("/softwarestudio.org/");
+
+    #if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD) && defined(HAVE_PTHREAD_CREATE)
+    test_get_component_threadsafety();
+    #endif
 
     tt = icaltime_current_time_with_zone(icaltimezone_get_builtin_timezone("America/New_York"));
 


### PR DESCRIPTION
Even the function does test whether the passed-in zone has set
the component, it doesn't retest it when it acquires the lock, but
other thread could already assign the component, which can cause
use-after-free in certain thread interleaving.


This patch has been applied to the version Fedora ships for, I guess, almost two years. It might help to resolve a crasher: https://gitlab.gnome.org/GNOME/evolution/-/issues/1128#note_924157