### PR TITLE
Fix typos and misspellings found by CodeSpell 2.1.0.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -4,7 +4,7 @@ Allan Clark <allanc@atlas.platypus.bc.ca> for testing libical against
 UnixWare.
 
 Graham Davison <g.m.davison@computer.org> for MacOS support and
-miscelaneous code bits
+miscellaneous code bits
 
 Seth Alves <alves@hungry.com> for the first cut at the Makefile.am
 files and various utility functions.
@@ -27,7 +27,7 @@ The Evolution team at Helixcode ( Federico Mena Quintero
 <federico@helixcode.com>, JP Rosevear <jpr@helixcode.com>, Ettore
 Perazzoli <ettore@helixcode.com>, Christopher James Lahey
 <clahey@helixcode.com>, Peter Williams <peterw@helixcode.com>) for
-miscelaneous patches and adjustments to the build system.
+miscellaneous patches and adjustments to the build system.
 
 Cornelius Schumacher <schumacher@kde.org> for many insightful
 suggestions and a few patches.

--- a/TODO
+++ b/TODO
@@ -4,7 +4,7 @@ TODOs for libical
 fix Coverity Scan issues
 
 libical treats properties with multiple values incorrecty -- it always
-seperates multiple values into multiple properties. This is not
+separates multiple values into multiple properties. This is not
 acceptable for CATEGORIES and RESOURCES.
 
 Some TEXT valued properties, like METHOD, have a limited set of valid
@@ -31,7 +31,7 @@ For some value types, if there illegal characters in the value ( like
 4.56 in an integer value), the parser will output the characters to
 stdout.
 
-Check all uses of strcpy and sprinf for buffer overflows
+Check all uses of strcpy and sprintf for buffer overflows
 
 Make the mime parsing code in sspm grow the list of parts as needed,
 rather than having a hard limit.

--- a/cmake/Toolchain-iOS.cmake
+++ b/cmake/Toolchain-iOS.cmake
@@ -47,7 +47,7 @@ set (CMAKE_C_OSX_CURRENT_VERSION_FLAG "-current_version ")
 set (CMAKE_CXX_OSX_COMPATIBILITY_VERSION_FLAG "${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}")
 set (CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
 
-# Hidden visibilty is required for cxx on iOS
+# Hidden visibility is required for cxx on iOS
 set (CMAKE_C_FLAGS "")
 set (CMAKE_CXX_FLAGS "-headerpad_max_install_names -fvisibility=hidden -fvisibility-inlines-hidden")
 
@@ -98,7 +98,7 @@ if (NOT DEFINED CMAKE_IOS_SDK_ROOT)
                 list (REVERSE _CMAKE_IOS_SDKS)
                 list (GET _CMAKE_IOS_SDKS 0 CMAKE_IOS_SDK_ROOT)
         else (_CMAKE_IOS_SDKS)
-                message (FATAL_ERROR "No iOS SDK's found in default seach path ${CMAKE_IOS_DEVELOPER_ROOT}. Manually set CMAKE_IOS_SDK_ROOT or install the iOS SDK.")
+                message (FATAL_ERROR "No iOS SDKs found in default search path ${CMAKE_IOS_DEVELOPER_ROOT}. Manually set CMAKE_IOS_SDK_ROOT or install the iOS SDK.")
         endif (_CMAKE_IOS_SDKS)
         message (STATUS "Toolchain using default iOS SDK: ${CMAKE_IOS_SDK_ROOT}")
 endif (NOT DEFINED CMAKE_IOS_SDK_ROOT)

--- a/debian/changelog
+++ b/debian/changelog
@@ -15,7 +15,7 @@ libical (0.30-1) unstable; urgency=low
 [ Wilfried Goesgens ]
   * remove CDBS
   * merge into upstream libical
-  * merge in several patches roaming arround 
+  * merge in several patches roaming around
 
  -- Wilfried Goesgens <w.goesgens@outgesourced.org>  Wed, 30 Nov 2007 12:19:06 +0100
 

--- a/design-data/parameters.csv
+++ b/design-data/parameters.csv
@@ -38,7 +38,7 @@
 "LOCALIZE","17","const char*",
 "OPTIONS","19","const char*",
 "NO","32",,
-"#In practice any unknown paramater that is not an xparam is treated as an ianaparam"
+"#In practice any unknown parameter that is not an xparam is treated as an ianaparam"
 "IANA","33","const char*",
 "ANY","0",,
 "#VPOLL Parameters","draft-york-vpoll","PUBLIC-COMMENT and RESPONSE are deprecated"

--- a/design-data/status.txt
+++ b/design-data/status.txt
@@ -2,7 +2,7 @@
 2.0.1 STARTSENDATA Start ICAL input; end with <CRLF>.<CRLF>
 2.0.11 OKDATAFOLLOWS The request was processed successfully. Reply data follows on the next line and terminates with <CRLF>.<CRLF>
 2.0.2 REPLYPENDING A timeout has occurred. The server is still working on the reply. Use CONTINUE to continue waiting for the reply or ABORT to terminate the command.
-2.0.3 ABORTED The  command currently underway was successsfully aborted.
+2.0.3 ABORTED The  command currently underway was successfully aborted.
 2.0.4 WILLATTEMPT The specified Calendar is not here but an attempt will be made to deliver the request or reply to the Calendar anyway.
 2.0.5 TRUSTEDWILLQUEUE The request or reply will be queued and delivered to the target calendar when its iRIP server contacts this server and issues the SWITCH command. 
 2.0.6 WILLATTEMPT The specified Calendar is not here but an attempt will be made to deliver the request or reply to the Calendar anyway. 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,7 +15,7 @@ set_package_properties(Doxygen PROPERTIES
   TYPE OPTIONAL
   DESCRIPTION "API Documentation system"
   URL "http://www.doxygen.org"
-  PURPOSE "Needed to build the API documention."
+  PURPOSE "Needed to build the API documentation."
 )
 if(DOXYGEN_FOUND)
   file(GLOB _dox_deps *.dox *.html)

--- a/doc/UsingLibical.md
+++ b/doc/UsingLibical.md
@@ -167,8 +167,8 @@ errors and component usage errors.
 
 #### 3.2.4 Memory Management
 
-Since many of libicals interfaces return strings, the library has its
-own memory management system to elimiate the need to free every string
+Since many of libical's interfaces return strings, the library has its
+own memory management system to eliminate the need to free every string
 returned from the library.
 
 #### 3.2.5 Storage classes
@@ -395,7 +395,7 @@ icalparser_set_gen_data(
 
 These routines will construct a parser object to which you can add
 lines of input and retrieve any components that the parser creates
-from the input. These routines work by specifing an adaptor routine
+from the input. These routines work by specifying an adaptor routine
 to get string data from a source. For example:
 
 ```c
@@ -562,7 +562,7 @@ for(c = icalcomponent_get_first_component(comp, ICAL_ANY_COMPONENT);
 }
 ```
 
-This code bit wil iterate through all of the subcomponents in `comp`
+This code bit will iterate through all of the subcomponents in `comp`
 but you can select a specific type of component by changing `ICAL_ANY_COMPONENT`
 to another component type.
 
@@ -859,7 +859,7 @@ hold the broken-out
 time values. The `is_utc` field distinguishes between times in UTC and
 a local time zone. The `is_date` field indicates if the time should
 be interpreted only as a date. If it is a date, the hour, minute and
-second fields are assumed to be zero, regardless of their actual vaules.
+second fields are assumed to be zero, regardless of their actual values.
 
 #### 5.3.2 Creating time structures
 
@@ -884,8 +884,8 @@ struct icaltimetype tt = icaltime_from_string("19970101T103000");
 `icaltime_from_timet_with_zone()` takes a `time_t` value, representing seconds past
 the POSIX epoch, a flag to indicate if the time is a date, and a time zone.
 Dates have an identical structure to a time, but the time portion (hours,
-minuts and seconds) is always 00:00:00. Dates act differently in
-sorting and comparision, and they have a different string representation
+minutes and seconds) is always 00:00:00. Dates act differently in
+sorting and comparison, and they have a different string representation
 in [RFC5545][].
 
 #### 5.3.3 Time manipulating routines
@@ -1009,11 +1009,11 @@ struct icaltimetype icaltime_as_local(
 The libical distribution includes a separate library, libicalss, that
 allows you to store iCal component data to disk in a variety of ways.
 
-The file storage routines are organized in an inheritance heirarchy
+The file storage routines are organized in an inheritance hierarchy
 that is rooted in icalset, with the derived class icalfileset and
 icaldirset. Icalfileset stores components to a file, while icaldirset
 stores components to multiple files, one per month based on DTSTAMP.
-Other storages classess, for storage to a heap or a mysql database
+Other storages classes, for storage to a heap or a mysql database
 for example, could be added in the future.
 
 All of the icalset derived classes have the same interface:
@@ -1110,14 +1110,14 @@ icalfileset* icalfileset_new_open(
 
 `icalset_new_file()` is identical to `icalfileset_new()`. Both routines will
 open an existing file for readinga and writing, or create a new file
-if it does not exist. `icalfilset_new_open()` takes the same arguments
+if it does not exist. `icalfileset_new_open()` takes the same arguments
 as the open() system routine and behaves in the same way.
 
-The icalset and icalfilset objects are somewhat interchangable -- you
+The icalset and icalfileset objects are somewhat interchangeable -- you
 can use an `icalfileset*` as an argument to any of the icalset routines.
 
 The following examples will all use icalfileset routines; using the
-other icalset derived classess will be similar.
+other icalset derived classes will be similar.
 
 #### 5.4.2 Adding, Finding and Removing Components
 
@@ -1129,8 +1129,8 @@ icalerrorenum icalfileset_add_component(
     icalcomponent* child);
 ```
 
-The fileset keeps an inmemory copy of the components, and this set
-must be written back to the file ocassionally. There are two routines
+The fileset keeps an in-memory copy of the components, and this set
+must be written back to the file occasionally. There are two routines
 to manage this:
 
 ```c
@@ -1326,7 +1326,7 @@ RFC5545.
 There are a few routines to manipulate error properties:
 
 [ The following data is supposed to be in a table. It looks OK in LyX,
-but does not format propertly in output. ]
+but does not format properly in output. ]
 
 +-------------------------------------+---------------------------------------------------------+
 | Routine                             | Purpose                                                 |

--- a/doc/UsingLibical.txt
+++ b/doc/UsingLibical.txt
@@ -180,8 +180,8 @@ errors and component usage errors.
 
 3.2.4 Memory Management
 
-Since many of libicals interfaces return strings, the library has its
-own memory management system to elimiate the need to free every string
+Since many of libical's interfaces return strings, the library has its
+own memory management system to eliminate the need to free every string
 returned from the library.
 
 3.2.5 Storage classes
@@ -418,7 +418,7 @@ icalparser_set_gen_data(parser,stream)
 
 These routines will construct a parser object to which you can add
 lines of input and retrieve any components that the parser creates
-from the input. These routines work by specifing an adaptor routine
+from the input. These routines work by specifying an adaptor routine
 to get string data from a source. For an example:
 
 char* read_stream(char *s, size_t size, void *d)
@@ -559,7 +559,7 @@ iterate through all of a components subcomponents
 
 }
 
-This code bit wil iterate through all of the subcomponents in 'comp'
+This code bit will iterate through all of the subcomponents in 'comp'
 but you can select a specific type of component by changing ICAL_ANY_COMPONENT
 to another component type.
 
@@ -844,7 +844,7 @@ struct icaltimetype {
 The year, month, day, hour, minute and second fields hold the broken-out
 time values. The is_date field indicates if the time should
 be interpreted only as a date. If it is a date, the hour, minute and
-second fields are assumed to be zero, regardless of their actual vaules.
+second fields are assumed to be zero, regardless of their actual values.
 
 5.3.2 Creating time structures
 
@@ -863,8 +863,8 @@ struct icaltimetype tt = icaltime_from_string("19970101T103000");
 icaltime_from_timet_with_zone takes a time_t value, representing seconds past
 the POSIX epoch, a flag to indicate if the time is a date, and a time zone.
 Dates have an identical structure to a time, but the time portion (hours,
-minuts and seconds) is always 00:00:00. Dates act differently in
-sorting and comparision, and they have a different string representation
+minutes and seconds) is always 00:00:00. Dates act differently in
+sorting and comparison, and they have a different string representation
 in RFC5545.
 
 5.3.3 Time manipulating routines
@@ -953,11 +953,11 @@ struct icaltimetype icaltime_as_local(struct icaltimetype tt);
 The libical distribution includes a separate library, libicalss, that
 allows you to store iCal component data to disk in a variety of ways.
 
-The file storage routines are organized in an inheritance heirarchy
+The file storage routines are organized in an inheritance hierarchy
 that is rooted in icalset, with the derived class icalfileset and
 icaldirset. Icalfileset stores components to a file, while icaldirset
 stores components to multiple files, one per month based on DTSTAMP.
-Other storages classess, for storage to a heap or a mysql database
+Other storages classes, for storage to a heap or a mysql database
 for example, could be added in the future.
 
 All of the icalset derived classes have the same interface:
@@ -1023,14 +1023,14 @@ icalfileset* icalfileset_new_open(const char* path, int flags, int mode);
 
 icalset_new_file is identical to icalfileset_new. Both routines will
 open an existing file for readinga and writing, or create a new file
-if it does not exist. Icalfilset_new_open takes the same arguments
+if it does not exist. Icalfileset_new_open takes the same arguments
 as the open() system routine and behaves in the same way.
 
-The icalset and icalfilset objects are somewhat interchangable -- you
+The icalset and icalfileset objects are somewhat interchangeable -- you
 can use an icalfileset* as an argument to any of the icalset routines.
 
 The following examples will all use icalfileset routines; using the
-other icalset derived classess will be similar.
+other icalset derived classes will be similar.
 
 5.4.2 Adding, Finding and Removing Components
 
@@ -1039,8 +1039,8 @@ To add components to a set, use:
 icalerrorenum icalfileset_add_component(icalfileset* cluster, icalcomponent*
 child);
 
-The fileset keeps an inmemory copy of the components, and this set
-must be written back to the file ocassionally. There are two routines
+The fileset keeps an in-memory copy of the components, and this set
+must be written back to the file occasionally. There are two routines
 to manage this:
 
 void icalfileset_mark(icalfileset* cluster);
@@ -1243,7 +1243,7 @@ RFC5545.
 There are a few routines to manipulate error properties:
 
 [ The following data is supposed to be in a table. It looks OK in LyX,
-but does not format propertly in output. ]
+but does not format properly in output. ]
 
 +-------------------------------------+---------------------------------------------------------+
 | Routine                             | Purpose                                                 |

--- a/examples/access_components.c
+++ b/examples/access_components.c
@@ -17,7 +17,7 @@ void do_something(icalcomponent *c);
    style is show in create_new_component()
 
    The second variation uses vargs lists to nest many primitive part
-   constructors, resulting in a compact, neatly formated way to create
+   constructors, resulting in a compact, neatly formatted way to create
    components. This style is shown in create_new_component_with_va_args()
 
 
@@ -49,7 +49,7 @@ icalcomponent* create_new_component()
        of that class. So, icalcomponent_ functions will all take
        icalcomponent* as their first argument. */
 
-    /* The next call creates a new proeprty and immediately adds it to the
+    /* The next call creates a new property and immediately adds it to the
        'calendar' component. */
 
     icalcomponent_add_property(

--- a/examples/errors.c
+++ b/examples/errors.c
@@ -57,7 +57,7 @@ void component_errors(icalcomponent *comp)
 
     /* Since there are iTIP restriction errors, it may be impossible
        to process this component as an iTIP request. In this case, the
-       X-LIC-ERROR proeprties should be expressed as REQUEST-STATUS
+       X-LIC-ERROR properties should be expressed as REQUEST-STATUS
        properties in the reply. This following routine makes this
        conversion */
 

--- a/src/Net-ICal-Libical/lib/Net/ICal/Libical.pm
+++ b/src/Net-ICal-Libical/lib/Net/ICal/Libical.pm
@@ -175,7 +175,7 @@ sub start {}
 #The return value is an instance of Time.
 
 #If the Period has a duration set, but not an end time, this
-#method will caluculate the end time from the duration.
+#method will calculate the end time from the duration.
 sub end {}
 
 #Return or set the duration of the period. The duration may be

--- a/src/Net-ICal-Libical/lib/Net/ICal/Libical/Time.pm
+++ b/src/Net-ICal-Libical/lib/Net/ICal/Libical/Time.pm
@@ -46,7 +46,7 @@ Net::ICal::Time -- represent a time and date
 
 I<Time> represents a time, but can also hold the time zone for the
 time and indicate if the time should be treated as a date. The time
-can be constructed from a variey of formats.
+can be constructed from a variety of formats.
 
 =head1 METHODS
 
@@ -443,7 +443,7 @@ sub as_gmtime {
 
 Compare a time to this one and return -1 if the argument is earlier
 than this one, 1 if it is later, and 0 if it is the same. The routine
-does the comparision after converting the time to UTC. It converts
+does the comparison after converting the time to UTC. It converts
 floating times using the system notion of the timezone.
 
 =cut

--- a/src/Net-ICal-Libical/netical.i
+++ b/src/Net-ICal-Libical/netical.i
@@ -162,8 +162,8 @@ icalcomponent* icallangbind_get_next_component(icalcomponent *c,
 
 
 /* Returns a string that can be evaluated in perl or python to
-   generated a hash that holds the property's name, value and
-   parameters. Sep is the hash seperation string, "=>" for perl and
+   generate a hash that holds the property's name, value and
+   parameters. Sep is the hash separation string, "=>" for perl and
    ":" for python */
 const char* icallangbind_property_eval_string(icalproperty* prop, const char* sep);
 

--- a/src/java/testjni.java
+++ b/src/java/testjni.java
@@ -330,7 +330,7 @@ public class testjni
                 // AFTER the event or task start or due date, which is useless.
                 duration.setIs_neg(1);
 
-                // 2. Create a ICalTriggerType oject and set the duration on it.
+                // 2. Create a ICalTriggerType object and set the duration on it.
                 ICalTriggerType trigger = new ICalTriggerType();
                 trigger.setDuration(duration);
                 System.out.println("set trigger to duration object");

--- a/src/libical-glib/api/i-cal-array.xml
+++ b/src/libical-glib/api/i-cal-array.xml
@@ -59,7 +59,7 @@
     </method>
     <method name="i_cal_array_sort" corresponds="CUSTOM" annotation="skip" kind="others" since="1.0">
         <parameter type="ICalArray *" name="array" comment="The #ICalArray to be sorted"/>
-        <parameter type="gint (*compare)" name="(const void *, const void *)" annotation="scope call" comment="FULL: @compare: (scope call): The comapre function"/>
+        <parameter type="gint (*compare)" name="(const void *, const void *)" annotation="scope call" comment="FULL: @compare: (scope call): The compare function"/>
         <comment xml:space="preserve">Does not work right now. Sorts the @array using the sort function @compare.</comment>
         <custom>	g_return_if_fail (I_CAL_IS_ARRAY (array));
 	g_return_if_fail (array != NULL);

--- a/src/libical-glib/api/i-cal-attach.xml
+++ b/src/libical-glib/api/i-cal-attach.xml
@@ -21,7 +21,7 @@
     </method>
     <method name="i_cal_attach_new_from_data" corresponds="CUSTOM" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="data" comment="The data used to create the #ICalAttach"/>
-        <parameter type="GFunc" name="free_fn" translator="(icalattach_free_fn_t)" annotation="scope call, allow-none" comment="The function used to free the data when the create #ICalAttach is detroyed"/>
+        <parameter type="GFunc" name="free_fn" translator="(icalattach_free_fn_t)" annotation="scope call, allow-none" comment="The function used to free the data when the create #ICalAttach is destroyed"/>
         <parameter type="void *" name="free_fn_data" annotation="allow-none" comment="The userdata used for the free function @free_fn"/>
         <returns type="ICalAttach *" annotation="transfer full" comment="The newly created #ICalAttach" />
         <comment xml:space="preserve">Creates a new #ICalAttach from the data.</comment>

--- a/src/libical-glib/api/i-cal-parameter.xml
+++ b/src/libical-glib/api/i-cal-parameter.xml
@@ -36,7 +36,7 @@
         <comment xml:space="preserve">Creates a new #ICalParameter from just the value, the part after the "="</comment>
     </method>
     <method name="i_cal_parameter_free" corresponds="icalparameter_free" annotation="skip" kind="destructor" since="1.0">
-        <parameter type="ICalParameter *" name="parameter" annotation="in" comment="The #ICalParameter to be freeed"/>
+        <parameter type="ICalParameter *" name="parameter" annotation="in" comment="The #ICalParameter to be freed"/>
         <comment xml:space="preserve">Frees the native part of the ICalParameter.</comment>
     </method>
     <method name="i_cal_parameter_as_ical_string" corresponds="icalparameter_as_ical_string_r" kind="others" since="1.0">

--- a/src/libical-glib/api/i-cal-recur.xml
+++ b/src/libical-glib/api/i-cal-recur.xml
@@ -42,7 +42,7 @@
         <comment xml:space="preserve">Converts a string representation to an enum representation for the weekday.</comment>
     </method>
     <method name="i_cal_recurrence_weekday_to_string" corresponds="icalrecur_weekday_to_string" since="2.0">
-        <parameter type="ICalRecurrenceWeekday" name="kind" comment="The freqeuncy enum"/>
+        <parameter type="ICalRecurrenceWeekday" name="kind" comment="The frequency enum"/>
         <returns type="const gchar *" comment="The string representation of weekday"/>
         <comment xml:space="preserve">Converts a enum representation to a string representation for the weekday.</comment>
         </method>
@@ -52,7 +52,7 @@
         <comment xml:space="preserve">Converts a string representation to an enum representation for the frequency.</comment>
     </method>
     <method name="i_cal_recurrence_frequency_to_string" corresponds="icalrecur_freq_to_string" since="2.0">
-        <parameter type="ICalRecurrenceFrequency" name="kind" comment="The freqeuncy enum"/>
+        <parameter type="ICalRecurrenceFrequency" name="kind" comment="The frequency enum"/>
         <returns type="const gchar *" comment="The string representation of frequency"/>
         <comment xml:space="preserve">Converts a enum representation to a string representation for the frequency.</comment>
         </method>
@@ -62,7 +62,7 @@
         <comment xml:space="preserve">Converts a string representation to an enum representation for the skip.</comment>
     </method>
     <method name="i_cal_recurrence_skip_to_string" corresponds="icalrecur_skip_to_string" since="2.0">
-        <parameter type="ICalRecurrenceSkip" name="kind" comment="The freqeuncy enum"/>
+        <parameter type="ICalRecurrenceSkip" name="kind" comment="The frequency enum"/>
         <returns type="const gchar *" comment="The string representation of skip"/>
         <comment xml:space="preserve">Converts a enum representation to a string representation for the skip.</comment>
         </method>

--- a/src/libical-glib/i-cal-object.c.in
+++ b/src/libical-glib/i-cal-object.c.in
@@ -494,7 +494,7 @@ void i_cal_object_set_native_destroy_func(ICalObject *iobject, GDestroyNotify na
  * @iobject: an #ICalObject
  *
  * Obtains whether the native libical structure is a global shared memory,
- * thus should not be destroyed. This can be set only during contruction time.
+ * thus should not be destroyed. This can be set only during construction time.
  *
  * Returns: Whether the native libical structure is a global shared memory.
  *

--- a/src/libical/astime.h
+++ b/src/libical/astime.h
@@ -121,7 +121,7 @@ typedef struct ut_instant_int
  *		has been set. ( = 0 for 01 Jan 4713 B.C.)
  *
  *	output:  will set all the other elements of the structure.
- *		As a convienence, the function will also return the year.
+ *		As a convenience, the function will also return the year.
  *
  *	Reference: Astronomial formulae for calculators, meeus, p 23
  *	from fortran program by F. Espenak - April 1982 Page 277,

--- a/src/libical/caldate.c
+++ b/src/libical/caldate.c
@@ -73,7 +73,7 @@
  *		has been set. ( = 0 for 01 Jan 4713 B.C. 12 HR UT )
  *
  *	Output:  will set all the other elements of the structure.
- *		As a convienence, the function will also return the year.
+ *		As a convenience, the function will also return the year.
  *
  *	Reference: Astronomial formulae for calculators, meeus, p 23
  *	from fortran program by F. Espenak - April 1982 Page 277,

--- a/src/libical/icalarray.h
+++ b/src/libical/icalarray.h
@@ -173,7 +173,7 @@ LIBICAL_ICAL_EXPORT void icalarray_append(icalarray *array, const void *element)
  *
  * @par Error handling
  * If @a array is `NULL`, using this function results in undefined behaviour.
- * If the array is empty, using this functino results in undefined behaviour.
+ * If the array is empty, using this function results in undefined behaviour.
  * If the @a position is non-existent, it removes the last element.
  *
  * ### Usage

--- a/src/libical/icalduration.h
+++ b/src/libical/icalduration.h
@@ -69,7 +69,7 @@ LIBICAL_ICAL_EXPORT struct icaldurationtype icaldurationtype_from_int(int t);
  *
  * @par Error handling
  * When given bad input, it sets ::icalerrno to ::ICAL_MALFORMEDDATA_ERROR and
- * returnes icaldurationtype_bad_duration().
+ * returns icaldurationtype_bad_duration().
  *
  * ### Usage
  * ```c

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -403,7 +403,7 @@ static char *parser_get_next_value(char *line, char **end, icalvalue_kind kind)
 
         next = parser_get_next_char(',', p, 1);
 
-        /* Unforunately, RFC2445 allowed that for the RECUR value, COMMA
+        /* Unfortunately, RFC2445 allowed that for the RECUR value, COMMA
            could both separate digits in a list, and it could separate
            multiple recurrence specifications. This is not a friendly
            part of the spec and was deprecated in RFC5545. The following
@@ -922,7 +922,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
 
                 if (name_heap == 0) {
                     /* 'tail' defined above */
-                    insert_error(parser, tail, str, "Cant parse parameter name",
+                    insert_error(parser, tail, str, "Can't parse parameter name",
                                  ICAL_XLICERRORTYPE_PARAMETERNAMEPARSEERROR);
                     tail = 0;
                     break;
@@ -1033,7 +1033,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
                 /* Change for mozilla */
                 /* have the option of being flexible towards unsupported parameters */
 #if ICAL_ERRORS_ARE_FATAL == 1
-                insert_error(parser, tail, str, "Cant parse parameter name",
+                insert_error(parser, tail, str, "Can't parse parameter name",
                              ICAL_XLICERRORTYPE_PARAMETERNAMEPARSEERROR);
                 tail = 0;
                 parser->state = ICALPARSER_ERROR;
@@ -1075,7 +1075,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
 
             if (param == 0) {
                 /* 'tail' defined above */
-                insert_error(parser, tail, str, "Cant parse parameter value",
+                insert_error(parser, tail, str, "Can't parse parameter value",
                              ICAL_XLICERRORTYPE_PARAMETERVALUEPARSEERROR);
 
                 tail = 0;

--- a/src/libical/icalperiod.h
+++ b/src/libical/icalperiod.h
@@ -50,7 +50,7 @@ struct icalperiodtype
 /**
  * @brief Constructs a new ::icalperiodtype from @a str
  * @param str The string from which to construct a time period
- * @return An ::icalperiodtype representing the peroid @a str
+ * @return An ::icalperiodtype representing the period @a str
  * @sa icaltime_from_string(), icaldurationtype_from_string()
  *
  * @par Error handling

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -85,7 +85,7 @@
 #include <time.h>
 
 /* An opaque struct representing a timezone. We declare this here to avoid
-   a circular dependancy. */
+   a circular dependency. */
 #if !defined(ICALTIMEZONE_DEFINED)
 #define ICALTIMEZONE_DEFINED
 typedef struct _icaltimezone icaltimezone;
@@ -173,7 +173,7 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_timet_with_zone(const time
                                                                       const int is_date,
                                                                       const icaltimezone *zone);
 
-/**     @brief Contructor.
+/**     @brief Constructor.
  *
  * Creates a time from an ISO format string.
  *
@@ -184,7 +184,7 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_timet_with_zone(const time
  */
 LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_string(const char *str);
 
-/**     @brief Contructor.
+/**     @brief Constructor.
  *
  *      Creates a new time, given a day of year and a year.
  *

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -1594,7 +1594,7 @@ static int fetch_lat_long_from_string(const char *str,
     size_t len;
     char *sptr, *lat, *lon, *loc, *temp;
 
-    /* We need to parse the latitude/longitude co-ordinates and location fields  */
+    /* We need to parse the latitude/longitude coordinates and location fields  */
     sptr = (char *)str;
     while ((*sptr != '\t') && (*sptr != '\0')) {
         sptr++;

--- a/src/libical/icaltimezone.h
+++ b/src/libical/icaltimezone.h
@@ -31,7 +31,7 @@
 #if !defined(ICALTIMEZONE_DEFINED)
 #define ICALTIMEZONE_DEFINED
 /** @brief An opaque struct representing a timezone.
- * We declare this here to avoid a circular dependancy.
+ * We declare this here to avoid a circular dependency.
  */
 typedef struct _icaltimezone icaltimezone;
 #endif

--- a/src/libical/icalvalue.h
+++ b/src/libical/icalvalue.h
@@ -85,7 +85,7 @@ LIBICAL_ICAL_EXPORT const char *icalvalue_kind_to_string(const icalvalue_kind ki
 /** Check validity of a specific icalvalue_kind **/
 LIBICAL_ICAL_EXPORT int icalvalue_kind_is_valid(const icalvalue_kind kind);
 
-/** Encode a character string in ical format, esacpe certain characters, etc. */
+/** Encode a character string in ical format, escape certain characters, etc. */
 LIBICAL_ICAL_EXPORT int icalvalue_encode_ical_string(const char *szText,
                                                      char *szEncText, int MaxBufferLen);
 

--- a/src/libical/icptrholder_cxx.h
+++ b/src/libical/icptrholder_cxx.h
@@ -5,13 +5,13 @@
  *          VComponent::get_..._component, VComponent::get_..._property,
  *          ICalProperty::get_..._value.
  *
- * @remarks VComponent::get... functions returns a C++ oject that wraps the
+ * @remarks VComponent::get... functions returns a C++ object that wraps the
  * libical implementation. It is important to note that the wrapped
  * implementation still belongs to the original component. To stop memory leak,
  * caller must delete the pointer. However, the destructor will call the
  * appropriate free function. eg. ~VComponent calls icalcomponent_free(imp).
  *
- * As stated previously, imp stil belongs to the original component. To avoid
+ * As stated previously, imp still belongs to the original component. To avoid
  * freeing the wrapped "imp", caller must set the "imp" to null before deleting
  * the pointer.
  *

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -55,7 +55,7 @@ static int pvl_list_count = 0;
 /**
   struct pvl_list_t
 
-  The list structure. This is the hanlde for the entire list
+  The list structure. This is the handle for the entire list
 
   This type is also private. Use pvl_list instead
 
@@ -109,7 +109,7 @@ void pvl_free(pvl_list l)
  * @brief Creates a new list element, assigns a magic number, and assigns
  * the next and previous pointers.
  *
- * Passing in the next and previous points may seem odd, but it allos the user
+ * Passing in the next and previous points may seem odd, but it allows the user
  * to set them while keeping the internal data hidden. In nearly all cases,
  * the user is the pvl library itself.
  *
@@ -392,7 +392,7 @@ void *pvl_remove(pvl_list L, pvl_elem E)
 /**
  * @brief Return a pointer to data that satisfies a function.
  *
- * This routine will interate through the entire list and call the
+ * This routine will iterate through the entire list and call the
  * find function for each item. It will break and return a pointer to the
  * data that causes the find function to return 1.
  *

--- a/src/libical/pvl.h
+++ b/src/libical/pvl.h
@@ -75,7 +75,7 @@ LIBICAL_ICAL_EXPORT void pvl_clear(pvl_list);   /* Remove all elements, de-alloc
 
 LIBICAL_ICAL_EXPORT int pvl_count(pvl_list);
 
-/* Navagate the list */
+/* Navigate the list */
 LIBICAL_ICAL_EXPORT pvl_elem pvl_next(pvl_elem e);
 
 LIBICAL_ICAL_EXPORT pvl_elem pvl_prior(pvl_elem e);

--- a/src/libical/sspm.c
+++ b/src/libical/sspm.c
@@ -812,7 +812,7 @@ static void sspm_make_part(struct mime_impl *impl,
             }
 
             /* add a end-of-string after the data, just in case binary
-               data from decode64 gets passed to a tring handling
+               data from decode64 gets passed to a string handling
                routine in add_line  */
             data[*size + 1] = '\0';
 

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -586,7 +586,7 @@ bool VComponent::remove(VComponent &fromVC, bool ignoreValue)
                 // recursively go down the components
                 c->remove(*comp, ignoreValue);
                 // if all properties are removed and there is no sub-components, then
-                // remove this compoent
+                // remove this component
                 if ((c->count_properties(ICAL_ANY_PROPERTY) == 0) &&
                     (c->count_components(ICAL_ANY_COMPONENT) == 0)) {
                     this->remove_component(c);

--- a/src/libicalss/icalbdbset.c
+++ b/src/libicalss/icalbdbset.c
@@ -1263,7 +1263,7 @@ icalsetiter icalbdbset_begin_component(icalset *set, icalcomponent_kind kind,
     /* if there is a gauge, the first matched component is returned */
     while (comp != 0) {
 
-        /* check if it is a recurring component and with guage expand, if so
+        /* check if it is a recurring component and with gauge expand, if so
          * we need to add recurrence-id property to the given component */
         rrule = icalcomponent_get_first_property(comp, ICAL_RRULE_PROPERTY);
         g = icalgauge_get_expand(gauge);

--- a/src/libicalss/icalbdbset_cxx.h
+++ b/src/libicalss/icalbdbset_cxx.h
@@ -58,7 +58,7 @@ namespace LibICal
         VComponent *fetch_match(icalcomponent *c);
         int has_uid(std::string &uid);
 
-        // Iterate through components. If a guage has been defined, these
+        // Iterate through components. If a gauge has been defined, these
         // will skip over components that do not pass the gauge
         VComponent *get_current_component();
         VComponent *get_first_component();

--- a/src/libicalss/icaldirset.h
+++ b/src/libicalss/icaldirset.h
@@ -33,9 +33,9 @@
   The primary interfaces are icaldirset__get_first_component and
   icaldirset_get_next_component. These routine iterate through all of
   the components in the store, subject to the current gauge. A gauge
-  is an icalcomponent that is tested against other componets for a
+  is an icalcomponent that is tested against other components for a
   match. If a gauge has been set with icaldirset_select,
-  icaldirset_first and icaldirset_next will only return componentes
+  icaldirset_first and icaldirset_next will only return components
   that match the gauge.
 
   The Store generated UIDs for all objects that are stored if they do

--- a/src/libicalss/icalfileset.c
+++ b/src/libicalss/icalfileset.c
@@ -787,7 +787,7 @@ icalsetiter icalfileset_begin_component(icalset *set, icalcomponent_kind kind, i
 
     while (comp != 0) {
 
-        /* check if it is a recurring component and with guage expand, if so
+        /* check if it is a recurring component and with gauge expand, if so
            we need to add recurrence-id property to the given component */
         rrule = icalcomponent_get_first_property(comp, ICAL_RRULE_PROPERTY);
         g = icalgauge_get_expand(gauge);

--- a/src/libicalss/icalgauge.h
+++ b/src/libicalss/icalgauge.h
@@ -50,7 +50,7 @@ LIBICAL_ICALSS_EXPORT void icalgauge_dump(icalgauge *gauge);
 /** @brief Returns true if comp matches the gauge.
  *
  * The component must be in
- * cannonical form -- a VCALENDAR with one VEVENT, VTODO or VJOURNAL
+ * canonical form -- a VCALENDAR with one VEVENT, VTODO or VJOURNAL
  * sub component
  */
 LIBICAL_ICALSS_EXPORT int icalgauge_compare(icalgauge *g, icalcomponent *comp);

--- a/src/libicalss/icalset.h
+++ b/src/libicalss/icalset.h
@@ -147,7 +147,7 @@ LIBICAL_ICALSS_EXPORT icalcomponent *icalset_fetch_match(icalset *set, icalcompo
 LIBICAL_ICALSS_EXPORT icalerrorenum icalset_modify(icalset *set,
                                                    icalcomponent *oldc, icalcomponent *newc);
 
-/** Iterates through the components. If a guage has been defined, these
+/** Iterates through the components. If a gauge has been defined, these
    will skip over components that do not pass the gauge */
 
 LIBICAL_ICALSS_EXPORT icalcomponent *icalset_get_current_component(icalset *set);

--- a/src/libicalss/icalspanlist.c
+++ b/src/libicalss/icalspanlist.c
@@ -304,7 +304,7 @@ int *icalspanlist_as_freebusy_matrix(icalspanlist *sl, int delta_t)
     sl_start = icaltime_as_timet_with_zone(sl->start, icaltimezone_get_utc_timezone());
     sl_end = icaltime_as_timet_with_zone(sl->end, icaltimezone_get_utc_timezone());
 
-  /* insure that the time period falls on a time boundary divisable
+  /* insure that the time period falls on a time boundary divisible
       by delta_t */
 
     sl_start /= delta_t;

--- a/src/libicalvcal/README.TXT
+++ b/src/libicalvcal/README.TXT
@@ -396,8 +396,8 @@ b. vobject.h -- contains basic interfaces to the VObject APIs.
 
 c. values of a property is determined by the property definition
 	itself. The vobject APIs does not attempt to enforce
-	any of such definition. It is the consumer responsibility
-	to know what value is expected from a property. e.g
+	any of such definition. It is the consumer's responsibility
+	to know what value is expected from a property. E.g.
 	most properties have unicode string value, so to access
 	the value of these type of properties, you will use
 	the vObjectUStringZValue() to read the value and
@@ -405,7 +405,7 @@ c. values of a property is determined by the property definition
 	Refer to the VCard and VCalendar specifications for
 	the definition of each property.
 
-d. properties name (id) are case incensitive.
+d. properties name (id) are case insensitive.
 
 8. Brief descriptions of each APIs
    ===============================
@@ -565,7 +565,7 @@ d. properties name (id) are case incensitive.
 		write it to memory. If s is 0, then memory required
 		to hold the textual representation will be allocated
 		by this API. If a variable len is passed, len will
-		be overwriten with the byte size of the textual
+		be overwritten with the byte size of the textual
 		representation. If s is non-zero, then s has to
 		be a user allocated buffer whose size has be passed
 		in len as a variable. Memory allocated by the API
@@ -663,7 +663,7 @@ of Example.vcf and its VObject Representation
 	initPropIterator(&t,vcard);
 	while (moreIteration(&t)) {
 	    VObject *eachProp = nextVObject(&t);
-	    //	The primarly purpose of this example is to
+	    //	The primary purpose of this example is to
 	    //  show how to iterate through a VCard VObject,
 	    //	it is not meant to be efficient at all.
 	    char *n = vObjectName(eachProp);
@@ -686,7 +686,7 @@ of Example.vcf and its VObject Representation
 	initPropIterator(&t,vcard);
 	while (moreIteration(&t)) {
 	    VObject *eachProp = nextVObject(&t);
-	    //	The primarly purpose of this example is to
+	    //	The primary purpose of this example is to
 	    //  show how to iterate through a VCalendar VObject,
 	    //	it is not meant to be efficient at all.
 	    char *n = vObjectName(eachProp);

--- a/src/libicalvcal/icalvcal.c
+++ b/src/libicalvcal/icalvcal.c
@@ -1258,7 +1258,7 @@ static void *rule_prop(int icaltype, VObject *object, icalcomponent *comp,
     return (void *)prop;
 }
 
-/* directly convertable property. The string representation of vcal is
+/* directly convertible property. The string representation of vcal is
    the same as ical */
 
 void *dc_prop(int icaltype, VObject *object, icalcomponent *comp, icalvcal_defaults *defaults)

--- a/src/libicalvcal/vcc.c
+++ b/src/libicalvcal/vcc.c
@@ -880,7 +880,7 @@ static char* lexLookaheadWord() {
 
 #ifdef _SUPPORT_LINE_FOLDING
 static void handleMoreRFC822LineBreak(int c) {
-    /* suport RFC 822 line break in cases like
+    /* support RFC 822 line break in cases like
      *  ADR: foo;
      *    morefoo;
      *    more foo;
@@ -1275,7 +1275,7 @@ int yylex() {
                             }
                         }
                     else {
-                        /* unknow token */
+                        /* unknown token */
                         return 0;
                         }
                     break;

--- a/src/libicalvcal/vcc.y
+++ b/src/libicalvcal/vcc.y
@@ -708,7 +708,7 @@ static char* lexLookaheadWord() {
 
 #ifdef _SUPPORT_LINE_FOLDING
 static void handleMoreRFC822LineBreak(int c) {
-    /* suport RFC 822 line break in cases like
+    /* support RFC 822 line break in cases like
      *  ADR: foo;
      *    morefoo;
      *    more foo;
@@ -1103,7 +1103,7 @@ int yylex() {
                             }
                         }
                     else {
-                        /* unknow token */
+                        /* unknown token */
                         return 0;
                         }
                     break;

--- a/src/python/ChangeLog
+++ b/src/python/ChangeLog
@@ -73,9 +73,9 @@
 2001-02-28  Eric Busboom  <eric@civicknowledge.com>
 
 	* Property Remove most internal data. The property now work
- 	alsmost entirely off of the icalproperty that it holds a reference
- 	to. Made changes in all derived Properties to accomodate the
- 	change.
+	almost entirely off of the icalproperty that it holds a reference
+	to. Made changes in all derived Properties to accommodate the
+	change.
 
 	* Property Added __del__ 
 
@@ -110,7 +110,7 @@
 
 	* Period implemented methods in period
 
-	* Time Addedd addition and subtraction operators
+	* Time Added addition and subtraction operators
 
 2001-02-25  Eric Busboom  <eric@civicknowledge.com>
 

--- a/src/python/Collection.py
+++ b/src/python/Collection.py
@@ -20,11 +20,12 @@
 
 from types import *
 
+
 class Collection:
     """A group of components that can be modified somewhat like a list.
 
     Usage:
-        Collection(componet, propSequence)
+        Collection(component, propSequence)
 
     component is a Component object
     propSequence is a list or tuple of Property (or subclass of Property)
@@ -40,7 +41,7 @@ class Collection:
 
     def __setslice__(self, beg, end, sequence):
 
-        if  not isinstance(sequence,ListType):
+        if not isinstance(sequence, ListType):
             raise TypeError, "must assign list (not instance) to slice"
 
         oldProps = self._properties[beg:end]
@@ -58,7 +59,7 @@ class Collection:
     def __setitem__(self, i, prop):
         self._component.remove_property(self._properties[i])
         self._component.add_property(prop)
-        self._properties[i]=prop
+        self._properties[i] = prop
 
     def __delitem__(self, i):
         self._component.remove_property(self._properties[i])
@@ -79,6 +80,7 @@ class Collection:
     def append(self, property):
         self._properties.append(property)
         self._component.add_property(property)
+
 
 class ComponentCollection:
 
@@ -103,7 +105,7 @@ class ComponentCollection:
     def __setitem__(self, i, prop):
         self._parent.remove_component(self._components[i])
         self._parent.add_property(prop)
-        self._components[i]=prop
+        self._components[i] = prop
 
     def __delitem__(self, i):
         self._parent.remove_component(self._components[i])

--- a/src/python/Gauge.py
+++ b/src/python/Gauge.py
@@ -28,7 +28,7 @@ class Gauge:
     """
 
     class ConstructorFailedError(LibicalError):
-        "Failed to create a Guage "
+        "Failed to create a Gauge "
 
     class CloneFailedError(LibicalError):
         "Failed to clone a component given Gauge "

--- a/src/python/LibicalWrap_icaltime.i
+++ b/src/python/LibicalWrap_icaltime.i
@@ -123,7 +123,7 @@
         return icaltime_days_in_month(month, year);
     }
 
-    /** Returns whether you've specified a leapyear or not. */
+    /** Returns whether you've specified a leap year or not. */
     static int is_leap_year (const int year) {
         return icaltime_is_leap_year(year);
     }

--- a/src/python/Period.py
+++ b/src/python/Period.py
@@ -116,7 +116,7 @@ class Period(Property):
         The return value is an instance of Time.
 
         If the Period has a duration set, but not an end time, this
-        method will caluculate the end time from the duration.  """
+        method will calculate the end time from the duration.  """
 
         if v != None:
 

--- a/src/python/python-binding.txt
+++ b/src/python/python-binding.txt
@@ -92,14 +92,14 @@ component. But, if the component already has a DURATION property, then
 this is an error -- a component can't have both.
 
 icalcomponent_set_dtend determines if the component already has a
-DURATION. If it does, it substracts the dtstart time from the new
+DURATION. If it does, it subtracts the dtstart time from the new
 dtend time and sets the duration to that. Otherwise, it creates aor
 changes the DTEND.
 
 Also, icalcomponent_set_duration works the same regardless if the
 component is a VCALENDAR or a VEVENT. If it is a VCALENDAR, the
 routine descends into the VEVENT before making any changes. If it is
-allready a VEVENT ( or VTODO or VJOURNAL ) the routine just makes the
+already a VEVENT ( or VTODO or VJOURNAL ) the routine just makes the
 changes. With icalcomponent_add_property, you need to do this check
 yourself.
 

--- a/src/python/test.py
+++ b/src/python/test.py
@@ -32,7 +32,7 @@ PRODID:-//ABC Corporation//NONSGML My Product//EN
 METHOD:REQUEST
 BEGIN:VEVENT
 ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=GROUP:MAILTO:employee-A@host.com
-COMMENT: When in the course of writting comments and nonsense text\, it
+COMMENT: When in the course of writing comments and nonsense text\, it
  becomes necessary to insert a newline
 DTSTART:19972512T120000
 DTSTART:19970101T120000Z
@@ -395,7 +395,7 @@ def test_event():
 
     assert(len(event.x_properties('X-TEST'))==2)
 
-    event.description("A short description.  Longer ones break things. Really. What does it break. The code is supposed to handle realy long lines, longer, in fact, than any sane person would create except by writting a random text generator or by excerpting text from a less sane person. Actually, it did \"break\" and I had to remove an \n assert to fix it.")
+    event.description("A short description.  Longer ones break things. Really. What does it break. The code is supposed to handle really long lines, longer, in fact, than any sane person would create except by writing a random text generator or by excerpting text from a less sane person. Actually, it did \"break\" and I had to remove an \n assert to fix it.")
     event.status('TeNtAtIvE')
 
     print event.as_ical_string()

--- a/src/test/regression-classify.c
+++ b/src/test/regression-classify.c
@@ -147,7 +147,7 @@ void test_classify(void)
 
         if (this_uid != 0) {
             /* Look in the calendar for a component with the same UID
-               as the incoming component. We should reall also be
+               as the incoming component. We should really also be
                checking the RECURRENCE-ID. Another way to do this
                operation is to us icalset_find_match(), which does use
                the RECURRENCE-ID. */

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -2759,7 +2759,7 @@ static int test_juldat_caldat_instance(long year, int month, int day) {
 
 /*
  * This test verifies the caldat_int and juldat_int functions. The functions are reworked versions
- * of the original caldat and juldat functions but avoid using floating point arithmetics. As the
+ * of the original caldat and juldat functions but avoid using floating point arithmetic. As the
  * new functions are not exported, the test cannot access them directly. It therefore checks the
  * output of the icaltime_day_of_week, icaltime_start_doy_week and icaltime_week_number functions
  * which are based on the functions to be tested.


### PR DESCRIPTION
Also fix a few Python whitespace errors found by Syntastic.