### PR TITLE
icalcomponent_get_duration() clarification in comment

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1506,7 +1506,7 @@ struct icaldurationtype icalcomponent_get_duration(icalcomponent *comp)
         /**
          * FIXME
          * We assume DTSTART and DTEND are not in different time zones.
-         * Does the standard actually guarantee this?
+         * The standard actually allows different time zones.
          */
         struct icaltimetype start = icalcomponent_get_dtstart(inner);
         struct icaltimetype end = icalcomponent_get_dtend(inner);


### PR DESCRIPTION
```diff
diff --git a/src/libical/icalcomponent.c b/src/libical/icalcomponent.c
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1506,7 +1506,7 @@ struct icaldurationtype icalcomponent_get_duration(icalcomponent *comp)
         /**
          * FIXME
          * We assume DTSTART and DTEND are not in different time zones.
-         * Does the standard actually guarantee this?
+         * The standard actually allows different time zones.
          */
         struct icaltimetype start = icalcomponent_get_dtstart(inner);
         struct icaltimetype end = icalcomponent_get_dtend(inner);
```