### PR TITLE
icalcomponent_get_duration() — calculate the duration differently for VEVENT and VTODO

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -39,6 +39,8 @@ Version 3.1.0 (NOT RELEASED YET):
      (were in the public headers but not used at all)
      + struct icaltimezonetype
      + struct icaltimezonephase
+ * icalcomponent_get_dtend() return icaltime_null_time(), unless called on VEVENT, VAVAILABILITY or VFREEBUSY
+ * icalcomponent_get_duration() for VTODO calculate with DUE instead of DTEND
 
 Version 3.0.13 (UNRELEASED):
 ----------------------------

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -281,6 +281,13 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icalcomponent_get_dtstart(icalcomponent 
  *      there is a DTEND and you call get_duration, the routine will
  *      return the difference between DTEND and DTSTART.
  *
+ *      When DURATION and DTEND are both missing, for VEVENT an implicit
+ *      DTEND is calculated based of DTSTART; for AVAILABLE, VAVAILABILITY,
+ *      and VFREEBUSY null-time is returned.
+ *
+ *      Returns null-time, unless called on AVAILABLE, VEVENT,
+ *      VAVAILABILITY, or VFREEBUSY components.
+ *
  *      FIXME this is useless until we can flag the failure
  */
 LIBICAL_ICAL_EXPORT struct icaltimetype icalcomponent_get_dtend(icalcomponent *comp);
@@ -345,15 +352,14 @@ LIBICAL_ICAL_EXPORT void icalcomponent_set_duration(icalcomponent *comp,
 /**     @brief Gets the DURATION property as an icalduration
  *
  *      For the icalcomponent routines only, DTEND and DURATION are tied
- *      together.
- *      If a DURATION property is not present but a DTEND is, we use
- *      that to determine the proper end.
- *
- *      For the icalcomponent routines only, dtend and duration are tied
  *      together. If you call the get routine for one and the other
  *      exists, the routine will calculate the return value. That is, if
- *      there is a DTEND and you call get_duration, the routine will
- *      return the difference between DTEND and DTSTART.
+ *      there is a DTEND and you call get_duration, the routine will return
+ *      the difference between DTEND and DTSTART in AVAILABLE, VEVENT, or
+ *      VAVAILABILITY; and the difference between DUE and DTSTART in VTODO.
+ *      When both DURATION and DTEND are missing from VEVENT an implicit
+ *      duration is returned, based on the value-type of DTSTART. Otherwise
+ *      null-duration is returned.
  */
 LIBICAL_ICAL_EXPORT struct icaldurationtype icalcomponent_get_duration(icalcomponent *comp);
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -5009,6 +5009,66 @@ static void test_vcc_vcard_parse(void)
     ok("vCalendar-broken cannot be parsed", (vcal == NULL));
 }
 
+static void test_implicit_dtend_duration(void)
+{
+    const struct icaltimetype start1 = icaltime_from_string("20220108");
+    icalcomponent* c = icalcomponent_vanew(
+            ICAL_VCALENDAR_COMPONENT,
+            icalcomponent_vanew(
+                ICAL_VEVENT_COMPONENT,
+                icalproperty_vanew_dtstart(start1, 0),
+                0),
+            0);
+    struct icaldurationtype d = icalcomponent_get_duration(c);
+    struct icaltimetype end = icalcomponent_get_dtend(c),
+        start = icaltime_from_string("20220108T101010Z");
+    if (VERBOSE) {
+        printf("%s\n", icaldurationtype_as_ical_string(d));
+    }
+    str_is("icaldurationtype_as_ical_string(d)", "P1D", icaldurationtype_as_ical_string(d));
+
+    if (VERBOSE) {
+        printf("%s\n", icaltime_as_ical_string(end));
+    }
+    str_is("icaltime_as_ical_string(end)", "20220109", icaltime_as_ical_string(end));
+
+    icalcomponent_set_dtstart(c, start);
+    d = icalcomponent_get_duration(c);
+    end = icalcomponent_get_dtend(c);
+    if (VERBOSE) {
+        printf("%s\n", icaldurationtype_as_ical_string(d));
+    }
+    int_is("icaldurationtype_as_int(d)", 0, icaldurationtype_as_int(d));
+
+    if (VERBOSE) {
+        printf("%s\n", icaltime_as_ical_string(end));
+    }
+    int_is("icaltime_compare(start, end)", 0, icaltime_compare(start, end));
+    icalcomponent_free(c);
+
+
+    c = icalcomponent_vanew(
+            ICAL_VCALENDAR_COMPONENT,
+                icalcomponent_vanew(
+                    ICAL_VTODO_COMPONENT,
+                    icalproperty_vanew_dtstart(start1, 0),
+                    0),
+            0);
+    icalcomponent_set_due(c, icaltime_from_string("20220109"));
+    d = icalcomponent_get_duration(c);
+    end = icalcomponent_get_dtend(c);
+    if (VERBOSE) {
+        printf("%s\n", icaldurationtype_as_ical_string(d));
+    }
+    str_is("P1D", "P1D", icaldurationtype_as_ical_string(d));
+
+    if (VERBOSE) {
+        printf("%i\n", icaltime_is_null_time(end));
+    }
+    int_is("icaltime_is_null_time(end)", 1, icaltime_is_null_time(end));
+    icalcomponent_free(c);
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -5154,6 +5214,7 @@ int main(int argc, char *argv[])
     test_run("Test icalcomponent_normalize", test_icalcomponent_normalize, do_test, do_header);
     test_run("Test builtin compat TZID", test_builtin_compat_tzid, do_test, do_header);
     test_run("Test VCC vCard parse", test_vcc_vcard_parse, do_test, do_header);
+    test_run("Test implicit DTEND and DURATION for VEVENT and VTODO", test_implicit_dtend_duration, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 


### PR DESCRIPTION
For VEVENT and VAVAILABILITY calculate the distance between DTSTART and DTEND.

For VTODO calculate the distance between DTSTART and DUE.

icalcomponent_get_dtend() — return null-time, unless called on VEVENT, VAVAILABILITY or VFREEBUSY.