### PR TITLE
icalcomponent.c: handle the case, when DTEND and DURATION are missing

### DIFF
--- a/src/test/regression-component.c
+++ b/src/test/regression-component.c
@@ -448,7 +448,7 @@ void test_icalcomponent_get_span()
     if (VERBOSE)
         print_span(tnum++, span);
 
-    int_is("null span", (int)span.start, 0);
+    int_is("start == end", (int)span.start, span.end);
     icalcomponent_free(c);
 
     /** test 7


### PR DESCRIPTION
In icalcomponent_get_dtend():
• when both DTEND and DURATION are missing,
  set DTEND to DTSTART when the value-type of DTSTART is DATE-TIME,
  otherwise set DTEND = DTSTART + 1 day, when the value-type of DTSTART is DATE
• throw an error, if both DTEND and DURATION are present, as it is done in icalcomponent_get_duration()

In icalcomponent_get_duration():
• if DTEND and DURATION are missing and
  the value-type of DTSTART is DATE-TIME return zero duration;
  otherwise, if the value-type of DTSTART is DATE, return one day duration
• do not throw an error, if DTEND and DURATION are missing

In icalcomponent_get_span() account for the fact, that icalcomponent_get_dtend()
returns the correct DTEND, based on the value-type of DTSTART, when DTEND is missing.

Likewise for icalcomponent_foreach_recurrence().

Adjust test/regression-component.c to assume span.start == span.end,
when the event has only DTSTART and its value-type is DATE-TIME.