### PR TITLE
libical-glib: Use the latest GObject code style for classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ if(ICAL_GLIB_VAPI)
   endif()
 endif()
 
-set(MIN_GLIB "2.38")
+set(MIN_GLIB "2.44")
 set(MIN_LIBXML "2.7.3")
 libical_option(ICAL_GLIB "Build libical-glib interface. Requires glib ${MIN_GLIB} and libxml ${MIN_LIBXML} development packages or higher." True)
 if(ICAL_GLIB)

--- a/src/libical-glib/api/i-cal-geo.xml
+++ b/src/libical-glib/api/i-cal-geo.xml
@@ -41,7 +41,7 @@
         <comment xml:space="preserve">Creates a new #ICalGeo, copy of @geo.</comment>
         <custom>    struct icalgeotype *src;
 
-    g_return_val_if_fail(I_CAL_IS_GEO(geo), NULL);
+    g_return_val_if_fail(I_CAL_IS_GEO((ICalGeo *)geo), NULL);
 
     src = (struct icalgeotype *)i_cal_object_get_native((ICalObject *)geo);
     g_return_val_if_fail(src != NULL, NULL);

--- a/src/libical-glib/api/i-cal-reqstat.xml
+++ b/src/libical-glib/api/i-cal-reqstat.xml
@@ -51,14 +51,14 @@
         <parameter type="const ICalReqstat *" name="reqstat" comment="The #ICalReqstat"/>
         <returns type="const gchar *" annotation="transfer none" comment="The desc of @reqstat."/>
         <comment>Gets the desc of #ICalReqstat.</comment>
-        <custom>        g_return_val_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT (reqstat), NULL);
+        <custom>        g_return_val_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT ((ICalReqstat *)reqstat), NULL);
         return ((struct icalreqstattype *)i_cal_object_get_native ((ICalObject *)reqstat))->desc;</custom>
     </method>
     <method name="i_cal_reqstat_get_debug" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="const ICalReqstat *" name="reqstat" comment="The #ICalReqstat"/>
         <returns type="const gchar *" annotation="transfer none" comment="The debug of @reqstat."/>
         <comment>Gets the debug of #ICalReqstat.</comment>
-        <custom>        g_return_val_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT (reqstat), NULL);
+        <custom>        g_return_val_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT ((ICalReqstat *)reqstat), NULL);
         return ((struct icalreqstattype *)i_cal_object_get_native ((ICalObject *)reqstat))->debug;</custom>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-time-span.xml
+++ b/src/libical-glib/api/i-cal-time-span.xml
@@ -31,7 +31,7 @@
         <returns type="ICalTimeSpan *" annotation="transfer full" comment="The newly created #ICalTimeSpan, clone of @src." />
         <comment xml:space="preserve">Creates a new #ICalTimeSpan, clone of @src. Free it with g_object_unref(), when no longer needed.</comment>
         <custom>    struct icaltime_span *span;
-    g_return_val_if_fail(I_CAL_IS_TIME_SPAN(src), NULL);
+    g_return_val_if_fail(I_CAL_IS_TIME_SPAN((ICalTimeSpan *)src), NULL);
     span = ((struct icaltime_span *)i_cal_object_get_native ((ICalObject *)src));
     g_return_val_if_fail (span != NULL, NULL);
     return i_cal_time_span_new_full(*span);</custom>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -25,7 +25,7 @@
         <comment xml:space="preserve">Creates a new #ICalTime, copy of @timetype.</comment>
         <custom>    struct icaltimetype *itt;
 
-    g_return_val_if_fail(I_CAL_IS_TIME(timetype), NULL);
+    g_return_val_if_fail(I_CAL_IS_TIME((ICalTime *)timetype), NULL);
 
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);
     g_return_val_if_fail(itt != NULL, NULL);

--- a/src/libical-glib/i-cal-object.c.in
+++ b/src/libical-glib/i-cal-object.c.in
@@ -20,9 +20,6 @@
 
 #include "i-cal-object.h"
 
-#define LOCK_PROPS(x) g_mutex_lock (&((x)->priv->props_lock))
-#define UNLOCK_PROPS(x) g_mutex_unlock (&((x)->priv->props_lock))
-
 typedef struct _GlobalData {
     GType object_type;
     gpointer native;
@@ -103,7 +100,7 @@ void i_cal_object_free_global_objects(void)
     }
 }
 
-struct _ICalObjectPrivate
+typedef struct
 {
     GMutex props_lock;  /* to guard all the below members */
 
@@ -112,9 +109,12 @@ struct _ICalObjectPrivate
     gboolean is_global_memory;
     GObject *owner;
     GSList *dependers;  /* referenced GObject-s */
-};
+} ICalObjectPrivate;
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(ICalObject, i_cal_object, G_TYPE_OBJECT)
+
+#define LOCK_PROPS(x) g_mutex_lock (&((x)->props_lock))
+#define UNLOCK_PROPS(x) g_mutex_unlock (&((x)->props_lock))
 
 enum
 {
@@ -128,17 +128,16 @@ enum
 static void i_cal_object_set_property(GObject *object, guint property_id,
                                       const GValue * value, GParamSpec * pspec)
 {
-    ICalObject *iobject;
+    ICalObject *iobject = I_CAL_OBJECT(object);
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
     g_return_if_fail(I_CAL_IS_OBJECT(object));
-
-    iobject = I_CAL_OBJECT(object);
 
     switch (property_id) {
     case PROP_NATIVE:
         /* no need for LOCK_PROPS() here, these can be set only during construction time */
-        g_return_if_fail(iobject->priv->native == NULL);
-        iobject->priv->native = g_value_get_pointer(value);
+        g_return_if_fail(priv->native == NULL);
+        priv->native = g_value_get_pointer(value);
         return;
 
     case PROP_NATIVE_DESTROY_FUNC:
@@ -147,7 +146,7 @@ static void i_cal_object_set_property(GObject *object, guint property_id,
 
     case PROP_IS_GLOBAL_MEMORY:
         /* no need for LOCK_PROPS() here, these can be set only during construction time */
-        iobject->priv->is_global_memory = g_value_get_boolean(value);
+        priv->is_global_memory = g_value_get_boolean(value);
         return;
 
     case PROP_OWNER:
@@ -161,11 +160,9 @@ static void i_cal_object_set_property(GObject *object, guint property_id,
 static void i_cal_object_get_property(GObject *object, guint property_id,
                                       GValue * value, GParamSpec * pspec)
 {
-    ICalObject *iobject;
+    ICalObject *iobject = I_CAL_OBJECT(object);
 
     g_return_if_fail(I_CAL_IS_OBJECT(object));
-
-    iobject = I_CAL_OBJECT(object);
 
     switch (property_id) {
     case PROP_NATIVE:
@@ -191,19 +188,18 @@ static void i_cal_object_get_property(GObject *object, guint property_id,
 static void i_cal_object_finalize(GObject *object)
 {
     ICalObject *iobject = I_CAL_OBJECT(object);
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
-    if (!iobject->priv->owner && !iobject->priv->is_global_memory &&
-        iobject->priv->native && iobject->priv->native_destroy_func) {
-        iobject->priv->native_destroy_func(iobject->priv->native);
+    if (!priv->owner && !priv->is_global_memory &&
+        priv->native && priv->native_destroy_func) {
+        g_clear_pointer (&priv->native, priv->native_destroy_func);
     }
 
-    if (iobject->priv->owner) {
-        g_object_unref(iobject->priv->owner);
-    }
+    g_clear_object (&priv->owner);
 
-    g_slist_free_full(iobject->priv->dependers, g_object_unref);
+    g_slist_free_full(priv->dependers, g_object_unref);
 
-    g_mutex_clear(&iobject->priv->props_lock);
+    g_mutex_clear(&priv->props_lock);
 
     /* Chain up to parent's method. */
     G_OBJECT_CLASS(i_cal_object_parent_class)->finalize(object);
@@ -287,9 +283,9 @@ static void i_cal_object_class_init(ICalObjectClass * class)
 
 static void i_cal_object_init(ICalObject *iobject)
 {
-    iobject->priv = i_cal_object_get_instance_private(iobject);
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
-    g_mutex_init(&iobject->priv->props_lock);
+    g_mutex_init(&priv->props_lock);
 }
 
 /**
@@ -322,6 +318,7 @@ i_cal_object_construct(GType object_type,
                        GObject *owner)
 {
     ICalObject *iobject;
+    ICalObjectPrivate *priv;
 
     g_return_val_if_fail(object_type != G_TYPE_INVALID, NULL);
     g_return_val_if_fail(native != NULL, NULL);
@@ -347,14 +344,15 @@ i_cal_object_construct(GType object_type,
     }
 
     iobject = g_object_new(object_type, NULL);
+    priv = i_cal_object_get_instance_private(iobject);
 
     /* LOCK_PROPS (iobject); */
 
-    g_warn_if_fail(iobject->priv->native == NULL);
+    g_warn_if_fail(priv->native == NULL);
 
-    iobject->priv->native = native;
-    iobject->priv->native_destroy_func = native_destroy_func;
-    iobject->priv->is_global_memory = is_global_memory;
+    priv->native = native;
+    priv->native_destroy_func = native_destroy_func;
+    priv->is_global_memory = is_global_memory;
     i_cal_object_set_owner(iobject, owner);
 
     /* UNLOCK_PROPS (iobject); */
@@ -395,14 +393,15 @@ i_cal_object_construct(GType object_type,
 gpointer i_cal_object_get_native(ICalObject *iobject)
 {
     gpointer native;
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
     g_return_val_if_fail(I_CAL_IS_OBJECT(iobject), NULL);
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    native = iobject->priv->native;
+    native = priv->native;
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     return native;
 }
@@ -421,15 +420,15 @@ gpointer i_cal_object_get_native(ICalObject *iobject)
 gpointer i_cal_object_steal_native(ICalObject *iobject)
 {
     gpointer native;
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
     g_return_val_if_fail(I_CAL_IS_OBJECT(iobject), NULL);
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    native = iobject->priv->native;
-    iobject->priv->native = NULL;
+    native = g_steal_pointer (&priv->native);
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     return native;
 }
@@ -448,14 +447,15 @@ gpointer i_cal_object_steal_native(ICalObject *iobject)
 GDestroyNotify i_cal_object_get_native_destroy_func(ICalObject *iobject)
 {
     GDestroyNotify func;
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
     g_return_val_if_fail(I_CAL_IS_OBJECT(iobject), NULL);
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    func = iobject->priv->native_destroy_func;
+    func = priv->native_destroy_func;
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     return func;
 }
@@ -471,18 +471,20 @@ GDestroyNotify i_cal_object_get_native_destroy_func(ICalObject *iobject)
  **/
 void i_cal_object_set_native_destroy_func(ICalObject *iobject, GDestroyNotify native_destroy_func)
 {
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
+
     g_return_if_fail(I_CAL_IS_OBJECT(iobject));
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    if (native_destroy_func == iobject->priv->native_destroy_func) {
-        UNLOCK_PROPS(iobject);
+    if (native_destroy_func == priv->native_destroy_func) {
+        UNLOCK_PROPS(priv);
         return;
     }
 
-    iobject->priv->native_destroy_func = native_destroy_func;
+    priv->native_destroy_func = native_destroy_func;
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     g_object_notify(G_OBJECT(iobject), "native-destroy-func");
 }
@@ -500,15 +502,16 @@ void i_cal_object_set_native_destroy_func(ICalObject *iobject, GDestroyNotify na
  **/
 gboolean i_cal_object_get_is_global_memory(ICalObject *iobject)
 {
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
     gboolean is_global_memory;
 
     g_return_val_if_fail(I_CAL_IS_OBJECT(iobject), FALSE);
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    is_global_memory = iobject->priv->is_global_memory;
+    is_global_memory = priv->is_global_memory;
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     return is_global_memory;
 }
@@ -525,24 +528,22 @@ gboolean i_cal_object_get_is_global_memory(ICalObject *iobject)
  **/
 void i_cal_object_set_owner(ICalObject *iobject, GObject *owner)
 {
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
+
     g_return_if_fail(I_CAL_IS_OBJECT(iobject));
     if (owner)
         g_return_if_fail(G_IS_OBJECT(owner));
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    if (owner == iobject->priv->owner) {
-        UNLOCK_PROPS(iobject);
+    if (owner == priv->owner) {
+        UNLOCK_PROPS(priv);
         return;
     }
 
-    if (owner) {
-        g_object_ref(owner);
-    }
-    g_clear_object(&iobject->priv->owner);
-    iobject->priv->owner = owner;
+    g_set_object (&priv->owner, owner);
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     g_object_notify(G_OBJECT(iobject), "owner");
 }
@@ -562,17 +563,18 @@ void i_cal_object_set_owner(ICalObject *iobject, GObject *owner)
  **/
 GObject *i_cal_object_ref_owner(ICalObject *iobject)
 {
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
     GObject *owner;
 
     g_return_val_if_fail(I_CAL_IS_OBJECT(iobject), NULL);
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    owner = iobject->priv->owner;
+    owner = priv->owner;
     if (owner)
         g_object_ref(owner);
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 
     return owner;
 }
@@ -587,19 +589,15 @@ GObject *i_cal_object_ref_owner(ICalObject *iobject)
  **/
 void i_cal_object_remove_owner(ICalObject *iobject)
 {
-    GObject *owner;
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
 
     g_return_if_fail(I_CAL_IS_OBJECT(iobject));
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    owner = iobject->priv->owner;
-    if (owner) {
-        g_object_unref(owner);
-        iobject->priv->owner = NULL;
-    }
+    g_clear_object (&priv->owner);
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 }
 
 /**
@@ -616,20 +614,22 @@ void i_cal_object_remove_owner(ICalObject *iobject)
  **/
 void i_cal_object_add_depender(ICalObject *iobject, GObject *depender)
 {
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
+
     g_return_if_fail(I_CAL_IS_OBJECT(iobject));
     g_return_if_fail(G_IS_OBJECT(depender));
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    if (g_slist_find(iobject->priv->dependers, depender)) {
+    if (g_slist_find(priv->dependers, depender)) {
         g_warn_if_reached();
-        UNLOCK_PROPS(iobject);
+        UNLOCK_PROPS(priv);
         return;
     }
 
-    iobject->priv->dependers = g_slist_prepend(iobject->priv->dependers, g_object_ref(depender));
+    priv->dependers = g_slist_prepend(priv->dependers, g_object_ref(depender));
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 }
 
 /**
@@ -645,19 +645,21 @@ void i_cal_object_add_depender(ICalObject *iobject, GObject *depender)
  **/
 void i_cal_object_remove_depender(ICalObject *iobject, GObject *depender)
 {
+    ICalObjectPrivate *priv = i_cal_object_get_instance_private(iobject);
+
     g_return_if_fail(I_CAL_IS_OBJECT(iobject));
     g_return_if_fail(G_IS_OBJECT(depender));
 
-    LOCK_PROPS(iobject);
+    LOCK_PROPS(priv);
 
-    if (!g_slist_find(iobject->priv->dependers, depender)) {
+    if (!g_slist_find(priv->dependers, depender)) {
         g_warn_if_reached();
-        UNLOCK_PROPS(iobject);
+        UNLOCK_PROPS(priv);
         return;
     }
 
-    iobject->priv->dependers = g_slist_remove(iobject->priv->dependers, depender);
+    priv->dependers = g_slist_remove(priv->dependers, depender);
     g_object_unref(depender);
 
-    UNLOCK_PROPS(iobject);
+    UNLOCK_PROPS(priv);
 }

--- a/src/libical-glib/i-cal-object.h.in
+++ b/src/libical-glib/i-cal-object.h.in
@@ -29,26 +29,8 @@
 
 #define I_CAL_TYPE_OBJECT \
     (i_cal_object_get_type ())
-
-#define I_CAL_OBJECT(obj)       \
-    (G_TYPE_CHECK_INSTANCE_CAST \
-    ((obj), I_CAL_TYPE_OBJECT, ICalObject))
-
-#define I_CAL_OBJECT_CLASS(cls)                 \
-    (G_TYPE_CHECK_CLASS_CAST \
-    ((cls), I_CAL_TYPE_OBJECT, ICalObjectClass))
-
-#define I_CAL_IS_OBJECT(obj)    \
-    (G_TYPE_CHECK_INSTANCE_TYPE \
-    ((obj), I_CAL_TYPE_OBJECT))
-
-#define I_CAL_IS_OBJECT_CLASS(cls)              \
-    (G_TYPE_CHECK_CLASS_TYPE \
-    ((cls), I_CAL_TYPE_OBJECT))
-
-#define I_CAL_OBJECT_GET_CLASS(obj)             \
-    (G_TYPE_INSTANCE_GET_CLASS \
-    ((obj), I_CAL_TYPE_OBJECT, ICalObjectClass))
+LIBICAL_ICAL_EXPORT
+G_DECLARE_DERIVABLE_TYPE (ICalObject, i_cal_object, I_CAL, OBJECT, GObject)
 
 G_BEGIN_DECLS
 /**
@@ -56,30 +38,18 @@ G_BEGIN_DECLS
  *
  * This is an ICalObject instance struct.
  */
-typedef struct _ICalObject ICalObject;
 
 /**
  * ICalObjectClass:
  *
  * This is an ICalObject class struct.
  */
-typedef struct _ICalObjectClass ICalObjectClass;
-typedef struct _ICalObjectPrivate ICalObjectPrivate;
-
-struct _ICalObject
-{
-    /*< private > */
-    GObject parent;
-    ICalObjectPrivate *priv;
-};
 
 struct _ICalObjectClass
 {
     /*< private > */
     GObjectClass parent_class;
 };
-
-LIBICAL_ICAL_EXPORT GType i_cal_object_get_type(void);
 
 LIBICAL_ICAL_EXPORT gpointer i_cal_object_construct(GType object_type,
                                                     gpointer native,

--- a/src/libical-glib/tools/generator.c
+++ b/src/libical-glib/tools/generator.c
@@ -329,26 +329,6 @@ gchar *get_lower_train_from_upper_camel(const gchar *upperCamel)
     return ret;
 }
 
-void generate_header_method_get_type(FILE *out, Structure *structure)
-{
-    gchar *upperCamel;
-    gchar *lowerSnake;
-    Method *get_type;
-
-    g_return_if_fail(out != NULL && structure != NULL);
-    upperCamel = g_strconcat(structure->nameSpace, structure->name, NULL);
-    lowerSnake = get_lower_snake_from_upper_camel(upperCamel);
-    g_free(upperCamel);
-
-    get_type = method_new();
-    get_type->ret = ret_new();
-    get_type->ret->type = g_strdup("GType");
-    get_type->name = g_strconcat(lowerSnake, "_get_type", NULL);
-    g_free(lowerSnake);
-    generate_header_method_proto(out, get_type, FALSE);
-    method_free(get_type);
-}
-
 void generate_header_method_new_full(FILE *out, Structure *structure)
 {
     gchar *upperCamel;
@@ -705,8 +685,6 @@ void generate_header_method_protos(FILE *out, Structure *structure)
         privateHeader = open_private_header();
         write_str(privateHeader, privateHeaderComment);
         generate_header_method_new_full(privateHeader, structure);
-
-        generate_header_method_get_type(out, structure);
     }
 
     for (iter = g_list_first(structure->methods); iter != NULL; iter = g_list_next(iter)) {
@@ -1640,7 +1618,7 @@ gchar *get_inline_parameter(Parameter *para)
         (void)g_stpcpy(buffer + strlen(buffer), translator);
         (void)g_stpcpy(buffer + strlen(buffer), " (");
         if (para->translator == NULL && !is_enum_type(para->type))
-            (void)g_stpcpy(buffer + strlen(buffer), "I_CAL_OBJECT (");
+            (void)g_stpcpy(buffer + strlen(buffer), "I_CAL_OBJECT ((ICalObject *)");
     }
 
     (void)g_stpcpy(buffer + strlen(buffer), para->name);
@@ -2085,7 +2063,7 @@ gchar *get_source_run_time_checkers(Method *method, const gchar *namespace)
                 nameSpaceUpperSnake = get_upper_snake_from_upper_camel(namespace);
                 nameUpperSnake = get_upper_snake_from_upper_camel(trueType + i);
                 typeCheck =
-                    g_strconcat(nameSpaceUpperSnake, "_IS_", nameUpperSnake, " (", parameter->name,
+                    g_strconcat(nameSpaceUpperSnake, "_IS_", nameUpperSnake, " ((", trueType, "*)", parameter->name,
                                 ")", NULL);
                 defaultValue = NULL;
                 if (method->ret != NULL) {

--- a/src/libical-glib/tools/header-structure-boilerplate-template
+++ b/src/libical-glib/tools/header-structure-boilerplate-template
@@ -1,21 +1,8 @@
+
 #define ${namespaceLowerSnake}_TYPE_${nameLowerSnake} \
     (${lowerSnake}_get_type ())
-
-#define ${upperSnake}(obj) \
-    (G_TYPE_CHECK_INSTANCE_CAST \
-    ((obj), ${namespaceLowerSnake}_TYPE_${nameLowerSnake}, ${upperCamel}))
-
-#define ${upperSnake}_CLASS(klass) \
-    (G_TYPE_CHECK_CLASS_CAST \
-    ((klass), ${namespaceLowerSnake}_TYPE_${nameLowerSnake}, ${upperCamel}Class))
-
-#define ${namespaceLowerSnake}_IS_${nameLowerSnake}(obj) \
-    (G_TYPE_CHECK_INSTANCE_TYPE \
-    ((obj), ${namespaceLowerSnake}_TYPE_${nameLowerSnake}))
-
-#define ${namespaceLowerSnake}_IS_${nameLowerSnake}_CLASS(klass) \
-    (G_TYPE_CHECK_CLASS_TYPE \
-    ((klass), ${namespaceLowerSnake}_TYPE_${nameLowerSnake}))
+LIBICAL_ICAL_EXPORT
+G_DECLARE_DERIVABLE_TYPE(${upperCamel}, ${lowerSnake}, ${namespaceLowerSnake}, ${nameLowerSnake}, ICalObject)
 
 /**
  * ${upperCamel}:
@@ -28,13 +15,6 @@
  *
  * This is the ${upperCamel} class.
  */
-typedef struct _${upperCamel}Class ${upperCamel}Class;
-
-struct _${upperCamel} {
-    /*< private >*/
-    ICalObject parent;
-};
-
 struct _${upperCamel}Class {
     /*< private >*/
     ICalObjectClass parent;


### PR DESCRIPTION
Requires GLib 2.44.

GLib 2.44 comes with some handy macros. This also allows developers to use `g_autoptr()` with Clang/GCC.