### PR TITLE
icalvalue: Reset non-UTC icaltimetype::zone on set

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,7 +3,7 @@ Release Highlights
 
 Version 3.0.14 (UNRELEASED):
 ----------------------------
- *
+ * icalvalue: Reset non-UTC icaltimetype::zone on set
 
 Version 3.0.13 (17 January 2022):
 ---------------------------------

--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -28,6 +28,7 @@
 #include "icalvalueimpl.h"
 #include "icalerror.h"
 #include "icalmemory.h"
+#include "icaltimezone.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -298,6 +299,11 @@ void icalvalue_set_datetimedate(icalvalue *value, struct icaltimetype v)
 
     impl = (struct icalvalue_impl *)value;
     impl->data.v_time = v;
+
+    /* preserve only built-in UTC time zone, otherwise unset any set on the 'v' */
+    if(impl->data.v_time.zone != NULL &&
+       impl->data.v_time.zone != icaltimezone_get_utc_timezone())
+       impl->data.v_time.zone = NULL;
 
     icalvalue_reset_kind(impl);
 }


### PR DESCRIPTION
When setting an icaltimetype value, the passed-in structure can
have set a timezone, which is tight to the source component
of the passed-in value and which can be made invalid when the source
component is freed. As the structure is copied completely even
on clone of the component, then the 'zone' pointer can be passed
forward in the clones.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=2038090