### PR TITLE
Move some variables to the read-only section

### DIFF
--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -218,7 +218,7 @@ void icalproperty_free(icalproperty *p)
 
 /* This returns where the start of the next line should be. chars_left does
    not include the trailing '\0'. */
-static size_t MAX_LINE_LEN = 75;
+static const size_t MAX_LINE_LEN = 75;
 
 static char *get_next_line_start(char *line_start, size_t chars_left)
 {

--- a/src/libical/icalrestriction.c.in
+++ b/src/libical/icalrestriction.c.in
@@ -54,7 +54,7 @@ typedef struct icalrestriction_component_record
 static const icalrestriction_property_record *icalrestriction_get_property_restriction(
     icalproperty_method method, icalcomponent_kind component, icalproperty_kind property);
 
-static icalrestriction_property_record null_prop_record =
+static const icalrestriction_property_record null_prop_record =
     { ICAL_METHOD_NONE, ICAL_NO_COMPONENT, ICAL_NO_PROPERTY, ICAL_RESTRICTION_UNKNOWN, NULL };
 
 /** Each row gives the result of comparing a restriction against a count.
@@ -63,7 +63,7 @@ static icalrestriction_property_record null_prop_record =
    ICAL_RESTRICTION_ONE, if there is 1 of a property with that
    restriction, it passes, but if there are 0 or 2+, it fails. */
 
-static char compare_map[ICAL_RESTRICTION_UNKNOWN + 1][3] = {
+static const char compare_map[ICAL_RESTRICTION_UNKNOWN + 1][3] = {
     {1, 1, 1}, /*ICAL_RESTRICTION_NONE */
     {1, 0, 0}, /*ICAL_RESTRICTION_ZERO */
     {0, 1, 0}, /*ICAL_RESTRICTION_ONE */

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -430,7 +430,7 @@ int icaltime_days_in_year(const int year)
     }
 }
 
-static int _days_in_month[] = { 0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+static const int _days_in_month[] = { 0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 int icaltime_days_in_month(const int month, const int year)
 {

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -1863,7 +1863,7 @@ static char *icaltimezone_load_get_line_fn(char *s, size_t size, void *data)
 
 int icaltimezone_dump_changes(icaltimezone *zone, int max_year, FILE *fp)
 {
-    static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    static const char months[][4] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     };
     icaltimezonechange *zone_change;

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -224,7 +224,7 @@ const char *icaltzutil_get_zone_directory(void)
 
 static int calculate_pos(icaltimetype icaltime)
 {
-   static int r_pos[] = {1, 2, 3, -2, -1};
+   static const int r_pos[] = {1, 2, 3, -2, -1};
    int pos;
 
    pos = (icaltime.day - 1) / 7;

--- a/src/libical/sspm.c
+++ b/src/libical/sspm.c
@@ -1320,7 +1320,7 @@ static void sspm_encode_quoted_printable(struct sspm_buffer *buf, char *data)
     }
 }
 
-static char BaseTable[64] = {
+static const char BaseTable[64] = {
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
     'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
     'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',


### PR DESCRIPTION
so that they do not allocate additional memory in each binary, that uses libical.