### PR TITLE
libicalvcal: Cast EOF to 'char' to ensure matching its value against it

### DIFF
--- a/src/libicalvcal/vcc.c
+++ b/src/libicalvcal/vcc.c
@@ -987,6 +987,10 @@ void initLex(const char *inputstring, unsigned long inputlen, FILE *inputfile)
     }
 
 static void finiLex() {
+    VObject* vobj;
+    while(vobj = popVObject(), vobj) {
+        cleanVObject(vobj);
+    }
     free(lexBuf.strs);
     }
 
@@ -1298,9 +1302,12 @@ static VObject* Parse_MIMEHelper()
     mime_lineNum = 1;
     vObjList = 0;
     curObj = 0;
+    curProp = 0;
 
-    if (yyparse() != 0)
+    if (yyparse() != 0) {
+        finiLex();
         return 0;
+    }
 
     finiLex();
     return vObjList;

--- a/src/libicalvcal/vcc.c
+++ b/src/libicalvcal/vcc.c
@@ -744,7 +744,7 @@ static int lexGeta_(int i)
     }
 
 static void lexSkipLookahead() {
-    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=EOF) {
+    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=((char) EOF)) {
         /* don't skip EOF. */
         lexBuf.getPtr = (lexBuf.getPtr + 1) % MAX_LEX_LOOKAHEAD;
         lexBuf.len--;
@@ -779,7 +779,7 @@ static int lexLookahead() {
 
 static int lexGetc() {
     int c = lexLookahead();
-    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=EOF) {
+    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=((char) EOF)) {
         /* EOF will remain in lookahead buffer */
         lexBuf.getPtr = (lexBuf.getPtr + 1) % MAX_LEX_LOOKAHEAD;
         lexBuf.len--;
@@ -829,7 +829,7 @@ static char* lexGetWord() {
     lexSkipWhite();
     lexClearToken();
     c = lexLookahead();
-    while (c != EOF && !strchr("\t\n ;:=",c)) {
+    while (c != ((char) EOF) && !strchr("\t\n ;:=",c)) {
         lexAppendc(c);
         lexSkipLookahead();
         c = lexLookahead();
@@ -841,7 +841,7 @@ static char* lexGetWord() {
 static void lexPushLookaheadc(int c) {
     int putptr;
     /* can't putback EOF, because it never leaves lookahead buffer */
-    if (c == EOF) return;
+    if (((char) c) == ((char) EOF)) return;
     putptr = (int)lexBuf.getPtr - 1;
     if (putptr < 0) putptr += MAX_LEX_LOOKAHEAD;
     lexBuf.getPtr = (unsigned long)putptr;
@@ -863,7 +863,7 @@ static char* lexLookaheadWord() {
     while (len < (MAX_LEX_LOOKAHEAD_0)) {
         c = lexGetc();
         len++;
-        if (c == EOF || strchr("\t\n ;:=", c)) {
+        if (c == ((char) EOF) || strchr("\t\n ;:=", c)) {
             lexAppendc(0);
             /* restore lookahead buf. */
             lexBuf.len += len;
@@ -920,7 +920,7 @@ static char* lexGet1Value() {
     lexSkipWhite();
     c = lexLookahead();
     lexClearToken();
-    while (c != EOF && c != ';') {
+    while (c != ((char) EOF) && c != ';') {
         if (c == '\n') {
             int a;
             lexSkipLookahead();
@@ -942,7 +942,7 @@ static char* lexGet1Value() {
         }
     lexAppendc(0);
     handleMoreRFC822LineBreak(c);
-    return c==EOF?0:lexStr();
+    return c==((char) EOF)?0:lexStr();
     }
 #endif
 
@@ -1036,9 +1036,9 @@ static char * lexGetDataFromBase64()
                 else if (oldBytes) free(oldBytes);
                 /* error recovery: skip until 2 adjacent newlines. */
                 DBG_(("db: invalid character 0x%x '%c'\n", c,c));
-                if (c != EOF)  {
+                if (c != ((char) EOF))  {
                     c = lexGetc();
-                    while (c != EOF) {
+                    while (c != ((char) EOF)) {
                         if (c == '\n' && lexLookahead() == '\n') {
                             ++mime_lineNum;
                             break;
@@ -1256,7 +1256,7 @@ int yylex() {
                     ++mime_lineNum;
                     continue;
                     }
-                case EOF: return 0;
+                case ((char) EOF): return 0;
                     break;
                 default: {
                     lexPushLookaheadc(c);

--- a/src/libicalvcal/vcc.y
+++ b/src/libicalvcal/vcc.y
@@ -572,7 +572,7 @@ static int lexGeta_(int i)
     }
 
 static void lexSkipLookahead() {
-    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=EOF) {
+    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=((char) EOF)) {
         /* don't skip EOF. */
         lexBuf.getPtr = (lexBuf.getPtr + 1) % MAX_LEX_LOOKAHEAD;
         lexBuf.len--;
@@ -607,7 +607,7 @@ static int lexLookahead() {
 
 static int lexGetc() {
     int c = lexLookahead();
-    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=EOF) {
+    if (lexBuf.len > 0 && lexBuf.buf[lexBuf.getPtr]!=((char) EOF)) {
         /* EOF will remain in lookahead buffer */
         lexBuf.getPtr = (lexBuf.getPtr + 1) % MAX_LEX_LOOKAHEAD;
         lexBuf.len--;
@@ -657,7 +657,7 @@ static char* lexGetWord() {
     lexSkipWhite();
     lexClearToken();
     c = lexLookahead();
-    while (c != EOF && !strchr("\t\n ;:=",c)) {
+    while (c != ((char) EOF) && !strchr("\t\n ;:=",c)) {
         lexAppendc(c);
         lexSkipLookahead();
         c = lexLookahead();
@@ -669,7 +669,7 @@ static char* lexGetWord() {
 static void lexPushLookaheadc(int c) {
     int putptr;
     /* can't putback EOF, because it never leaves lookahead buffer */
-    if (c == EOF) return;
+    if (((char) c) == ((char) EOF)) return;
     putptr = (int)lexBuf.getPtr - 1;
     if (putptr < 0) putptr += MAX_LEX_LOOKAHEAD;
     lexBuf.getPtr = (unsigned long)putptr;
@@ -691,7 +691,7 @@ static char* lexLookaheadWord() {
     while (len < (MAX_LEX_LOOKAHEAD_0)) {
         c = lexGetc();
         len++;
-        if (c == EOF || strchr("\t\n ;:=", c)) {
+        if (c == ((char) EOF) || strchr("\t\n ;:=", c)) {
             lexAppendc(0);
             /* restore lookahead buf. */
             lexBuf.len += len;
@@ -748,7 +748,7 @@ static char* lexGet1Value() {
     lexSkipWhite();
     c = lexLookahead();
     lexClearToken();
-    while (c != EOF && c != ';') {
+    while (c != ((char) EOF) && c != ';') {
         if (c == '\n') {
             int a;
             lexSkipLookahead();
@@ -770,7 +770,7 @@ static char* lexGet1Value() {
         }
     lexAppendc(0);
     handleMoreRFC822LineBreak(c);
-    return c==EOF?0:lexStr();
+    return c==((char) EOF)?0:lexStr();
     }
 #endif
 
@@ -864,9 +864,9 @@ static char * lexGetDataFromBase64()
                 else if (oldBytes) free(oldBytes);
                 /* error recovery: skip until 2 adjacent newlines. */
                 DBG_(("db: invalid character 0x%x '%c'\n", c,c));
-                if (c != EOF)  {
+                if (c != ((char) EOF))  {
                     c = lexGetc();
-                    while (c != EOF) {
+                    while (c != ((char) EOF)) {
                         if (c == '\n' && lexLookahead() == '\n') {
                             ++mime_lineNum;
                             break;
@@ -1084,7 +1084,7 @@ int yylex() {
                     ++mime_lineNum;
                     continue;
                     }
-                case EOF: return 0;
+                case ((char) EOF): return 0;
                     break;
                 default: {
                     lexPushLookaheadc(c);

--- a/src/libicalvcal/vcc.y
+++ b/src/libicalvcal/vcc.y
@@ -815,6 +815,10 @@ void initLex(const char *inputstring, unsigned long inputlen, FILE *inputfile)
     }
 
 static void finiLex() {
+    VObject* vobj;
+    while(vobj = popVObject(), vobj) {
+        cleanVObject(vobj);
+    }
     free(lexBuf.strs);
     }
 
@@ -1126,9 +1130,12 @@ static VObject* Parse_MIMEHelper()
     mime_lineNum = 1;
     vObjList = 0;
     curObj = 0;
+    curProp = 0;
 
-    if (yyparse() != 0)
+    if (yyparse() != 0) {
+        finiLex();
         return 0;
+    }
 
     finiLex();
     return vObjList;

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4252,6 +4252,8 @@ void test_vcal(void)
         if (comp) {
             icalcomponent_free(comp);
         }
+
+        cleanVObject(vcal);
     }
 }
 


### PR DESCRIPTION
Some arches (like aarch64, ppc64le and s390x) may not match the EOF
constant against its value cast to 'char'. That breaks the parser and
can cause an indefinite read of the content, with growing memory use.