### PR TITLE
Add include path to the exported target definition

### DIFF
--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -265,6 +265,8 @@ elseif(STATIC_ONLY)
   add_library(ical-static ALIAS ical)
 endif()
 
+target_include_directories(ical INTERFACE "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>")
+
 target_link_libraries(ical ${CMAKE_THREAD_LIBS_INIT})
 
 if(ICU_FOUND)


### PR DESCRIPTION
Otherwise the libical headers are not found by consumers if libical is installed in a non-standard location