### PR TITLE
Fix building *-static libraries when STATIC_ONLY is enabled.

### DIFF
--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -260,9 +260,11 @@ add_custom_command(
 
 add_library(ical ${LIBRARY_TYPE} ${ical_LIB_SRCS})
 add_dependencies(ical ical-header)
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   add_library(ical-static STATIC ${ical_LIB_SRCS})
   add_dependencies(ical-static ical-header)
+elseif(STATIC_ONLY)
+  add_library(ical-static ALIAS ical)
 endif()
 
 target_link_libraries(ical ${CMAKE_THREAD_LIBS_INIT})
@@ -277,11 +279,11 @@ endif()
 
 if(MSVC)
   set_target_properties(ical PROPERTIES PREFIX "lib")
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(ical-static PROPERTIES PREFIX "lib")
   endif()
 else()
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(ical-static PROPERTIES OUTPUT_NAME "ical")
   endif()
 endif()
@@ -290,7 +292,7 @@ set_target_properties(ical PROPERTIES
   SOVERSION ${LIBICAL_LIB_MAJOR_VERSION}
 )
 set_target_properties(ical PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   set_target_properties(ical-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 endif()
 
@@ -299,7 +301,7 @@ install(
   EXPORT icalTargets
   DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(
     TARGETS ical-static
     EXPORT icalTargets
@@ -326,19 +328,21 @@ if(WITH_CXX_BINDINGS)
 
   add_library(ical_cxx ${LIBRARY_TYPE} ${icalcxx_LIB_SRCS})
   add_dependencies(ical_cxx ical-header)
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     add_library(ical_cxx-static STATIC ${icalcxx_LIB_SRCS})
     add_dependencies(ical_cxx-static ical-header)
+  elseif(STATIC_ONLY)
+    add_library(ical_cxx-static ALIAS ical_cxx)
   endif()
   target_link_libraries(ical_cxx ical ${CMAKE_THREAD_LIBS_INIT})
 
   if(MSVC)
     set_target_properties(ical_cxx PROPERTIES PREFIX "lib")
-    if(NOT SHARED_ONLY)
+    if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
       set_target_properties(ical_cxx-static PROPERTIES PREFIX "lib")
     endif()
   else()
-    if(NOT SHARED_ONLY)
+    if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
       set_target_properties(ical_cxx-static PROPERTIES OUTPUT_NAME "ical_cxx")
     endif()
   endif()
@@ -348,7 +352,7 @@ if(WITH_CXX_BINDINGS)
     SOVERSION ${LIBICAL_LIB_MAJOR_VERSION}
   )
   set_target_properties(ical_cxx PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(ical_cxx-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
   endif()
 
@@ -357,7 +361,7 @@ if(WITH_CXX_BINDINGS)
     EXPORT icalTargets
     DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
   )
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     install(
       TARGETS ical_cxx-static
       EXPORT icalTargets

--- a/src/libicalss/CMakeLists.txt
+++ b/src/libicalss/CMakeLists.txt
@@ -79,9 +79,11 @@ add_custom_command(
 
 add_library(icalss ${LIBRARY_TYPE} ${icalss_LIB_SRCS})
 add_dependencies(icalss ical-header icalss-header)
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   add_library(icalss-static STATIC ${icalss_LIB_SRCS})
   add_dependencies(icalss-static ical-header icalss-header)
+elseif(STATIC_ONLY)
+  add_library(icalss-static ALIAS icalss)
 endif()
 
 target_link_libraries(icalss ical)
@@ -91,11 +93,11 @@ endif()
 
 if(MSVC)
   set_target_properties(icalss PROPERTIES PREFIX "lib")
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(icalss-static PROPERTIES PREFIX "lib")
   endif()
 else()
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(icalss-static PROPERTIES OUTPUT_NAME "icalss")
   endif()
 endif()
@@ -104,7 +106,7 @@ set_target_properties(icalss PROPERTIES
   SOVERSION ${LIBICAL_LIB_MAJOR_VERSION}
 )
 set_target_properties(icalss PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   set_target_properties(icalss-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 endif()
 
@@ -113,7 +115,7 @@ install(
   EXPORT icalTargets
   DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(
     TARGETS icalss-static
     EXPORT icalTargets
@@ -135,20 +137,22 @@ if(WITH_CXX_BINDINGS)
   endif()
   add_library(icalss_cxx ${LIBRARY_TYPE} ${icalsscxx_LIB_SRCS})
   add_dependencies(icalss_cxx ical-header icalss-header)
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     add_library(icalss_cxx-static STATIC ${icalsscxx_LIB_SRCS})
     add_dependencies(icalss_cxx-static ical-header icalss-header)
+  elseif(STATIC_ONLY)
+    add_library(icalss_cxx-static ALIAS icalss_cxx)
   endif()
 
   target_link_libraries(icalss_cxx icalss ical_cxx ${CMAKE_THREAD_LIBS_INIT})
 
   if(MSVC)
     set_target_properties(icalss_cxx PROPERTIES PREFIX "lib")
-    if(NOT SHARED_ONLY)
+    if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
       set_target_properties(icalss_cxx-static PROPERTIES PREFIX "lib")
     endif()
   else()
-    if(NOT SHARED_ONLY)
+    if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
       set_target_properties(icalss_cxx-static PROPERTIES OUTPUT_NAME "icalss_cxx")
     endif()
   endif()
@@ -157,7 +161,7 @@ if(WITH_CXX_BINDINGS)
     SOVERSION ${LIBICAL_LIB_MAJOR_VERSION}
   )
   set_target_properties(icalss_cxx PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(icalss_cxx-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
   endif()
 
@@ -166,7 +170,7 @@ if(WITH_CXX_BINDINGS)
     EXPORT icalTargets
     DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
   )
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     install(
       TARGETS icalss_cxx-static
       EXPORT icalTargets

--- a/src/libicalvcal/CMakeLists.txt
+++ b/src/libicalvcal/CMakeLists.txt
@@ -27,20 +27,22 @@ set(icalvcal_LIB_SRCS
 
 add_library(icalvcal ${LIBRARY_TYPE} ${icalvcal_LIB_SRCS})
 add_dependencies(icalvcal ical-header)
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   add_library(icalvcal-static STATIC ${icalvcal_LIB_SRCS})
   add_dependencies(icalvcal-static ical-header)
+elseif(STATIC_ONLY)
+  add_library(icalvcal-static ALIAS icalvcal)
 endif()
 
 target_link_libraries(icalvcal ical)
 
 if(MSVC)
   set_target_properties(icalvcal PROPERTIES PREFIX "lib")
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(icalvcal-static PROPERTIES PREFIX "lib")
   endif()
 else()
-  if(NOT SHARED_ONLY)
+  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     set_target_properties(icalvcal-static PROPERTIES OUTPUT_NAME "icalvcal")
   endif()
 endif()
@@ -49,7 +51,7 @@ set_target_properties(icalvcal PROPERTIES
   SOVERSION ${LIBICAL_LIB_MAJOR_VERSION}
 )
 set_target_properties(icalvcal PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   set_target_properties(icalvcal-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 endif()
 
@@ -58,7 +60,7 @@ install(
   EXPORT icalTargets
   DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-if(NOT SHARED_ONLY)
+if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(
     TARGETS icalvcal-static
     EXPORT icalTargets


### PR DESCRIPTION
When `STATIC_ONLY` is enabled, both the regular libraries, and the ones with the `-static` postfix are built. This PR aims to fix this.