### PR TITLE
Fix build with icu-68.1

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -143,6 +143,7 @@
 #include <stdlib.h>
 
 #if defined(HAVE_LIBICU)
+#include <stdbool.h>
 #include <unicode/ucal.h>
 #include <unicode/ustring.h>
 #else
@@ -1079,7 +1080,7 @@ icalarray *icalrecurrencetype_rscale_supported_calendars(void)
 
     calendars = icalarray_new(sizeof(const char **), 20);
 
-    en = ucal_getKeywordValuesForLocale("calendar", NULL, FALSE, &status);
+    en = ucal_getKeywordValuesForLocale("calendar", NULL, false, &status);
     while ((cal = uenum_next(en, NULL, &status))) {
         cal = icalmemory_tmp_copy(cal);
         icalarray_append(calendars, &cal);
@@ -1472,7 +1473,7 @@ static int initialize_rscale(icalrecur_iterator *impl)
         }
 
         /* Check if specified calendar is supported */
-        en = ucal_getKeywordValuesForLocale("calendar", NULL, FALSE, &status);
+        en = ucal_getKeywordValuesForLocale("calendar", NULL, false, &status);
         while ((cal = uenum_next(en, NULL, &status))) {
             if (!strcmp(cal, rule.rscale)) {
                 is_hebrew = !strcmp(rule.rscale, "hebrew");


### PR DESCRIPTION
icu-68.1 removed public macro definitions for TRUE and FALSE

See icu upstream commit: https://github.com/unicode-org/icu/commit/a18df7ba2834afc2b577a1d5a7d906868ade6fa9