### PR TITLE
icaltz util fixes

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -45,6 +45,8 @@ Version 3.0.10 (UNRELEASED):
  * Fix building -DSTATIC_ONLY=True with Ninja
  * Fix generating wrong recurrence rules (#478)
  * Fix a bug computing transitions in tzfiles
+ * Fix reading TZif files to use TZ string in the footer as the last (non-terminating) transitions
+ * Fix reading TZif files to use more RRULEs and/or RDATEs whevever possible
 
 Version 3.0.9 (16 January 2021):
 --------------------------------

--- a/src/libical/icalduration.h
+++ b/src/libical/icalduration.h
@@ -43,6 +43,8 @@ struct icaldurationtype
     unsigned int seconds;
 };
 
+#define ICALDURATIONTYPE_INITIALIZER { 0, 0, 0, 0, 0, 0 }
+
 /**
  * @brief Creates a new ::icaldurationtype from a duration in seconds.
  * @param t The duration in seconds

--- a/src/libical/icalperiod.h
+++ b/src/libical/icalperiod.h
@@ -41,6 +41,12 @@ struct icalperiodtype
     struct icaldurationtype duration;
 };
 
+#define ICALPERIODTYPE_INITIALIZER { \
+    ICALTIMETYPE_INITIALIZER,        \
+    ICALTIMETYPE_INITIALIZER,        \
+    ICALDURATIONTYPE_INITIALIZER     \
+}
+
 /**
  * @brief Constructs a new ::icalperiodtype from @a str
  * @param str The string from which to construct a time period

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -333,23 +333,25 @@ struct icalrecur_parser
 enum byrule
 {
     NO_CONTRACTION = -1,
-    BY_SECOND = 0,
-    BY_MINUTE = 1,
-    BY_HOUR = 2,
-    BY_DAY = 3,
-    BY_MONTH_DAY = 4,
-    BY_YEAR_DAY = 5,
-    BY_WEEK_NO = 6,
-    BY_MONTH = 7,
-    BY_SET_POS
+    BY_MONTH       =  0,
+    BY_WEEK_NO     =  1,
+    BY_YEAR_DAY    =  2,
+    BY_MONTH_DAY   =  3,
+    BY_DAY         =  4,
+    BY_HOUR        =  5,
+    BY_MINUTE      =  6,
+    BY_SECOND      =  7,
+    BY_SET_POS     =  8
 };
+
+#define NUM_BY_PARTS  9
 
 enum expand_table
 {
-    UNKNOWN = 0,
+    UNKNOWN  = 0,
     CONTRACT = 1,
-    EXPAND = 2,
-    ILLEGAL = 3
+    EXPAND   = 2,
+    ILLEGAL  = 3
 };
 
 struct expand_split_map_struct
@@ -359,7 +361,7 @@ struct expand_split_map_struct
     /* Elements of the 'map' array correspond to the BYxxx rules:
        Second,Minute,Hour,Day,Month Day,Year Day,Week No,Month,SetPos */
 
-    short map[BY_SET_POS+1];
+    short map[NUM_BY_PARTS];
 };
 
 /**
@@ -370,13 +372,13 @@ struct expand_split_map_struct
  */
 
 static const struct expand_split_map_struct expand_map[] = {
-    /*                           s  m  h  D  MD YD W  M  P */
-    {ICAL_SECONDLY_RECURRENCE, { 1, 1, 1, 1, 1, 1, 3, 1, 1 }},
-    {ICAL_MINUTELY_RECURRENCE, { 2, 1, 1, 1, 1, 1, 3, 1, 1 }},
-    {ICAL_HOURLY_RECURRENCE,   { 2, 2, 1, 1, 1, 1, 3, 1, 1 }},
-    {ICAL_DAILY_RECURRENCE,    { 2, 2, 2, 1, 1, 3, 3, 1, 1 }},
-    {ICAL_WEEKLY_RECURRENCE,   { 2, 2, 2, 2, 3, 3, 3, 1, 1 }},
-    {ICAL_MONTHLY_RECURRENCE,  { 2, 2, 2, 2, 2, 3, 3, 1, 1 }},
+    /*                           M  W  YD MD D  h  m  s  P */
+    {ICAL_SECONDLY_RECURRENCE, { 1, 3, 1, 1, 1, 1, 1, 1, 1 }},
+    {ICAL_MINUTELY_RECURRENCE, { 1, 3, 1, 1, 1, 1, 1, 2, 1 }},
+    {ICAL_HOURLY_RECURRENCE,   { 1, 3, 1, 1, 1, 1, 2, 2, 1 }},
+    {ICAL_DAILY_RECURRENCE,    { 1, 3, 3, 1, 1, 2, 2, 2, 1 }},
+    {ICAL_WEEKLY_RECURRENCE,   { 1, 3, 3, 3, 2, 2, 2, 2, 1 }},
+    {ICAL_MONTHLY_RECURRENCE,  { 1, 3, 3, 2, 2, 2, 2, 2, 1 }},
     {ICAL_YEARLY_RECURRENCE,   { 2, 2, 2, 2, 2, 2, 2, 2, 1 }},
     {ICAL_NO_RECURRENCE,       { 0, 0, 0, 0, 0, 0, 0, 0, 0 }} //krazy:exclude=style
 };
@@ -388,22 +390,22 @@ static struct recur_map
     int size;
     int min;
 } recur_map[] = {
-    { "BYSECOND",   offsetof(struct icalrecurrencetype, by_second),
-      ICAL_BY_SECOND_SIZE,    0 },
-    { "BYMINUTE",   offsetof(struct icalrecurrencetype, by_minute),
-      ICAL_BY_MINUTE_SIZE,    0 },
-    { "BYHOUR",     offsetof(struct icalrecurrencetype, by_hour),
-      ICAL_BY_HOUR_SIZE,      0 },
-    { "BYDAY",      offsetof(struct icalrecurrencetype, by_day),
-      ICAL_BY_DAY_SIZE,       0 },
-    { "BYMONTHDAY", offsetof(struct icalrecurrencetype, by_month_day),
-      ICAL_BY_MONTHDAY_SIZE, -1 },
-    { "BYYEARDAY",  offsetof(struct icalrecurrencetype, by_year_day),
-      ICAL_BY_YEARDAY_SIZE,  -1 },
-    { "BYWEEKNO",   offsetof(struct icalrecurrencetype, by_week_no),
-      ICAL_BY_WEEKNO_SIZE,   -1 },
     { "BYMONTH",    offsetof(struct icalrecurrencetype, by_month),
       ICAL_BY_MONTH_SIZE,     1 },
+    { "BYWEEKNO",   offsetof(struct icalrecurrencetype, by_week_no),
+      ICAL_BY_WEEKNO_SIZE,   -1 },
+    { "BYYEARDAY",  offsetof(struct icalrecurrencetype, by_year_day),
+      ICAL_BY_YEARDAY_SIZE,  -1 },
+    { "BYMONTHDAY", offsetof(struct icalrecurrencetype, by_month_day),
+      ICAL_BY_MONTHDAY_SIZE, -1 },
+    { "BYDAY",      offsetof(struct icalrecurrencetype, by_day),
+      ICAL_BY_DAY_SIZE,       0 },
+    { "BYHOUR",     offsetof(struct icalrecurrencetype, by_hour),
+      ICAL_BY_HOUR_SIZE,      0 },
+    { "BYMINUTE",   offsetof(struct icalrecurrencetype, by_minute),
+      ICAL_BY_MINUTE_SIZE,    0 },
+    { "BYSECOND",   offsetof(struct icalrecurrencetype, by_second),
+      ICAL_BY_SECOND_SIZE,    0 },
     { "BYSETPOS",   offsetof(struct icalrecurrencetype, by_set_pos),
       ICAL_BY_SETPOS_SIZE,   -1 },
 };
@@ -745,7 +747,7 @@ struct icalrecurrencetype icalrecurrencetype_from_string(const char *str)
         } else if (strncasecmp(name, "BY", 2) == 0) {
             r = -1;
 
-            for (byrule = BY_SECOND; byrule <= BY_SET_POS; byrule++) {
+            for (byrule = 0; byrule < NUM_BY_PARTS; byrule++) {
                 if (strcasecmp(name+2, recur_map[byrule].str+2) == 0) {
                     if (byrule == BY_DAY) {
                         r = icalrecur_add_bydayrules(&parser, value);
@@ -778,7 +780,7 @@ struct icalrecurrencetype icalrecurrencetype_from_string(const char *str)
         }
     }
 
-    for (byrule = BY_SECOND; byrule <= BY_SET_POS; byrule++) {
+    for (byrule = 0; byrule < NUM_BY_PARTS; byrule++) {
         short *array = (short *)(recur_map[byrule].offset + (size_t) &parser.rt);
 
         if (array[0] != ICAL_RECURRENCE_ARRAY_MAX &&
@@ -832,6 +834,7 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
         icalmemory_append_string(&str, &str_p, &buf_sz, "RSCALE=");
         icalmemory_append_string(&str, &str_p, &buf_sz, recur->rscale);
 
+        /* Omit is the default, so no need to write that out */
         if (recur->skip != ICAL_SKIP_OMIT) {
             const char *skipstr = icalrecur_skip_to_string(recur->skip);
             icalmemory_append_string(&str, &str_p, &buf_sz, ";SKIP=");
@@ -844,6 +847,13 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
     icalmemory_append_string(&str, &str_p, &buf_sz,
                              icalrecur_freq_to_string(recur->freq));
 
+    /* 1 is the default, so no need to write that out */
+    if (recur->interval != 1) {
+        snprintf(temp, sizeof(temp), "%d", recur->interval);
+        icalmemory_append_string(&str, &str_p, &buf_sz, ";INTERVAL=");
+        icalmemory_append_string(&str, &str_p, &buf_sz, temp);
+    }
+
     /* Monday is the default, so no need to write that out */
     if (recur->week_start != ICAL_MONDAY_WEEKDAY &&
         recur->week_start != ICAL_NO_WEEKDAY) {
@@ -853,7 +863,7 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
         icalmemory_append_string(&str, &str_p, &buf_sz, daystr);
     }
 
-    for (j = BY_SET_POS; j >= BY_SECOND; j--) {
+    for (j = 0; j < NUM_BY_PARTS; j++) {
         short *array = (short *)(recur_map[j].offset + (size_t) recur);
         int limit = recur_map[j].size - 1;
 
@@ -864,8 +874,7 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
             icalmemory_append_string(&str, &str_p, &buf_sz, recur_map[j].str);
             icalmemory_append_char(&str, &str_p, &buf_sz, '=');
 
-            for (i = 0;
-                 i < limit && array[i] != ICAL_RECURRENCE_ARRAY_MAX; i++) {
+            for (i = 0; i < limit && array[i] != ICAL_RECURRENCE_ARRAY_MAX; i++) {
                 if (j == BY_DAY) {
                     int pos = icalrecurrencetype_day_position(array[i]);
                     int dow = icalrecurrencetype_day_day_of_week(array[i]);
@@ -896,14 +905,7 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
         }
     }
 
-    if (recur->interval != 1) {
-        snprintf(temp, sizeof(temp), "%d", recur->interval);
-        icalmemory_append_string(&str, &str_p, &buf_sz, ";INTERVAL=");
-        icalmemory_append_string(&str, &str_p, &buf_sz, temp);
-    }
-
     if (recur->until.year != 0) {
-
         temp[0] = 0;
         if (recur->until.is_date) {
             print_date_to_string(temp, &(recur->until));
@@ -969,10 +971,10 @@ struct icalrecur_iterator_impl
     short days_index;
 
     enum byrule byrule;
-    short by_indices[9];
-    short orig_data[9]; /**< 1 if there was data in the byrule */
+    short by_indices[NUM_BY_PARTS];
+    short orig_data[NUM_BY_PARTS]; /**< 1 if there was data in the byrule */
 
-    short *by_ptrs[9]; /**< Pointers into the by_* array elements of the rule */
+    short *by_ptrs[NUM_BY_PARTS];  /**< Pointers into the by_* array elements of the rule */
 
 };
 
@@ -1953,7 +1955,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype rule,
     impl->by_ptrs[BY_SECOND] = impl->rule.by_second;
     impl->by_ptrs[BY_SET_POS] = impl->rule.by_set_pos;
 
-    memset(impl->orig_data, 0, 9 * sizeof(short));
+    memset(impl->orig_data, 0, NUM_BY_PARTS * sizeof(short));
 
     /* Note which by rules had data in them when the iterator was
        created. We can't use the actual by_x arrays, because the
@@ -1981,7 +1983,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype rule,
 
     /* Check if the recurrence rule is legal */
 
-    for (byrule = BY_SECOND; byrule <= BY_SET_POS; byrule++) {
+    for (byrule = 0; byrule < NUM_BY_PARTS; byrule++) {
         if (expand_map[freq].map[byrule] == ILLEGAL &&
             has_by_data(impl, byrule)) {
             ical_invalid_rrule_handling rruleHandlingSetting =

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -831,13 +831,13 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
     if (recur->rscale != 0) {
         icalmemory_append_string(&str, &str_p, &buf_sz, "RSCALE=");
         icalmemory_append_string(&str, &str_p, &buf_sz, recur->rscale);
-        icalmemory_append_char(&str, &str_p, &buf_sz, ';');
 
         if (recur->skip != ICAL_SKIP_OMIT) {
             const char *skipstr = icalrecur_skip_to_string(recur->skip);
             icalmemory_append_string(&str, &str_p, &buf_sz, ";SKIP=");
             icalmemory_append_string(&str, &str_p, &buf_sz, skipstr);
         }
+        icalmemory_append_char(&str, &str_p, &buf_sz, ';');
     }
 
     icalmemory_append_string(&str, &str_p, &buf_sz, "FREQ=");

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -200,6 +200,25 @@ struct icalrecurrencetype
     icalrecurrencetype_skip skip;
 };
 
+#define ICALRECURRENCETYPE_INITIALIZER {                    \
+    ICAL_NO_RECURRENCE,                  /* freq         */ \
+    ICALTIMETYPE_INITIALIZER,            /* until        */ \
+    0,                                   /* count        */ \
+    1,                                   /* interval     */ \
+    ICAL_MONDAY_WEEKDAY,                 /* week_start   */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_second    */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_minute    */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_hour      */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_day       */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_month_day */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_year_day  */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_week_no   */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_month     */ \
+    { ICAL_RECURRENCE_ARRAY_MAX_BYTE },  /* by_set_pos   */ \
+    NULL,                                /* rscale       */ \
+    ICAL_SKIP_OMIT                       /* skip         */ \
+}
+
 LIBICAL_ICAL_EXPORT int icalrecurrencetype_rscale_is_supported(void);
 
 LIBICAL_ICAL_EXPORT icalarray *icalrecurrencetype_rscale_supported_calendars(void);

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -119,6 +119,8 @@ struct icaltimetype
 
 typedef struct icaltimetype icaltimetype;
 
+#define ICALTIMETYPE_INITIALIZER { 0, 0, 0, 0, 0, 0, 0, 0, 0}
+
 /**     @brief Constructor.
  *
  *      @returns A null time, which indicates no time has been set.

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -563,7 +563,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
     if (num_trans == 0) {
         // Add one transition using time type 0 at 19011213T204552Z
-        transitions[0] = INT_MIN;
+        transitions[0] = (time_t)INT_MIN;
         trans_idx[0] = 0;
         num_trans = 1;
     } else {
@@ -757,7 +757,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     idx = 0;  // time type 0 is always time prior to first transition
 
     for (i = 0; i < num_trans; i++) {
-        int by_day;
+        int by_day = 0;
         time_t start;
         enum icalrecurrencetype_weekday dow;
 
@@ -790,7 +790,8 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             // Check if the zone name or either of the offsets have changed
             if (types[prev_idx].gmtoff != zone->gmtoff_from ||
                 types[idx].gmtoff      != zone->gmtoff_to   ||
-                strcmp(types[idx].zname, zone->name)) {
+                (types[idx].zname != NULL &&
+                 strcmp(types[idx].zname, zone->name))) {
 
                 zone->rdate_comp = NULL;
                 terminate = 1;

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -726,10 +726,9 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     icalproperty_set_x_name(icalprop, "X-LIC-LOCATION");
     icalcomponent_add_property(tz_comp, icalprop);
 
-    prev_idx = 0;
-    idx = trans_idx[0];
+    idx = 0;  // time type 0 is always time prior to first transition
 
-    for (i = 1; i < num_trans; i++) {
+    for (i = 0; i < num_trans; i++) {
         int last_trans = 0;
         int terminate = 0;
         int rdate = 0;

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -769,12 +769,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         start = transitions[i] + types[prev_idx].gmtoff;
 
         icaltime = icaltime_from_timet_with_zone(start, 0, NULL);
-        /* Flag this as the last transition time for the zone, if:
-           this is the last transition time overall, OR
-           this is the penultimate transition time, AND either
-           we have a TZ string for future transitions, OR
-           the last two transitions have different time types
-        */
+        // The last two transition times are DTSTART for the TZ string RRULEs
         if (tzstr && (i >= num_trans - 2)) {
             last_trans = 1;
         }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -433,17 +433,15 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     struct zone_context standard =
         { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN, LONG_MIN,
-          icaltime_null_time(), icaltime_null_time(),
+          ICALTIMETYPE_INITIALIZER, ICALTIMETYPE_INITIALIZER,
           NULL, NULL, NULL,
-          icalrecurrencetype_from_string("0"),
-          icalrecurrencetype_from_string("0")
+          ICALRECURRENCETYPE_INITIALIZER, ICALRECURRENCETYPE_INITIALIZER
         };
     struct zone_context daylight =
         { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN, LONG_MIN,
-          icaltime_null_time(), icaltime_null_time(),
+          ICALTIMETYPE_INITIALIZER, ICALTIMETYPE_INITIALIZER,
           NULL, NULL, NULL,
-          icalrecurrencetype_from_string("0"),
-          icalrecurrencetype_from_string("0")
+          ICALRECURRENCETYPE_INITIALIZER, ICALRECURRENCETYPE_INITIALIZER
         };
     struct zone_context *zone;
 
@@ -813,7 +811,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     // Add an RDATE to the previous component
                     // Remove the current component
                     struct icaldatetimeperiodtype dtp =
-                        { zone->time, icalperiodtype_null_period() };
+                        { zone->time, ICALPERIODTYPE_INITIALIZER };
 
                     icalprop = icalproperty_new_rdate(dtp);
                     icalcomponent_add_property(zone->rdate_comp, icalprop);

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -434,11 +434,13 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     struct zone_context standard =
         { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
-          NULL, NULL, NULL, {}, {} };
+          NULL, NULL, NULL,
+          { .freq = ICAL_NO_RECURRENCE }, { .freq = ICAL_NO_RECURRENCE } };
     struct zone_context daylight =
         { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
-          NULL, NULL, NULL, {}, {} };
+          NULL, NULL, NULL,
+          { .freq = ICAL_NO_RECURRENCE }, { .freq = ICAL_NO_RECURRENCE } };
     struct zone_context *zone;
 
     if (icaltimezone_get_builtin_tzdata()) {

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -396,6 +396,7 @@ struct zone_context {
     icaltimetype time;
     icaltimetype prev_time;
 
+    icalcomponent *rdate_comp;
     icalcomponent *rrule_comp;
     icalproperty *rrule_prop;
     struct icalrecurrencetype recur;
@@ -433,11 +434,11 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     struct zone_context standard =
         { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
-          NULL, NULL, {}, {} };
+          NULL, NULL, NULL, {}, {} };
     struct zone_context daylight =
         { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
-          NULL, NULL, {}, {} };
+          NULL, NULL, NULL, {}, {} };
     struct zone_context *zone;
 
     if (icaltimezone_get_builtin_tzdata()) {
@@ -716,6 +717,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     for (i = 1; i < num_trans; i++) {
         int last_trans = 0;
         int terminate = 0;
+        int rdate = 0;
         int by_day;
         time_t start;
 
@@ -767,13 +769,13 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     zone->recur.by_day[0] = ICAL_RECURRENCE_ARRAY_MAX;
                 }
                 else {
-                    // Different BYDAY and BYMONTHDAY
-                    terminate = 1;
+                    // Different BYDAY and BYMONTHDAY - possible RDATE
+                    rdate = terminate = 1;
                 }
             }
             else {
-                // Different recurrence pattern entirely
-                terminate = 1;
+                // Different recurrence pattern entirely - possible RDATE
+                rdate = terminate = 1;
             }
 
             if (terminate) {
@@ -787,12 +789,30 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                             
                     zone->recur.until = zone->time;
                     icalproperty_set_rrule(zone->rrule_prop, zone->recur);
+
+                    zone->rdate_comp = NULL;
+                }
+                else if (rdate && zone->rdate_comp) {
+                    // Add an RDATE to the previous component
+                    // Remove the current component
+                    struct icaldatetimeperiodtype dtp =
+                        { zone->time, icalperiodtype_null_period() };
+
+                    icalprop = icalproperty_new_rdate(dtp);
+                    icalcomponent_add_property(zone->rdate_comp, icalprop);
+
+                    icalcomponent_remove_component(tz_comp, zone->rrule_comp);
+                    icalcomponent_free(zone->rrule_comp);
                 }
                 else {
                     // Remove the RRULE from the previous component
                     icalcomponent_remove_property(zone->rrule_comp,
                                                   zone->rrule_prop);
                     icalproperty_free(zone->rrule_prop);
+
+                    if (rdate) {
+                        zone->rdate_comp = zone->rrule_comp;
+                    }
                 }
 
                 zone->rrule_comp = NULL;

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -257,6 +257,125 @@ static int calculate_pos(icaltimetype icaltime)
    return r_pos[pos];
 }
 
+static char *parse_posix_zone(char *p, ttinfo *type)
+{
+    size_t size;
+
+    /* Zone name */
+    if (*p == '<') {
+        /* Alphanumeric, '-', or '+' */
+        size = strcspn(++p, ">");
+    }
+    else {
+        /* Alpha ONLY */
+        size = strcspn(p, "-+0123456789,\n");
+    }
+
+    type->zname = (char *) malloc(size + 1);
+    strncpy(type->zname, p, size);
+    type->zname[size] = '\0';
+    p += size;
+
+    if (*p == '>') p++;
+
+    if (*p == ',') return p;
+
+    /* Zone offset: hh[:mm[:ss]] */
+    type->gmtoff = strtol(p, &p, 10) * -3600;  /* sign of offset is reversed */
+    if (*p == ':') type->gmtoff += strtol(++p, &p, 10) * 60;
+    if (*p == ':') type->gmtoff += strtol(++p, &p, 10);
+
+    return p;
+}
+
+static char *parse_posix_rule(char *p,
+                              struct icalrecurrencetype *recur, icaltimetype *t)
+{
+    int month = 0, monthday = 0, week = 0, day;
+
+    /* Parse date */
+    if (*p == 'J') {
+        /* The Julian day n (1 <= n <= 365).
+           Leap days shall not be counted. That is, in all years,
+           including leap years, February 28 is day 59 and March 1 is day 60.
+           It is impossible to refer explicitly to the occasional February 29.
+        */
+        day = strtol(++p, &p, 10);
+    }
+    else if (*p == 'M') {
+        /* The d'th day (0 <= d <= 6)
+           of week n of month m of the year (1 <= n <= 5, 1 <= m <= 12,
+           where week 5 means "the last d day in month m"
+           which may occur in either the fourth or the fifth week).
+           Week 1 is the first week in which the d'th day occurs.
+           Day zero is Sunday.
+        */
+        month = strtol(++p, &p, 10);
+        week = strtol(++p, &p, 10);
+        day = strtol(++p, &p, 10);
+        if (week == 5) week = -1;
+    }
+    else {
+        /* The zero-based Julian day (0 <= n <= 365).
+           Leap days shall be counted, and it is possible to refer to February 29. 
+        */
+        /* XXX  Currently not used by any zone */
+    }
+
+    /* Parse time */
+    *t = icaltime_null_time();
+    t->hour = 2;  /* default is 02:00 */
+
+    if (*p == '/') {
+        t->hour = strtol(++p, &p, 10);
+        if (*p == ':') t->minute = strtol(++p, &p, 10);
+        if (*p == ':') t->second = strtol(++p, &p, 10);
+    }
+
+    /* Do adjustments for extended TZ strings */
+    if (t->hour < 0 || t->hour > 23) {
+        int days_adjust = t->hour / 24;
+
+        t->hour %= 24;
+        day += days_adjust;
+
+        if (t->hour < 0) {
+            t->hour += 24;
+            day += 6;
+        }
+        if (month) {
+            if (week == -1) {
+                monthday = icaltime_days_in_month(month, -1) + days_adjust - 7;
+            }
+            else {
+                monthday = 1 + (week - 1) * 7 + days_adjust;
+            }
+            week = 0;
+        }
+    }
+
+    /* Create rule */
+    icalrecurrencetype_clear(recur);
+    recur->freq = ICAL_YEARLY_RECURRENCE;
+
+    if (month) {
+        recur->by_day[0] = icalrecurrencetype_encode_day((day % 7) + 1, week);
+        recur->by_month[0] = month;
+
+        if (monthday) {
+            unsigned i;
+            for (i = 0; i < 7; i++) {
+                recur->by_month_day[i] = monthday++;
+            }
+        }
+    }
+    else {
+        recur->by_year_day[0] = day;
+    }
+
+    return p;
+}
+ 
 icalcomponent *icaltzutil_fetch_timezone(const char *location)
 {
     tzinfo header;
@@ -278,12 +397,16 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     leap *leaps = NULL;
     char *tzid = NULL;
 
+    char footer[100], *tzstr = NULL;
+
     int idx, prev_idx;
     icalcomponent *tz_comp = NULL, *comp = NULL;
     icalproperty *icalprop;
     icaltimetype icaltime;
     struct icalrecurrencetype standard_recur;
     struct icalrecurrencetype daylight_recur;
+    struct icalrecurrencetype final_standard_recur;
+    struct icalrecurrencetype final_daylight_recur;
     icaltimetype prev_standard_time = icaltime_null_time();
     icaltimetype prev_daylight_time = icaltime_null_time();
     icaltimetype prev_prev_standard_time;
@@ -373,7 +496,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     /* read data block */
     if (num_trans > 0) {
-        transitions = calloc(num_trans, sizeof(time_t));
+        transitions = calloc(num_trans+1, sizeof(time_t));  // +1 for TZ string
         if (transitions == NULL) {
             icalerror_set_errno(ICAL_NEWFAILED_ERROR);
             goto error;
@@ -389,7 +512,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
     EFREAD(r_trans, (size_t)trans_size, num_trans, f);
     temp = r_trans;
-    trans_idx = calloc(num_trans, sizeof(int));
+    trans_idx = calloc(num_trans+1, sizeof(int));  // +1 for TZ string
     if (trans_idx == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -405,7 +528,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
     r_trans = temp;
 
-    types = calloc(num_types, sizeof(ttinfo));
+    types = calloc(num_types+2, sizeof(ttinfo));  // +2 for TZ string
     if (types == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -471,16 +594,84 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         types[i++].isgmt = 0;
     }
 
-    if (trans_size == 8) {
-        /* XXX  Do we need/want to read and use the footer? */
-    }
-
-    /* Read all the contents now */
-
     for (i = 0; i < num_types; i++) {
         /* coverity[tainted_data] */
         types[i].zname = zname_from_stridx(znames, types[i].abbr);
     }
+
+    /* Read the footer */
+    if (trans_size == 8 &&
+        (footer[0] = fgetc(f)) == '\n' &&
+        fgets(footer+1, sizeof(footer)-1, f) &&
+        footer[strlen(footer)-1] == '\n') {
+        tzstr = footer+1;
+    }
+    if (tzstr) {
+        /* Parse the TZ string:
+           stdoffset[dst[offset][,start[/time],end[/time]]]
+        */
+        ttinfo *std_type = &types[num_types++];
+        ttinfo *dst_type = &types[num_types++];
+        char *p = tzstr;
+
+        /* Parse standard zone */
+        p = parse_posix_zone(p, std_type);
+        if (*p == '\n') {
+            /* No DST, so ignore the TZ string */
+            tzstr = NULL;
+        }
+        else {
+            /* Parse DST zone */
+            dst_type->isdst = 1;
+            dst_type->gmtoff = std_type->gmtoff + 3600;  /* default is +1hr */
+            p = parse_posix_zone(p, dst_type);
+
+            if (*p != ',') {
+                /* No rule, so ignore the TZ string */
+                tzstr = NULL;
+            }
+            else {
+                struct icaltimetype std_trans, dst_trans, last_trans;
+                icalrecur_iterator *iter;
+
+                /* Parse std->dst rule */
+                p = parse_posix_rule(++p /* skip ',' */,
+                                     &final_daylight_recur, &dst_trans);
+
+                /* Parse dst->std rule */
+                p = parse_posix_rule(++p /* skip ',' */,
+                                     &final_standard_recur, &std_trans);
+
+                last_trans = icaltime_from_timet_with_zone(transitions[num_trans-1], 0, NULL);
+                if (types[trans_idx[num_trans-1]].isdst) {
+                    /* Add next dst->std transition */
+                    std_trans.year  = last_trans.year;
+                    std_trans.month = last_trans.month;
+                    std_trans.day   = last_trans.day;
+                    iter = icalrecur_iterator_new(final_standard_recur, std_trans);
+                    std_trans = icalrecur_iterator_next(iter);
+                    icaltime_adjust(&std_trans, 0, 0, 0, -dst_type->gmtoff);
+                    transitions[num_trans] = icaltime_as_timet(std_trans);
+                    trans_idx[num_trans++] = num_types-2;
+                    icalrecur_iterator_free(iter);
+                }
+                else {
+                    /* Add next std->dst transition */
+                    dst_trans.year  = last_trans.year;
+                    dst_trans.month = last_trans.month;
+                    dst_trans.day   = last_trans.day;
+                    iter = icalrecur_iterator_new(final_daylight_recur, dst_trans);
+                    dst_trans = icalrecur_iterator_next(iter);
+                    icaltime_adjust(&dst_trans, 0, 0, 0, -std_type->gmtoff);
+                    transitions[num_trans] = icaltime_as_timet(dst_trans);
+                    trans_idx[num_trans++] = num_types-1;
+                    icalrecur_iterator_free(iter);
+                }
+            }
+        }
+    }
+
+    /* Build the VTIMEZONE now */
 
     tz_comp = icalcomponent_new(ICAL_VTIMEZONE_COMPONENT);
 
@@ -503,6 +694,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     idx = trans_idx[0];
 
     for (i = 1; i < num_trans; i++) {
+        int last_trans = 0;
         int by_day;
         int is_new_comp = 0;
         time_t start;
@@ -513,9 +705,14 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         start = transitions[i] + types[prev_idx].gmtoff;
 
         icaltime = icaltime_from_timet_with_zone(start, 0, NULL);
-        pos = calculate_pos(icaltime);
-        pos < 0 ? (sign = -1): (sign = 1);
-        by_day = sign * ((abs(pos) * 8) + icaltime_day_of_week(icaltime));
+        if (tzstr && (i >= num_trans - 2)) {
+            last_trans = 1;
+        }
+        else {
+            pos = calculate_pos(icaltime);
+            pos < 0 ? (sign = -1): (sign = 1);
+            by_day = sign * ((abs(pos) * 8) + icaltime_day_of_week(icaltime));
+        }
 
         // Figure out if the rule has changed since the previous year
         // If it has, update the recurrence rule of the current component and create a new component
@@ -525,7 +722,8 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 // Check if the pattern for daylight has changed
                 // If it has, create a new component and update UNTIL
                 // of previous component's RRULE
-                if (daylight_recur.by_month[0] != icaltime.month ||
+                if (last_trans ||
+                    daylight_recur.by_month[0] != icaltime.month ||
                     daylight_recur.by_day[0] != by_day ||
                     types[prev_idx].gmtoff != prev_daylight_gmtoff ||
                     prev_daylight_time.hour != icaltime.hour ||
@@ -561,22 +759,30 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             }
 
             comp = cur_daylight_comp;
-            recur = &daylight_recur;
-
-            if (icaltime_is_null_time(prev_daylight_time)) {
-                prev_prev_daylight_time = icaltime;
-            } else {
-                prev_prev_daylight_time = prev_daylight_time;
+            if (last_trans) {
+                /* This rule will take us into the future */
+                recur = &final_daylight_recur;
+                prev_daylight_time = icaltime_from_day_of_year(1, 9999);
             }
+            else {
+                recur = &daylight_recur;
 
-            prev_daylight_time = icaltime;
-            prev_daylight_gmtoff = types[prev_idx].gmtoff;
+                if (icaltime_is_null_time(prev_daylight_time)) {
+                    prev_prev_daylight_time = icaltime;
+                } else {
+                    prev_prev_daylight_time = prev_daylight_time;
+                }
+
+                prev_daylight_time = icaltime;
+                prev_daylight_gmtoff = types[prev_idx].gmtoff;
+            }
         } else {
             if (cur_standard_comp) {
                 // Check if the pattern for standard has changed
                 // If it has, create a new component and update UNTIL
                 // of the previous component's RRULE
-                if (standard_recur.by_month[0] != icaltime.month ||
+                if (last_trans || 
+                    standard_recur.by_month[0] != icaltime.month ||
                     standard_recur.by_day[0] != by_day ||
                     types[prev_idx].gmtoff != prev_standard_gmtoff ||
                     prev_standard_time.hour != icaltime.hour ||
@@ -610,16 +816,23 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             }
 
             comp = cur_standard_comp;
-            recur = &standard_recur;
-
-            if (icaltime_is_null_time(prev_standard_time)) {
-                prev_prev_standard_time = icaltime;
-            } else {
-                prev_prev_standard_time = prev_standard_time;
+            if (last_trans) {
+                /* This rule will take us into the future */
+                recur = &final_standard_recur;
+                prev_standard_time = icaltime_from_day_of_year(1, 9999);
             }
+            else {
+                recur = &standard_recur;
 
-            prev_standard_time = icaltime;
-            prev_standard_gmtoff = types[prev_idx].gmtoff;
+                if (icaltime_is_null_time(prev_standard_time)) {
+                    prev_prev_standard_time = icaltime;
+                } else {
+                    prev_prev_standard_time = prev_standard_time;
+                }
+
+                prev_standard_time = icaltime;
+                prev_standard_gmtoff = types[prev_idx].gmtoff;
+            }
         }
 
         if (is_new_comp) {
@@ -632,11 +845,14 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             icalprop = icalproperty_new_tzoffsetto(types[idx].gmtoff);
             icalcomponent_add_property(comp, icalprop);
 
-            // Determine the recurrence rule for the current set of changes
-            icalrecurrencetype_clear(recur);
-            recur->freq = ICAL_YEARLY_RECURRENCE;
-            recur->by_month[0] = icaltime.month;
-            recur->by_day[0] = by_day;
+            if (!last_trans) {
+                // Determine the recurrence rule for the current set of changes
+                icalrecurrencetype_clear(recur);
+                recur->freq = ICAL_YEARLY_RECURRENCE;
+                recur->by_month[0] = icaltime.month;
+                recur->by_day[0] = by_day;
+            }
+
             icalprop = icalproperty_new_rrule(*recur);
             icalcomponent_add_property(comp, icalprop);
 

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -613,7 +613,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     /* Read the footer */
     if (trans_size == 8 &&
         (footer[0] = fgetc(f)) == '\n' &&
-        fgets(footer+1, sizeof(footer)-1, f) &&
+        fgets(footer+1, (int) sizeof(footer)-1, f) &&
         footer[strlen(footer)-1] == '\n') {
         tzstr = footer+1;
     }
@@ -663,7 +663,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     std_trans = icalrecur_iterator_next(iter);
                     icaltime_adjust(&std_trans, 0, 0, 0, -dst_type->gmtoff);
                     transitions[num_trans] = icaltime_as_timet(std_trans);
-                    trans_idx[num_trans++] = num_types-2;
+                    trans_idx[num_trans++] = (int) num_types-2;
                     icalrecur_iterator_free(iter);
                 }
                 else {
@@ -675,7 +675,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     dst_trans = icalrecur_iterator_next(iter);
                     icaltime_adjust(&dst_trans, 0, 0, 0, -std_type->gmtoff);
                     transitions[num_trans] = icaltime_as_timet(dst_trans);
-                    trans_idx[num_trans++] = num_types-1;
+                    trans_idx[num_trans++] = (int) num_types-1;
                     icalrecur_iterator_free(iter);
                 }
             }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -406,13 +406,13 @@ struct zone_context {
     struct icalrecurrencetype final_recur;
 };
 
-static void terminate_rrule(struct zone_context *zone, long int gmtoff)
+static void terminate_rrule(struct zone_context *zone)
 {
     if (icaltime_compare(zone->time, zone->prev_time)) {
         // Multiple instances
         // Set UNTIL of the component's recurrence
         zone->recur.until = zone->time;
-        icaltime_adjust(&zone->recur.until, 0, 0, 0, gmtoff);
+        icaltime_adjust(&zone->recur.until, 0, 0, 0, -zone->gmtoff_from);
         zone->recur.until.zone = icaltimezone_get_utc_timezone();
 
         // Remove BYMONTHDAY if BYDAY week != 0
@@ -856,7 +856,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
             if (terminate) {
                 // Terminate the current RRULE
-                terminate_rrule(zone, -types[prev_idx].gmtoff);
+                terminate_rrule(zone);
 
                 if (rdate) {
                     if (zone->rdate_comp) {
@@ -917,10 +917,10 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     else {
         // Terminate the last recurrence rules
         if (standard.rrule_comp) {
-            terminate_rrule(&standard, -standard.gmtoff_from);
+            terminate_rrule(&standard);
         }
         if (daylight.rrule_comp) {
-            terminate_rrule(&daylight, -daylight.gmtoff_from);
+            terminate_rrule(&daylight);
         }
     }
 

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -257,31 +257,6 @@ static int calculate_pos(icaltimetype icaltime)
    return r_pos[pos];
 }
 
-static void adjust_dtstart_day_to_rrule(icalcomponent *comp, struct icalrecurrencetype rule)
-{
-    time_t now, year_start;
-    struct icaltimetype start, comp_start, iter_start, itime;
-    icalrecur_iterator *iter;
-
-    now = time(NULL);
-    itime = icaltime_from_timet_with_zone(now, 0, NULL);
-    itime.month = itime.day = 1;
-    itime.hour = itime.minute = itime.second = 0;
-    year_start = icaltime_as_timet(itime);
-
-    comp_start = icalcomponent_get_dtstart(comp);
-    start = icaltime_from_timet_with_zone(year_start, 0, NULL);
-
-    iter = icalrecur_iterator_new(rule, start);
-    iter_start = icalrecur_iterator_next(iter);
-    icalrecur_iterator_free(iter);
-
-    if (iter_start.day != comp_start.day) {
-        comp_start.day = iter_start.day;
-        icalcomponent_set_dtstart(comp, comp_start);
-    }
-}
-
 icalcomponent *icaltzutil_fetch_timezone(const char *location)
 {
     tzinfo header;
@@ -652,8 +627,6 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             } else {
                 cur_standard_rrule_property = icalprop;
             }
-
-            adjust_dtstart_day_to_rrule(comp, *recur);
 
             icalcomponent_add_component(tz_comp, comp);
         }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -810,10 +810,10 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                      icaltime.second == zone->time.second) {
 
                 if (by_day == zone->recur.by_day[0]) {
-                    // Same week and day - continue
+                    // Same nth weekday of the month - continue
                 }
                 else if (dow == icalrecurrencetype_day_day_of_week(zone->recur.by_day[0])) {
-                    // Same weekday
+                    // Same weekday in the month
                     if (icaltime.day >= zone->recur.by_month_day[0] + 7 ||
                         icaltime.day + 7 <= zone->recur.by_month_day[zone->num_monthdays-1]) {
                         // Different week - possible RDATE
@@ -841,7 +841,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     }
                 }
                 else if (icaltime.day == zone->recur.by_month_day[0]) {
-                    // Same monthday - remove BYDAY
+                    // Same day of the month - remove BYDAY
                     zone->recur.by_day[0] = ICAL_RECURRENCE_ARRAY_MAX;
                 }
                 else {

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -792,6 +792,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                      types[idx].gmtoff      != zone->gmtoff_to   ||
                      strcmp(types[idx].zname, zone->name)) {
 
+                zone->rdate_comp = NULL;
                 terminate = 1;
             }
             // Check if most of the recurrence pattern is the same

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -714,6 +714,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     for (i = 1; i < num_trans; i++) {
         int last_trans = 0;
+        int terminate = 0;
         int by_day;
         time_t start;
 
@@ -738,34 +739,48 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             zone = &standard;
         }
 
-        // Figure out if the rule has changed since the previous year
-        // If it has, update the recurrence rule of the current component and create a new component
-        // If it the current component was only valid for one year then remove the recurrence rule
         if (zone->rrule_comp) {
-            // Check if the pattern for daylight has changed
-            // If it has, create a new component and update UNTIL
-            // of previous component's RRULE
-            if (last_trans ||
-                zone->recur.by_month[0] != icaltime.month ||
-                zone->recur.by_day[0] != by_day ||
-                types[prev_idx].gmtoff != zone->gmtoff_from ||
-                zone->time.hour != icaltime.hour ||
-                zone->time.minute != icaltime.minute ||
-                zone->time.second != icaltime.second ||
-                strcmp(types[idx].zname, zone->name)) {
+            if (last_trans) {
+                terminate = 1;
+            }
+            // Check if the zone name or the offset has changed
+            else if (types[prev_idx].gmtoff != zone->gmtoff_from ||
+                     strcmp(types[idx].zname, zone->name)) {
 
+                terminate = 1;
+            }
+            // Check if most of the recurrence pattern is the same
+            else if (icaltime.month  == zone->time.month    &&
+                     icaltime.hour   == zone->time.hour     &&
+                     icaltime.minute == zone->time.minute   &&
+                     icaltime.second == zone->time.second) {
+
+                if (by_day != zone->recur.by_day[0]) {
+                    // Different BYDAY
+                    terminate = 1;
+                }
+            }
+            else {
+                // Different recurrence pattern entirely
+                terminate = 1;
+            }
+
+            if (terminate) {
+                // Terminate the current RRULE
                 if (icaltime_compare(zone->time, zone->prev_time)) {
+                    // Multiple instances
                     // Set UNTIL of the previous component's recurrence
-                    icaltime_adjust(&zone->time, 0, 0, 0, -types[prev_idx].gmtoff);
+                    icaltime_adjust(&zone->time,
+                                    0, 0, 0, -types[prev_idx].gmtoff);
                     zone->time.zone = icaltimezone_get_utc_timezone();
-
+                            
                     zone->recur.until = zone->time;
                     icalproperty_set_rrule(zone->rrule_prop, zone->recur);
                 }
                 else {
-                    // Don't set UNTIL for a single instance
-                    // Remove the RRULE
-                    icalcomponent_remove_property(zone->rrule_comp, zone->rrule_prop);
+                    // Remove the RRULE from the previous component
+                    icalcomponent_remove_property(zone->rrule_comp,
+                                                  zone->rrule_prop);
                     icalproperty_free(zone->rrule_prop);
                 }
 
@@ -780,7 +795,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         if (!zone->rrule_comp) {
             zone->name = types[idx].zname;
             zone->prev_time = icaltime;
- 
+
             zone->rrule_comp =
                 icalcomponent_vanew(zone->kind,
                                     icalproperty_new_tzname(types[idx].zname),

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -317,7 +317,7 @@ static char *parse_posix_rule(char *p,
     }
     else {
         /* The zero-based Julian day (0 <= n <= 365).
-           Leap days shall be counted, and it is possible to refer to February 29. 
+           Leap days shall be counted, and it is possible to refer to February 29.
 
            Flag this by adding 1001 to the day.
         */
@@ -435,12 +435,16 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
           NULL, NULL, NULL,
-          { .freq = ICAL_NO_RECURRENCE }, { .freq = ICAL_NO_RECURRENCE } };
+          icalrecurrencetype_from_string("0"),
+          icalrecurrencetype_from_string("0")
+        };
     struct zone_context daylight =
         { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
           NULL, NULL, NULL,
-          { .freq = ICAL_NO_RECURRENCE }, { .freq = ICAL_NO_RECURRENCE } };
+          icalrecurrencetype_from_string("0"),
+          icalrecurrencetype_from_string("0")
+        };
     struct zone_context *zone;
 
     if (icaltimezone_get_builtin_tzdata()) {
@@ -799,7 +803,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     icaltime_adjust(&zone->time,
                                     0, 0, 0, -types[prev_idx].gmtoff);
                     zone->time.zone = icaltimezone_get_utc_timezone();
-                            
+
                     zone->recur.until = zone->time;
                     icalproperty_set_rrule(zone->rrule_prop, zone->recur);
 
@@ -847,7 +851,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                                     icalproperty_new_tzoffsetfrom(types[prev_idx].gmtoff),
                                     icalproperty_new_tzoffsetto(types[idx].gmtoff),
                                     icalproperty_new_dtstart(icaltime),
-                                    NULL);
+                                    0);
             icalcomponent_add_component(tz_comp, zone->rrule_comp);
 
             if (last_trans) {

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -288,8 +288,10 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     icaltimetype prev_daylight_time = icaltime_null_time();
     icaltimetype prev_prev_standard_time;
     icaltimetype prev_prev_daylight_time;
-    long prev_standard_gmtoff = 0;
-    long prev_daylight_gmtoff = 0;
+    long prev_standard_gmtoff = LONG_MIN;
+    long prev_daylight_gmtoff = LONG_MIN;
+    const char *prev_standard_name = NULL;
+    const char *prev_daylight_name = NULL;
     icalcomponent *cur_standard_comp = NULL;
     icalcomponent *cur_daylight_comp = NULL;
     icalproperty *cur_standard_rrule_property = NULL;
@@ -521,13 +523,16 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         if (types[idx].isdst) {
             if (cur_daylight_comp) {
                 // Check if the pattern for daylight has changed
-                // If it has, create a new component and update UNTIL of previous component's RRULE
+                // If it has, create a new component and update UNTIL
+                // of previous component's RRULE
                 if (daylight_recur.by_month[0] != icaltime.month ||
-                        daylight_recur.by_day[0] != by_day ||
-                        types[prev_idx].gmtoff != prev_daylight_gmtoff ||
-                        prev_daylight_time.hour != icaltime.hour ||
-                        prev_daylight_time.minute != icaltime.minute ||
-                        prev_daylight_time.second != icaltime.second) {
+                    daylight_recur.by_day[0] != by_day ||
+                    types[prev_idx].gmtoff != prev_daylight_gmtoff ||
+                    prev_daylight_time.hour != icaltime.hour ||
+                    prev_daylight_time.minute != icaltime.minute ||
+                    prev_daylight_time.second != icaltime.second ||
+                    strcmp(types[idx].zname, prev_daylight_name)) {
+
                     if (icaltime_compare(prev_daylight_time, prev_prev_daylight_time)) {
                         // Set UNTIL of the previous component's recurrence
                         icaltime_adjust(&prev_daylight_time, 0, 0, 0, -types[prev_idx].gmtoff);
@@ -551,6 +556,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 cur_daylight_comp = icalcomponent_new(ICAL_XDAYLIGHT_COMPONENT);
                 is_new_comp = 1;
 
+                prev_daylight_name = types[idx].zname;
                 prev_daylight_time = icaltime_null_time();
             }
 
@@ -571,11 +577,13 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 // If it has, create a new component and update UNTIL
                 // of the previous component's RRULE
                 if (standard_recur.by_month[0] != icaltime.month ||
-                        standard_recur.by_day[0] != by_day ||
-                        types[prev_idx].gmtoff != prev_standard_gmtoff ||
-                        prev_standard_time.hour != icaltime.hour ||
-                        prev_standard_time.minute != icaltime.minute ||
-                        prev_standard_time.second != icaltime.second) {
+                    standard_recur.by_day[0] != by_day ||
+                    types[prev_idx].gmtoff != prev_standard_gmtoff ||
+                    prev_standard_time.hour != icaltime.hour ||
+                    prev_standard_time.minute != icaltime.minute ||
+                    prev_standard_time.second != icaltime.second ||
+                    strcmp(types[idx].zname, prev_standard_name)) {
+
                     if (icaltime_compare(prev_standard_time, prev_prev_standard_time)) {
                         icaltime_adjust(&prev_standard_time, 0, 0, 0, -types[prev_idx].gmtoff);
                         prev_standard_time.zone = icaltimezone_get_utc_timezone();
@@ -597,6 +605,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 cur_standard_comp = icalcomponent_new(ICAL_XSTANDARD_COMPONENT);
                 is_new_comp = 1;
 
+                prev_standard_name = types[idx].zname;
                 prev_standard_time = icaltime_null_time();
             }
 

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -758,8 +758,16 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                      icaltime.minute == zone->time.minute   &&
                      icaltime.second == zone->time.second) {
 
-                if (by_day != zone->recur.by_day[0]) {
-                    // Different BYDAY
+                if (by_day == zone->recur.by_day[0]) {
+                    // Same week and day - remove BYMONTHDAY
+                    zone->recur.by_month_day[0] = ICAL_RECURRENCE_ARRAY_MAX;
+                }
+                else if (icaltime.day == zone->recur.by_month_day[0]) {
+                    // Same monthday - remove BYDAY
+                    zone->recur.by_day[0] = ICAL_RECURRENCE_ARRAY_MAX;
+                }
+                else {
+                    // Different BYDAY and BYMONTHDAY
                     terminate = 1;
                 }
             }
@@ -820,6 +828,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 zone->recur.freq = ICAL_YEARLY_RECURRENCE;
                 zone->recur.by_day[0] = by_day;
                 zone->recur.by_month[0] = icaltime.month;
+                zone->recur.by_month_day[0] = icaltime.day;
                 zone->rrule_prop = icalproperty_new_rrule(zone->recur);
             }
             icalcomponent_add_property(zone->rrule_comp, zone->rrule_prop);

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -391,6 +391,7 @@ struct zone_context {
     enum icalcomponent_kind kind;
     const char *name;
     long gmtoff_from;
+    long gmtoff_to;
 
     icaltimetype time;
     icaltimetype prev_time;
@@ -430,11 +431,11 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     icaltimetype icaltime;
 
     struct zone_context standard =
-        { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN,
+        { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
           NULL, NULL, {}, {} };
     struct zone_context daylight =
-        { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN,
+        { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           icaltime_null_time(), icaltime_null_time(),
           NULL, NULL, {}, {} };
     struct zone_context *zone;
@@ -745,6 +746,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             }
             // Check if the zone name or the offset has changed
             else if (types[prev_idx].gmtoff != zone->gmtoff_from ||
+                     types[idx].gmtoff      != zone->gmtoff_to   ||
                      strcmp(types[idx].zname, zone->name)) {
 
                 terminate = 1;
@@ -791,6 +793,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         zone->prev_time = zone->time;
         zone->time = icaltime;
         zone->gmtoff_from = types[prev_idx].gmtoff;
+        zone->gmtoff_to = types[idx].gmtoff;
 
         if (!zone->rrule_comp) {
             zone->name = types[idx].zname;

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -757,9 +757,6 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     idx = 0;  // time type 0 is always time prior to first transition
 
     for (i = 0; i < num_trans; i++) {
-        int last_trans = 0;
-        int terminate = 0;
-        int rdate = 0;
         int by_day;
         time_t start;
         enum icalrecurrencetype_weekday dow;
@@ -767,16 +764,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         prev_idx = idx;
         idx = trans_idx[i];
         start = transitions[i] + types[prev_idx].gmtoff;
-
         icaltime = icaltime_from_timet_with_zone(start, 0, NULL);
-        // The last two transition times are DTSTART for the TZ string RRULEs
-        if (tzstr && (i >= num_trans - 2)) {
-            last_trans = 1;
-        }
-        else {
-            dow = icaltime_day_of_week(icaltime);
-            by_day = nth_weekday(calculate_pos(icaltime), dow);
-        }
 
         if (types[idx].isdst) {
             zone = &daylight;
@@ -785,14 +773,24 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             zone = &standard;
         }
 
+        // The last two transition times are DTSTART for the TZ string RRULEs
+        if (tzstr && (i >= num_trans - 2)) {
+            terminate_rrule(zone);
+            zone->rrule_comp = NULL;
+        }
+        else {
+            dow = icaltime_day_of_week(icaltime);
+            by_day = nth_weekday(calculate_pos(icaltime), dow);
+        }
+
         if (zone->rrule_comp) {
-            if (last_trans) {
-                terminate = 1;
-            }
-            // Check if the zone name or the offset has changed
-            else if (types[prev_idx].gmtoff != zone->gmtoff_from ||
-                     types[idx].gmtoff      != zone->gmtoff_to   ||
-                     strcmp(types[idx].zname, zone->name)) {
+            int terminate = 0;
+            int rdate = 0;
+
+            // Check if the zone name or either of the offsets have changed
+            if (types[prev_idx].gmtoff != zone->gmtoff_from ||
+                types[idx].gmtoff      != zone->gmtoff_to   ||
+                strcmp(types[idx].zname, zone->name)) {
 
                 zone->rdate_comp = NULL;
                 terminate = 1;
@@ -811,11 +809,12 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     // Same weekday in the month
                     if (icaltime.day >= zone->recur.by_month_day[0] + 7 ||
                         icaltime.day + 7 <= zone->recur.by_month_day[zone->num_monthdays-1]) {
-                        // Different week - possible RDATE
+                        // Don't allow two month days with the same weekday -
+                        // possible RDATE
                         rdate = terminate = 1;
                     }
                     else {
-                        // Insert MONTHDAY into the array
+                        // Insert day of month into the array
                         int j;
                         for (j = 0; j < zone->num_monthdays; j++) {
                             if (icaltime.day <= zone->recur.by_month_day[j]) {
@@ -831,7 +830,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                             zone->num_monthdays++;
                         }
 
-                        // Remove week from BYDAY
+                        // Remove week number from BYDAY
                         zone->recur.by_day[0] = nth_weekday(0, dow);
                     }
                 }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -752,7 +752,8 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                 terminate = 1;
             }
             // Check if most of the recurrence pattern is the same
-            else if (icaltime.month  == zone->time.month    &&
+            else if (icaltime.year   == zone->time.year + 1 &&
+                     icaltime.month  == zone->time.month    &&
                      icaltime.hour   == zone->time.hour     &&
                      icaltime.minute == zone->time.minute   &&
                      icaltime.second == zone->time.second) {

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -401,6 +401,7 @@ struct zone_context {
     icalcomponent *rdate_comp;
     icalcomponent *rrule_comp;
     icalproperty *rrule_prop;
+    short num_monthdays;
     struct icalrecurrencetype recur;
     struct icalrecurrencetype final_recur;
 };
@@ -410,10 +411,15 @@ static void terminate_rrule(struct zone_context *zone, long int gmtoff)
     if (icaltime_compare(zone->time, zone->prev_time)) {
         // Multiple instances
         // Set UNTIL of the component's recurrence
-        icaltime_adjust(&zone->time, 0, 0, 0, gmtoff);
-        zone->time.zone = icaltimezone_get_utc_timezone();
-
         zone->recur.until = zone->time;
+        icaltime_adjust(&zone->recur.until, 0, 0, 0, gmtoff);
+        zone->recur.until.zone = icaltimezone_get_utc_timezone();
+
+        // Remove BYMONTHDAY if BYDAY week != 0
+        if (icalrecurrencetype_day_position(zone->recur.by_day[0])) {
+            zone->recur.by_month_day[0] = ICAL_RECURRENCE_ARRAY_MAX;
+        }
+
         icalproperty_set_rrule(zone->rrule_prop, zone->recur);
 
         zone->rdate_comp = zone->rrule_comp = NULL;
@@ -454,13 +460,13 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     struct zone_context standard =
         { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           ICALTIMETYPE_INITIALIZER, ICALTIMETYPE_INITIALIZER,
-          NULL, NULL, NULL,
+          NULL, NULL, NULL, 0,
           ICALRECURRENCETYPE_INITIALIZER, ICALRECURRENCETYPE_INITIALIZER
         };
     struct zone_context daylight =
         { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN, LONG_MIN,
           ICALTIMETYPE_INITIALIZER, ICALTIMETYPE_INITIALIZER,
-          NULL, NULL, NULL,
+          NULL, NULL, NULL, 0,
           ICALRECURRENCETYPE_INITIALIZER, ICALRECURRENCETYPE_INITIALIZER
         };
     struct zone_context *zone;
@@ -756,6 +762,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         int rdate = 0;
         int by_day;
         time_t start;
+        enum icalrecurrencetype_weekday dow;
 
         prev_idx = idx;
         idx = trans_idx[i];
@@ -772,8 +779,8 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             last_trans = 1;
         }
         else {
-            by_day = nth_weekday(calculate_pos(icaltime),
-                                 icaltime_day_of_week(icaltime));
+            dow = icaltime_day_of_week(icaltime);
+            by_day = nth_weekday(calculate_pos(icaltime), dow);
         }
 
         if (types[idx].isdst) {
@@ -803,8 +810,35 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                      icaltime.second == zone->time.second) {
 
                 if (by_day == zone->recur.by_day[0]) {
-                    // Same week and day - remove BYMONTHDAY
-                    zone->recur.by_month_day[0] = ICAL_RECURRENCE_ARRAY_MAX;
+                    // Same week and day - continue
+                }
+                else if (dow == icalrecurrencetype_day_day_of_week(zone->recur.by_day[0])) {
+                    // Same weekday
+                    if (icaltime.day >= zone->recur.by_month_day[0] + 7 ||
+                        icaltime.day + 7 <= zone->recur.by_month_day[zone->num_monthdays-1]) {
+                        // Different week - possible RDATE
+                        rdate = terminate = 1;
+                    }
+                    else {
+                        // Insert MONTHDAY into the array
+                        int j;
+                        for (j = 0; j < zone->num_monthdays; j++) {
+                            if (icaltime.day <= zone->recur.by_month_day[j]) {
+                                break;
+                            }
+                        }
+                        if (icaltime.day < zone->recur.by_month_day[j]) {
+                            memmove(&zone->recur.by_month_day[j+1],
+                                    &zone->recur.by_month_day[j],
+                                    (zone->num_monthdays - j) *
+                                    sizeof(zone->recur.by_month_day[0]));
+                            zone->recur.by_month_day[j] = icaltime.day;
+                            zone->num_monthdays++;
+                        }
+
+                        // Remove week from BYDAY
+                        zone->recur.by_day[0] = nth_weekday(0, dow);
+                    }
                 }
                 else if (icaltime.day == zone->recur.by_month_day[0]) {
                     // Same monthday - remove BYDAY
@@ -860,6 +894,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             zone->recur.by_day[0] = by_day;
             zone->recur.by_month[0] = icaltime.month;
             zone->recur.by_month_day[0] = icaltime.day;
+            zone->num_monthdays = 1;
             zone->rrule_prop = icalproperty_new_rrule(zone->recur);
 
             zone->rrule_comp =

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -386,7 +386,21 @@ static char *parse_posix_rule(char *p,
 
     return p;
 }
- 
+
+struct zone_context {
+    enum icalcomponent_kind kind;
+    const char *name;
+    long gmtoff_from;
+
+    icaltimetype time;
+    icaltimetype prev_time;
+
+    icalcomponent *rrule_comp;
+    icalproperty *rrule_prop;
+    struct icalrecurrencetype recur;
+    struct icalrecurrencetype final_recur;
+};
+
 icalcomponent *icaltzutil_fetch_timezone(const char *location)
 {
     tzinfo header;
@@ -414,22 +428,16 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     icalcomponent *tz_comp = NULL, *comp = NULL;
     icalproperty *icalprop;
     icaltimetype icaltime;
-    struct icalrecurrencetype standard_recur;
-    struct icalrecurrencetype daylight_recur;
-    struct icalrecurrencetype final_standard_recur;
-    struct icalrecurrencetype final_daylight_recur;
-    icaltimetype prev_standard_time = icaltime_null_time();
-    icaltimetype prev_daylight_time = icaltime_null_time();
-    icaltimetype prev_prev_standard_time;
-    icaltimetype prev_prev_daylight_time;
-    long prev_standard_gmtoff = LONG_MIN;
-    long prev_daylight_gmtoff = LONG_MIN;
-    const char *prev_standard_name = NULL;
-    const char *prev_daylight_name = NULL;
-    icalcomponent *cur_standard_comp = NULL;
-    icalcomponent *cur_daylight_comp = NULL;
-    icalproperty *cur_standard_rrule_property = NULL;
-    icalproperty *cur_daylight_rrule_property = NULL;
+
+    struct zone_context standard =
+        { ICAL_XSTANDARD_COMPONENT, NULL, LONG_MIN,
+          icaltime_null_time(), icaltime_null_time(),
+          NULL, NULL, {}, {} };
+    struct zone_context daylight =
+        { ICAL_XDAYLIGHT_COMPONENT, NULL, LONG_MIN,
+          icaltime_null_time(), icaltime_null_time(),
+          NULL, NULL, {}, {} };
+    struct zone_context *zone;
 
     if (icaltimezone_get_builtin_tzdata()) {
         goto error;
@@ -647,11 +655,11 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
                 /* Parse std->dst rule */
                 p = parse_posix_rule(++p /* skip ',' */,
-                                     &final_daylight_recur, &dst_trans);
+                                     &daylight.final_recur, &dst_trans);
 
                 /* Parse dst->std rule */
                 p = parse_posix_rule(++p /* skip ',' */,
-                                     &final_standard_recur, &std_trans);
+                                     &standard.final_recur, &std_trans);
 
                 last_trans = icaltime_from_timet_with_zone(transitions[num_trans-1], 0, NULL);
                 if (types[trans_idx[num_trans-1]].isdst) {
@@ -659,7 +667,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     std_trans.year  = last_trans.year;
                     std_trans.month = last_trans.month;
                     std_trans.day   = last_trans.day;
-                    iter = icalrecur_iterator_new(final_standard_recur, std_trans);
+                    iter = icalrecur_iterator_new(standard.final_recur, std_trans);
                     std_trans = icalrecur_iterator_next(iter);
                     icaltime_adjust(&std_trans, 0, 0, 0, -dst_type->gmtoff);
                     transitions[num_trans] = icaltime_as_timet(std_trans);
@@ -671,7 +679,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
                     dst_trans.year  = last_trans.year;
                     dst_trans.month = last_trans.month;
                     dst_trans.day   = last_trans.day;
-                    iter = icalrecur_iterator_new(final_daylight_recur, dst_trans);
+                    iter = icalrecur_iterator_new(daylight.final_recur, dst_trans);
                     dst_trans = icalrecur_iterator_next(iter);
                     icaltime_adjust(&dst_trans, 0, 0, 0, -std_type->gmtoff);
                     transitions[num_trans] = icaltime_as_timet(dst_trans);
@@ -707,9 +715,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     for (i = 1; i < num_trans; i++) {
         int last_trans = 0;
         int by_day;
-        int is_new_comp = 0;
         time_t start;
-        struct icalrecurrencetype *recur;
 
         prev_idx = idx;
         idx = trans_idx[i];
@@ -725,172 +731,96 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             by_day = sign * ((abs(pos) * 8) + icaltime_day_of_week(icaltime));
         }
 
+        if (types[idx].isdst) {
+            zone = &daylight;
+        }
+        else {
+            zone = &standard;
+        }
+
         // Figure out if the rule has changed since the previous year
         // If it has, update the recurrence rule of the current component and create a new component
         // If it the current component was only valid for one year then remove the recurrence rule
-        if (types[idx].isdst) {
-            if (cur_daylight_comp) {
-                // Check if the pattern for daylight has changed
-                // If it has, create a new component and update UNTIL
-                // of previous component's RRULE
-                if (last_trans ||
-                    daylight_recur.by_month[0] != icaltime.month ||
-                    daylight_recur.by_day[0] != by_day ||
-                    types[prev_idx].gmtoff != prev_daylight_gmtoff ||
-                    prev_daylight_time.hour != icaltime.hour ||
-                    prev_daylight_time.minute != icaltime.minute ||
-                    prev_daylight_time.second != icaltime.second ||
-                    strcmp(types[idx].zname, prev_daylight_name)) {
+        if (zone->rrule_comp) {
+            // Check if the pattern for daylight has changed
+            // If it has, create a new component and update UNTIL
+            // of previous component's RRULE
+            if (last_trans ||
+                zone->recur.by_month[0] != icaltime.month ||
+                zone->recur.by_day[0] != by_day ||
+                types[prev_idx].gmtoff != zone->gmtoff_from ||
+                zone->time.hour != icaltime.hour ||
+                zone->time.minute != icaltime.minute ||
+                zone->time.second != icaltime.second ||
+                strcmp(types[idx].zname, zone->name)) {
 
-                    if (icaltime_compare(prev_daylight_time, prev_prev_daylight_time)) {
-                        // Set UNTIL of the previous component's recurrence
-                        icaltime_adjust(&prev_daylight_time, 0, 0, 0, -types[prev_idx].gmtoff);
-                        prev_daylight_time.zone = icaltimezone_get_utc_timezone();
+                if (icaltime_compare(zone->time, zone->prev_time)) {
+                    // Set UNTIL of the previous component's recurrence
+                    icaltime_adjust(&zone->time, 0, 0, 0, -types[prev_idx].gmtoff);
+                    zone->time.zone = icaltimezone_get_utc_timezone();
 
-                        daylight_recur.until = prev_daylight_time;
-                        icalproperty_set_rrule(cur_daylight_rrule_property, daylight_recur);
-                    }
-                    else {
-                        // Don't set UNTIL for a single instance
-                        // Remove the RRULE
-                        icalcomponent_remove_property(cur_daylight_comp, cur_daylight_rrule_property);
-                        icalproperty_free(cur_daylight_rrule_property);
-                    }
-
-                    cur_daylight_comp = NULL;
+                    zone->recur.until = zone->time;
+                    icalproperty_set_rrule(zone->rrule_prop, zone->recur);
                 }
-            }
-
-            if (!cur_daylight_comp) {
-                cur_daylight_comp = icalcomponent_new(ICAL_XDAYLIGHT_COMPONENT);
-                is_new_comp = 1;
-
-                prev_daylight_name = types[idx].zname;
-                prev_daylight_time = icaltime_null_time();
-            }
-
-            comp = cur_daylight_comp;
-            if (last_trans) {
-                /* This rule will take us into the future */
-                recur = &final_daylight_recur;
-                prev_daylight_time = icaltime_from_day_of_year(1, 9999);
-            }
-            else {
-                recur = &daylight_recur;
-
-                if (icaltime_is_null_time(prev_daylight_time)) {
-                    prev_prev_daylight_time = icaltime;
-                } else {
-                    prev_prev_daylight_time = prev_daylight_time;
+                else {
+                    // Don't set UNTIL for a single instance
+                    // Remove the RRULE
+                    icalcomponent_remove_property(zone->rrule_comp, zone->rrule_prop);
+                    icalproperty_free(zone->rrule_prop);
                 }
 
-                prev_daylight_time = icaltime;
-                prev_daylight_gmtoff = types[prev_idx].gmtoff;
-            }
-        } else {
-            if (cur_standard_comp) {
-                // Check if the pattern for standard has changed
-                // If it has, create a new component and update UNTIL
-                // of the previous component's RRULE
-                if (last_trans || 
-                    standard_recur.by_month[0] != icaltime.month ||
-                    standard_recur.by_day[0] != by_day ||
-                    types[prev_idx].gmtoff != prev_standard_gmtoff ||
-                    prev_standard_time.hour != icaltime.hour ||
-                    prev_standard_time.minute != icaltime.minute ||
-                    prev_standard_time.second != icaltime.second ||
-                    strcmp(types[idx].zname, prev_standard_name)) {
-
-                    if (icaltime_compare(prev_standard_time, prev_prev_standard_time)) {
-                        icaltime_adjust(&prev_standard_time, 0, 0, 0, -types[prev_idx].gmtoff);
-                        prev_standard_time.zone = icaltimezone_get_utc_timezone();
-
-                        standard_recur.until = prev_standard_time;
-                        icalproperty_set_rrule(cur_standard_rrule_property, standard_recur);
-                    }
-                    else {
-                        // Don't set UNTIL for a single instance
-                        // Remove the RRULE
-                        icalcomponent_remove_property(cur_standard_comp, cur_standard_rrule_property);
-                        icalproperty_free(cur_standard_rrule_property);
-                    }
-
-                    cur_standard_comp = NULL;
-                }
-            }
-            if (!cur_standard_comp) {
-                cur_standard_comp = icalcomponent_new(ICAL_XSTANDARD_COMPONENT);
-                is_new_comp = 1;
-
-                prev_standard_name = types[idx].zname;
-                prev_standard_time = icaltime_null_time();
-            }
-
-            comp = cur_standard_comp;
-            if (last_trans) {
-                /* This rule will take us into the future */
-                recur = &final_standard_recur;
-                prev_standard_time = icaltime_from_day_of_year(1, 9999);
-            }
-            else {
-                recur = &standard_recur;
-
-                if (icaltime_is_null_time(prev_standard_time)) {
-                    prev_prev_standard_time = icaltime;
-                } else {
-                    prev_prev_standard_time = prev_standard_time;
-                }
-
-                prev_standard_time = icaltime;
-                prev_standard_gmtoff = types[prev_idx].gmtoff;
+                zone->rrule_comp = NULL;
             }
         }
 
-        if (is_new_comp) {
-            icalprop = icalproperty_new_tzname(types[idx].zname);
-            icalcomponent_add_property(comp, icalprop);
-            icalprop = icalproperty_new_dtstart(icaltime);
-            icalcomponent_add_property(comp, icalprop);
-            icalprop = icalproperty_new_tzoffsetfrom(types[prev_idx].gmtoff);
-            icalcomponent_add_property(comp, icalprop);
-            icalprop = icalproperty_new_tzoffsetto(types[idx].gmtoff);
-            icalcomponent_add_property(comp, icalprop);
+        zone->prev_time = zone->time;
+        zone->time = icaltime;
+        zone->gmtoff_from = types[prev_idx].gmtoff;
 
-            if (!last_trans) {
-                // Determine the recurrence rule for the current set of changes
-                icalrecurrencetype_clear(recur);
-                recur->freq = ICAL_YEARLY_RECURRENCE;
-                recur->by_month[0] = icaltime.month;
-                recur->by_day[0] = by_day;
+        if (!zone->rrule_comp) {
+            zone->name = types[idx].zname;
+            zone->prev_time = icaltime;
+ 
+            zone->rrule_comp =
+                icalcomponent_vanew(zone->kind,
+                                    icalproperty_new_tzname(types[idx].zname),
+                                    icalproperty_new_tzoffsetfrom(types[prev_idx].gmtoff),
+                                    icalproperty_new_tzoffsetto(types[idx].gmtoff),
+                                    icalproperty_new_dtstart(icaltime),
+                                    NULL);
+            icalcomponent_add_component(tz_comp, zone->rrule_comp);
+
+            if (last_trans) {
+                /* This rule will take us into the future */
+                zone->time = icaltime_from_day_of_year(1, 9999);
+                zone->rrule_prop = icalproperty_new_rrule(zone->final_recur);
             }
-
-            icalprop = icalproperty_new_rrule(*recur);
-            icalcomponent_add_property(comp, icalprop);
-
-            if (types[idx].isdst) {
-                cur_daylight_rrule_property = icalprop;
-            } else {
-                cur_standard_rrule_property = icalprop;
+            else {
+                // Create a recurrence rule for the current set of changes
+                icalrecurrencetype_clear(&zone->recur);
+                zone->recur.freq = ICAL_YEARLY_RECURRENCE;
+                zone->recur.by_day[0] = by_day;
+                zone->recur.by_month[0] = icaltime.month;
+                zone->rrule_prop = icalproperty_new_rrule(zone->recur);
             }
-
-            icalcomponent_add_component(tz_comp, comp);
+            icalcomponent_add_property(zone->rrule_comp, zone->rrule_prop);
         }
     }
 
     // Check if the last daylight or standard date was before now
     // If so, set the UNTIL date to the second-to-last transition date
     // and then insert a new component to indicate the time zone doesn't transition anymore
-    if (cur_daylight_comp && icaltime_as_timet(prev_daylight_time) < now) {
-        icaltime_adjust(&prev_prev_daylight_time, 0, 0, 0, -prev_daylight_gmtoff);
-        prev_prev_daylight_time.zone = icaltimezone_get_utc_timezone();
+    if (daylight.rrule_comp && icaltime_as_timet(daylight.time) < now) {
+        icaltime_adjust(&daylight.prev_time, 0, 0, 0, -daylight.gmtoff_from);
+        daylight.prev_time.zone = icaltimezone_get_utc_timezone();
 
-        daylight_recur.until = prev_prev_daylight_time;
-        icalproperty_set_rrule(cur_daylight_rrule_property, daylight_recur);
+        daylight.recur.until = daylight.prev_time;
+        icalproperty_set_rrule(daylight.rrule_prop, daylight.recur);
 
         comp = icalcomponent_new(ICAL_XDAYLIGHT_COMPONENT);
         icalprop = icalproperty_new_tzname(types[idx].zname);
         icalcomponent_add_property(comp, icalprop);
-        icalprop = icalproperty_new_dtstart(prev_daylight_time);
+        icalprop = icalproperty_new_dtstart(daylight.time);
         icalcomponent_add_property(comp, icalprop);
         icalprop = icalproperty_new_tzoffsetfrom(types[prev_idx].gmtoff);
         icalcomponent_add_property(comp, icalprop);
@@ -899,17 +829,17 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         icalcomponent_add_component(tz_comp, comp);
     }
 
-    if (cur_standard_comp && icaltime_as_timet(prev_standard_time) < now) {
-        icaltime_adjust(&prev_prev_standard_time, 0, 0, 0, -prev_standard_gmtoff);
-        prev_prev_standard_time.zone = icaltimezone_get_utc_timezone();
+    if (standard.rrule_comp && icaltime_as_timet(standard.time) < now) {
+        icaltime_adjust(&standard.prev_time, 0, 0, 0, -standard.gmtoff_from);
+        standard.prev_time.zone = icaltimezone_get_utc_timezone();
 
-        standard_recur.until = prev_prev_standard_time;
-        icalproperty_set_rrule(cur_standard_rrule_property, standard_recur);
+        standard.recur.until = standard.prev_time;
+        icalproperty_set_rrule(standard.rrule_prop, standard.recur);
 
         comp = icalcomponent_new(ICAL_XSTANDARD_COMPONENT);
         icalprop = icalproperty_new_tzname(types[idx].zname);
         icalcomponent_add_property(comp, icalprop);
-        icalprop = icalproperty_new_dtstart(prev_standard_time);
+        icalprop = icalproperty_new_dtstart(standard.time);
         icalcomponent_add_property(comp, icalprop);
         icalprop = icalproperty_new_tzoffsetfrom(types[prev_idx].gmtoff);
         icalcomponent_add_property(comp, icalprop);

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -288,6 +288,8 @@ static char *parse_posix_zone(char *p, ttinfo *type)
     return p;
 }
 
+#define nth_weekday(week, day) (icalrecurrencetype_encode_day(day, week))
+
 static char *parse_posix_rule(char *p,
                               struct icalrecurrencetype *recur, icaltimetype *t)
 {
@@ -363,7 +365,7 @@ static char *parse_posix_rule(char *p,
     recur->freq = ICAL_YEARLY_RECURRENCE;
 
     if (month) {
-        recur->by_day[0] = icalrecurrencetype_encode_day((day % 7) + 1, week);
+        recur->by_day[0] = nth_weekday(week, (day % 7) + 1);
         recur->by_month[0] = month;
 
         if (monthday) {
@@ -409,7 +411,6 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     size_t i, num_trans, num_chars, num_leaps, num_isstd, num_isgmt;
     size_t num_types = 0;
     size_t size;
-    int pos, sign;
     time_t now = time(NULL);
     int trans_size = 4;
 
@@ -745,9 +746,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
             last_trans = 1;
         }
         else {
-            pos = calculate_pos(icaltime);
-            pos < 0 ? (sign = -1): (sign = 1);
-            by_day = sign * ((abs(pos) * 8) + icaltime_day_of_week(icaltime));
+            by_day = nth_weekday(calculate_pos(icaltime), icaltime_day_of_week(icaltime));
         }
 
         if (types[idx].isdst) {

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1415,7 +1415,7 @@ void test_recur_parameter_bug()
 {
     static const char test_icalcomp_str[] =
         "BEGIN:VEVENT\r\n"
-        "RRULE;X-EVOLUTION-ENDDATE=20030209T081500:FREQ=DAILY;COUNT=10;INTERVAL=6\r\n"
+        "RRULE;X-EVOLUTION-ENDDATE=20030209T081500:FREQ=DAILY;INTERVAL=6;COUNT=10\r\n"
         "END:VEVENT\r\n";
 
     icalcomponent *icalcomp;
@@ -2686,7 +2686,7 @@ void test_recur_parser()
     const char *str;
 
     str =
-        "FREQ=YEARLY;UNTIL=20000131T090000Z;BYDAY=-1TU,3WE,-4FR,SA,SU;BYYEARDAY=34,65,76,78;BYMONTH=1,2,3,4,8";
+        "FREQ=YEARLY;BYMONTH=1,2,3,4,8;BYYEARDAY=34,65,76,78;BYDAY=-1TU,3WE,-4FR,SA,SU;UNTIL=20000131T090000Z";
     rt = icalrecurrencetype_from_string(str);
     str_is(str, icalrecurrencetype_as_string(&rt), str);
 
@@ -2713,7 +2713,7 @@ void test_recur_parser()
     ical_set_invalid_rrule_handling_setting(ICAL_RRULE_IGNORE_INVALID);
     rt = icalrecurrencetype_from_string(str);
     str_is(str, icalrecurrencetype_as_string(&rt),
-		   "FREQ=DAILY;COUNT=3;BYDAY=-1TU,3WE,-4FR,SA,SU;BYMONTH=1,2,3,4,8");
+		   "FREQ=DAILY;BYMONTH=1,2,3,4,8;BYDAY=-1TU,3WE,-4FR,SA,SU;COUNT=3");
 
     /* Try to parse an RRULE value with UNTIL + COUNT */
     str = "FREQ=YEARLY;UNTIL=20000131T090000Z;COUNT=3";


### PR DESCRIPTION
This fixes the issue with time zones created by zic -b slim.
We need to use the TZ string to create the non-terminating standard and daylight components