### PR TITLE
libical-glib: Fix annotation of i_cal_time_get_timezone

### DIFF
--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -85,7 +85,7 @@
     </method>
     <method name="i_cal_time_get_timezone" corresponds="(void *)icaltime_get_timezone" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
-        <returns type="ICalTimezone *" annotation="transfer none" translator_argus="(GObject *)tt, TRUE" comment="The timezone information" />
+        <returns type="ICalTimezone *" annotation="transfer full" translator_argus="(GObject *)tt, TRUE" comment="The timezone information" />
         <comment xml:space="preserve">Returns the timezone.</comment>
     </method>
     <method name="i_cal_time_set_timezone" corresponds="icaltime_set_timezone" kind="set" since="1.0">


### PR DESCRIPTION
It returns a reference of the newly create ICalTimezone so the caller has to actually unref it.