### PR TITLE
Consistent use of icalmemory_new_buffer et al.

### DIFF
--- a/scripts/mkderivedvalues.pl
+++ b/scripts/mkderivedvalues.pl
@@ -226,7 +226,7 @@ $pointer_check_rv\
       if ($union_data eq 'string') {
 
         print
-"    if (impl->data.v_${union_data} != 0) {\n        free((void *)impl->data.v_${union_data});\n    }\n";
+"    if (impl->data.v_${union_data} != 0) {\n        icalmemory_free_buffer((void *)impl->data.v_${union_data});\n    }\n";
       }
 
       print "\

--- a/src/libical/icalattach.c
+++ b/src/libical/icalattach.c
@@ -22,6 +22,7 @@
 
 #include "icalattachimpl.h"
 #include "icalerror.h"
+#include "icalmemory.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -33,13 +34,13 @@ icalattach *icalattach_new_from_url(const char *url)
 
     icalerror_check_arg_rz((url != NULL), "url");
 
-    if ((attach = malloc(sizeof(icalattach))) == NULL) {
+    if ((attach = icalmemory_new_buffer(sizeof(icalattach))) == NULL) {
         errno = ENOMEM;
         return NULL;
     }
 
-    if ((url_copy = strdup(url)) == NULL) {
-        free(attach);
+    if ((url_copy = icalmemory_strdup(url)) == NULL) {
+        icalmemory_free_buffer(attach);
         errno = ENOMEM;
         return NULL;
     }
@@ -54,7 +55,7 @@ icalattach *icalattach_new_from_url(const char *url)
 static void attach_data_free(char *data, void *free_fn_data)
 {
     _unused(free_fn_data);
-    free(data);
+    icalmemory_free_buffer(data);
 }
 
 icalattach *icalattach_new_from_data(const char *data, icalattach_free_fn_t free_fn,
@@ -64,15 +65,15 @@ icalattach *icalattach_new_from_data(const char *data, icalattach_free_fn_t free
 
     icalerror_check_arg_rz((data != NULL), "data");
 
-    if ((attach = malloc(sizeof(icalattach))) == NULL) {
+    if ((attach = icalmemory_new_buffer(sizeof(icalattach))) == NULL) {
         errno = ENOMEM;
         return NULL;
     }
 
     if (!free_fn) {
-        data = strdup(data);
+        data = icalmemory_strdup(data);
         if (!data) {
-            free(attach);
+            icalmemory_free_buffer(attach);
             errno = ENOMEM;
             return NULL;
         }
@@ -107,12 +108,12 @@ void icalattach_unref(icalattach *attach)
         return;
 
     if (attach->is_url) {
-        free(attach->u.url.url);
+        icalmemory_free_buffer(attach->u.url.url);
     } else if (attach->u.data.free_fn) {
         (* attach->u.data.free_fn) (attach->u.data.data, attach->u.data.free_fn_data);
     }
 
-    free(attach);
+    icalmemory_free_buffer(attach);
 }
 
 int icalattach_get_is_url(icalattach *attach)

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -91,7 +91,7 @@ static icalcomponent *icalcomponent_new_impl(icalcomponent_kind kind)
     if (!icalcomponent_kind_is_valid(kind))
         return NULL;
 
-    if ((comp = (icalcomponent *) malloc(sizeof(icalcomponent))) == 0) {
+    if ((comp = (icalcomponent *) icalmemory_new_buffer(sizeof(icalcomponent))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -210,7 +210,7 @@ void icalcomponent_free(icalcomponent *c)
         pvl_free(c->components);
 
         if (c->x_name != 0) {
-            free(c->x_name);
+            icalmemory_free_buffer(c->x_name);
         }
 
         if (c->timezones) {
@@ -227,7 +227,7 @@ void icalcomponent_free(icalcomponent *c)
         c->id[0] = 'X';
         c->timezones = NULL;
 
-        free(c);
+        icalmemory_free_buffer(c);
     }
 }
 
@@ -282,7 +282,7 @@ char *icalcomponent_as_ical_string_r(icalcomponent *impl)
         tmp_buf = icalproperty_as_ical_string_r(p);
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, tmp_buf);
-        free(tmp_buf);
+        icalmemory_free_buffer(tmp_buf);
     }
 
     for (itr = pvl_head(impl->components); itr != 0; itr = pvl_next(itr)) {
@@ -291,7 +291,7 @@ char *icalcomponent_as_ical_string_r(icalcomponent *impl)
         tmp_buf = icalcomponent_as_ical_string_r(c);
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, tmp_buf);
-        free(tmp_buf);
+        icalmemory_free_buffer(tmp_buf);
     }
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, "END:");
@@ -2015,7 +2015,7 @@ void icalcomponent_merge_component(icalcomponent *comp, icalcomponent *comp_to_m
 
         /* Now free the tzids_to_rename array. */
         for (i = 0; i < tzids_to_rename->num_elements; i++) {
-            free(icalarray_element_at(tzids_to_rename, i));
+            icalmemory_free_buffer(icalarray_element_at(tzids_to_rename, i));
         }
     }
     icalarray_free(tzids_to_rename);
@@ -2074,7 +2074,7 @@ static void icalcomponent_merge_vtimezone(icalcomponent *comp,
        unique one), so we compare the VTIMEZONE components to see if they are
        the same. If they are, we don't need to do anything. We make a copy of
        the tzid, since the parameter may get modified in these calls. */
-    tzid_copy = strdup(tzid);
+    tzid_copy = icalmemory_strdup(tzid);
     if (!tzid_copy) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return;
@@ -2087,7 +2087,7 @@ static void icalcomponent_merge_vtimezone(icalcomponent *comp,
         icalcomponent_handle_conflicting_vtimezones(comp, vtimezone, tzid_prop,
                                                     tzid_copy, tzids_to_rename);
     }
-    free(tzid_copy);
+    icalmemory_free_buffer(tzid_copy);
 }
 
 static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
@@ -2131,20 +2131,20 @@ static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
             if (icalcomponent_compare_vtimezones(icaltimezone_get_component(zone), vtimezone)) {
                 /* The VTIMEZONEs match, so we can use the existing VTIMEZONE. But
                    we have to rename TZIDs to this TZID. */
-                tzid_copy = strdup(tzid);
+                tzid_copy = icalmemory_strdup(tzid);
                 if (!tzid_copy) {
                     icalerror_set_errno(ICAL_NEWFAILED_ERROR);
                     return;
                 }
-                existing_tzid_copy = strdup(existing_tzid);
+                existing_tzid_copy = icalmemory_strdup(existing_tzid);
                 if (!existing_tzid_copy) {
                     icalerror_set_errno(ICAL_NEWFAILED_ERROR);
-                    free(tzid_copy);
+                    icalmemory_free_buffer(tzid_copy);
                 } else {
                     icalarray_append(tzids_to_rename, tzid_copy);
-                    free(tzid_copy);
+                    icalmemory_free_buffer(tzid_copy);
                     icalarray_append(tzids_to_rename, existing_tzid_copy);
-                    free(existing_tzid_copy);
+                    icalmemory_free_buffer(existing_tzid_copy);
                 }
                 return;
             } else {
@@ -2161,17 +2161,17 @@ static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
 
     /* We didn't find a VTIMEZONE that matched, so we have to rename the TZID,
        using the maximum numerical suffix found + 1. */
-    tzid_copy = strdup(tzid);
+    tzid_copy = icalmemory_strdup(tzid);
     if (!tzid_copy) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return;
     }
 
     snprintf(suffix_buf, sizeof(suffix_buf), "%i", max_suffix + 1);
-    new_tzid = malloc(tzid_len + strlen(suffix_buf) + 1);
+    new_tzid = icalmemory_new_buffer(tzid_len + strlen(suffix_buf) + 1);
     if (!new_tzid) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
-        free(tzid_copy);
+        icalmemory_free_buffer(tzid_copy);
         return;
     }
 
@@ -2179,8 +2179,8 @@ static void icalcomponent_handle_conflicting_vtimezones(icalcomponent *comp,
     strcpy(new_tzid + tzid_len, suffix_buf);
     icalarray_append(tzids_to_rename, tzid_copy);
     icalarray_append(tzids_to_rename, new_tzid);
-    free(tzid_copy);
-    free(new_tzid);
+    icalmemory_free_buffer(tzid_copy);
+    icalmemory_free_buffer(new_tzid);
 }
 
 /* Returns the length of the TZID, without any trailing digits. */
@@ -2353,7 +2353,7 @@ static int icalcomponent_compare_vtimezones(icalcomponent *vtimezone1, icalcompo
 
     /* Copy the second TZID, and set the property to the same as the first
        TZID, since we don't care if these match of not. */
-    tzid2_copy = strdup(tzid2);
+    tzid2_copy = icalmemory_strdup(tzid2);
     if (!tzid2_copy) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
@@ -2364,25 +2364,25 @@ static int icalcomponent_compare_vtimezones(icalcomponent *vtimezone1, icalcompo
     /* Now convert both VTIMEZONEs to strings and compare them. */
     string1 = icalcomponent_as_ical_string_r(vtimezone1);
     if (!string1) {
-        free(tzid2_copy);
+        icalmemory_free_buffer(tzid2_copy);
         return -1;
     }
 
     string2 = icalcomponent_as_ical_string_r(vtimezone2);
     if (!string2) {
-        free(string1);
-        free(tzid2_copy);
+        icalmemory_free_buffer(string1);
+        icalmemory_free_buffer(tzid2_copy);
         return -1;
     }
 
     cmp = strcmp(string1, string2);
 
-    free(string1);
-    free(string2);
+    icalmemory_free_buffer(string1);
+    icalmemory_free_buffer(string2);
 
     /* Now reset the second TZID. */
     icalproperty_set_tzid(prop2, tzid2_copy);
-    free(tzid2_copy);
+    icalmemory_free_buffer(tzid2_copy);
 
     return (cmp == 0) ? 1 : 0;
 }

--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -115,7 +115,7 @@ void icalvalue_set_x(icalvalue *impl, const char *v)
     icalerror_check_arg_rv((v != 0), "v");
 
     if (impl->x_value != 0) {
-        free((void *)impl->x_value);
+        icalmemory_free_buffer((void *)impl->x_value);
     }
 
     impl->x_value = icalmemory_strdup(v);
@@ -151,12 +151,12 @@ void icalvalue_set_recur(icalvalue *impl, struct icalrecurrencetype v)
     icalerror_check_value_type(value, ICAL_RECUR_VALUE);
 
     if (impl->data.v_recur != 0) {
-        free(impl->data.v_recur->rscale);
-        free(impl->data.v_recur);
+        icalmemory_free_buffer(impl->data.v_recur->rscale);
+        icalmemory_free_buffer(impl->data.v_recur);
         impl->data.v_recur = 0;
     }
 
-    impl->data.v_recur = malloc(sizeof(struct icalrecurrencetype));
+    impl->data.v_recur = icalmemory_new_buffer(sizeof(struct icalrecurrencetype));
 
     if (impl->data.v_recur == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);

--- a/src/libical/icalduration.h
+++ b/src/libical/icalduration.h
@@ -108,7 +108,7 @@ LIBICAL_ICAL_EXPORT int icaldurationtype_as_int(struct icaldurationtype duration
  *
  * @b Ownership
  * The string returned by this function is owned by the caller and needs to be
- * released with `free()` after it's no longer needed.
+ * released with `icalmemory_free_buffer()` after it's no longer needed.
  *
  * @b Usage
  * ```c
@@ -121,7 +121,7 @@ LIBICAL_ICAL_EXPORT int icaldurationtype_as_int(struct icaldurationtype duration
  * printf("%s\n", ical);
  *
  * // release string
- * free(ical);
+ * icalmemory_free_buffer(ical);
  * ```
  */
 LIBICAL_ICAL_EXPORT char *icaldurationtype_as_ical_string(struct icaldurationtype d);

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -23,6 +23,7 @@
 #endif
 
 #include "icalerror.h"
+#include "icalmemory.h"
 
 #include <stdlib.h>
 
@@ -38,7 +39,7 @@ static pthread_once_t icalerrno_key_once = PTHREAD_ONCE_INIT;
 
 static void icalerrno_destroy(void *buf)
 {
-    free(buf);
+    icalmemory_free_buffer(buf);
     pthread_setspecific(icalerrno_key, NULL);
 }
 
@@ -56,7 +57,7 @@ icalerrorenum *icalerrno_return(void)
     _errno = (icalerrorenum *) pthread_getspecific(icalerrno_key);
 
     if (!_errno) {
-        _errno = malloc(sizeof(icalerrorenum));
+        _errno = icalmemory_new_buffer(sizeof(icalerrorenum));
         *_errno = ICAL_NO_ERROR;
         pthread_setspecific(icalerrno_key, _errno);
     }
@@ -277,6 +278,6 @@ void ical_bt(void)
             fprintf(stderr, "%p\n", stack_frames[i]);
         }
     }
-    free(strings);
+    icalmemory_free_buffer(strings);
 #endif
 }

--- a/src/libical/icallangbind.c
+++ b/src/libical/icallangbind.c
@@ -29,14 +29,14 @@
 
 int *icallangbind_new_array(int size)
 {
-    int *p = (int *)malloc(size * sizeof(int));
+    int *p = (int *)icalmemory_new_buffer(size * sizeof(int));
 
     return p;   /* Caller handles failures */
 }
 
 void icallangbind_free_array(int *array)
 {
-    free(array);
+    icalmemory_free_buffer(array);
 }
 
 int icallangbind_access_array(int *array, int index)
@@ -195,7 +195,7 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
         default:
             {
                 char *str = icalvalue_as_ical_string_r(value);
-                char *copy = (char *)malloc(strlen(str) + 1);
+                char *copy = (char *)icalmemory_new_buffer(strlen(str) + 1);
 
                 const char *i;
                 char *j;
@@ -221,8 +221,8 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
                 APPENDS(copy);
                 APPENDC('\'');
 
-                free(copy);
-                free(str);
+                icalmemory_free_buffer(copy);
+                icalmemory_free_buffer(str);
                 break;
             }
         }
@@ -244,7 +244,7 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
         v = strchr(copy, '=');
 
         if (v == 0) {
-            free(copy);
+            icalmemory_free_buffer(copy);
             continue;
         }
 
@@ -260,7 +260,7 @@ char *icallangbind_property_eval_string_r(icalproperty *prop, const char *sep)
         APPENDC('\'');
         APPENDS(v);
         APPENDC('\'');
-        free(copy);
+        icalmemory_free_buffer(copy);
     }
 
     APPENDC('}');

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -250,7 +250,20 @@ char *icalmemory_tmp_copy(const char *str)
 
 char *icalmemory_strdup(const char *s)
 {
-    return strdup(s);
+    size_t l;
+    char *res;
+
+    if (!s)
+        return NULL;
+
+    l = (strlen(s) + 1) * sizeof(char);
+    res = (char *) icalmemory_new_buffer(l);
+    if (res == NULL)
+        return NULL;
+
+    memcpy(res, s, l);
+
+    return res;
 }
 
 /*

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -74,10 +74,10 @@ static void icalmemory_free_ring_byval(buffer_ring * br)
 
     for (i = 0; i < BUFFER_RING_SIZE; i++) {
         if (br->ring[i] != 0) {
-            free(br->ring[i]);
+            icalmemory_free_buffer(br->ring[i]);
         }
     }
-    free(br);
+    icalmemory_free_buffer(br);
 }
 
 #if defined(HAVE_PTHREAD)
@@ -109,7 +109,7 @@ static void icalmemory_free_tmp_buffer(void *buf)
         return;
     }
 
-    free(buf);
+    icalmemory_free_buffer(buf);
 }
 
 #endif
@@ -122,7 +122,7 @@ static buffer_ring *buffer_ring_new(void)
     buffer_ring *br;
     int i;
 
-    br = (buffer_ring *) malloc(sizeof(buffer_ring));
+    br = (buffer_ring *) icalmemory_new_buffer(sizeof(buffer_ring));
 
     for (i = 0; i < BUFFER_RING_SIZE; i++) {
         br->ring[i] = 0;
@@ -190,7 +190,7 @@ void icalmemory_add_tmp_buffer(void *buf)
 
     /* Free buffers as their slots are overwritten */
     if (br->ring[br->pos] != 0) {
-        free(br->ring[br->pos]);
+        icalmemory_free_buffer(br->ring[br->pos]);
     }
 
     /* Assign the buffer to a slot */
@@ -210,7 +210,7 @@ void *icalmemory_tmp_buffer(size_t size)
         size = MIN_BUFFER_SIZE;
     }
 
-    buf = (void *)malloc(size);
+    buf = (void *)icalmemory_new_buffer(size);
 
     if (buf == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
@@ -314,7 +314,7 @@ void icalmemory_append_string(char **buf, char **pos, size_t *buf_size, const ch
 
         *buf_size = (*buf_size) * 2 + final_length;
 
-        new_buf = realloc(*buf, *buf_size);
+        new_buf = icalmemory_resize_buffer(*buf, *buf_size);
 
         new_pos = (void *)((size_t) new_buf + data_length);
 
@@ -351,7 +351,7 @@ void icalmemory_append_char(char **buf, char **pos, size_t *buf_size, char ch)
 
         *buf_size = (*buf_size) * 2 + final_length + 1;
 
-        new_buf = realloc(*buf, *buf_size);
+        new_buf = icalmemory_resize_buffer(*buf, *buf_size);
 
         new_pos = (void *)((size_t) new_buf + data_length);
 

--- a/src/libical/icalmemory.h
+++ b/src/libical/icalmemory.h
@@ -142,7 +142,7 @@ LIBICAL_ICAL_EXPORT void icalmemory_add_tmp_buffer(void *buf);
 LIBICAL_ICAL_EXPORT void icalmemory_free_ring(void);
 
 /* Non-tmp buffers must be freed. These are mostly wrappers around
- * malloc, etc, but are used so the caller can change the memory
+ * icalmemory_new_buffer, etc, but are used so the caller can change the memory
  * allocators in a future version of the library */
 
 /**
@@ -323,17 +323,19 @@ LIBICAL_ICAL_EXPORT void icalmemory_append_char(char **buf, char **pos, size_t *
  *
  * @par Ownership
  * The returned string is owned by the caller and needs to be released with the
- * appropriate `free()` method.
+ * `icalmemory_free_buffer()` method.
  *
- * A wrapper around `strdup()`.  Partly to trap calls to `strdup()`, partly
- * because in `-ansi`, `gcc` on Red Hat claims that `strdup()` is undeclared.
+ * Replaces `strdup()`. The function uses icalmemory_new_buffer() for memory
+ * allocation. It also helps trapping calls to `strdup()` and solves the
+ * problem that in `-ansi`, `gcc` on Red Hat claims that `strdup()` is
+ * undeclared.
  *
  * ### Usage
  * ```c
  * const char *my_str = "LibIcal";
  * char *dup = icalmemory_strdup(my_str);
  * printf("%s\n", dup);
- * free(dup);
+ * icalmemory_free_buffer(dup);
  * ```
  */
 LIBICAL_ICAL_EXPORT char *icalmemory_strdup(const char *s);

--- a/src/libical/icalmime.c
+++ b/src/libical/icalmime.c
@@ -49,7 +49,7 @@ static void *icalmime_text_new_part(void)
 
     struct text_part *impl;
 
-    if ((impl = (struct text_part *)malloc(sizeof(struct text_part))) == 0) {
+    if ((impl = (struct text_part *)icalmemory_new_buffer(sizeof(struct text_part))) == 0) {
         return 0;
     }
 
@@ -77,7 +77,7 @@ static void *icalmime_textcalendar_end_part(void *part)
     icalcomponent *c = icalparser_parse_string(impl->buf);
 
     icalmemory_free_buffer(impl->buf);
-    free(impl);
+    icalmemory_free_buffer(impl);
 
     return c;
 }
@@ -88,7 +88,7 @@ static void *icalmime_text_end_part_r(void *part)
     struct text_part *impl = (struct text_part *)part;
 
     buf = impl->buf;
-    free(impl);
+    icalmemory_free_buffer(impl);
 
     return buf;
 }
@@ -166,7 +166,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
     int i, last_level = 0;
     icalcomponent *root = 0, *parent = 0, *comp = 0, *last = 0;
 
-    if ((parts = (struct sspm_part *)malloc(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
+    if ((parts = (struct sspm_part *)icalmemory_new_buffer(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -245,7 +245,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
             icalcomponent_add_property(
                 comp,
                 icalproperty_new_xlicmimecontenttype(mimeTypeCopy));
-            free(mimeTypeCopy);
+            icalmemory_free_buffer(mimeTypeCopy);
         }
 
         if (parts[i].header.encoding != SSPM_NO_ENCODING) {
@@ -288,7 +288,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
             icalcomponent_add_property(
                 comp,
                 icalproperty_new_description(descStr));
-            free(descStr);
+            icalmemory_free_buffer(descStr);
             parts[i].data = 0;
         }
 
@@ -331,7 +331,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
     }
 
     sspm_free_parts(parts, NUM_PARTS);
-    free(parts);
+    icalmemory_free_buffer(parts);
 
     return root;
 }
@@ -342,7 +342,7 @@ int icalmime_test(char *(*get_string) (char *s, size_t size, void *d), void *dat
     struct sspm_part *parts;
     int i;
 
-    if ((parts = (struct sspm_part *)malloc(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
+    if ((parts = (struct sspm_part *)icalmemory_new_buffer(NUM_PARTS * sizeof(struct sspm_part))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -363,7 +363,7 @@ int icalmime_test(char *(*get_string) (char *s, size_t size, void *d), void *dat
     sspm_write_mime(parts, NUM_PARTS, &out, "To: bob@bob.org");
 
     printf("%s\n", out);
-    free(out);
+    icalmemory_free_buffer(out);
 
     return 0;
 }

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -36,7 +36,7 @@ LIBICAL_ICAL_EXPORT struct icalparameter_impl *icalparameter_new_impl(icalparame
 {
     struct icalparameter_impl *v;
 
-    if ((v = (struct icalparameter_impl *)malloc(sizeof(struct icalparameter_impl))) == 0) {
+    if ((v = (struct icalparameter_impl *)icalmemory_new_buffer(sizeof(struct icalparameter_impl))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -67,18 +67,18 @@ void icalparameter_free(icalparameter *param)
     }
 
     if (param->string != 0) {
-        free((void *)param->string);
+        icalmemory_free_buffer((void *)param->string);
     }
 
     if (param->x_name != 0) {
-        free((void *)param->x_name);
+        icalmemory_free_buffer((void *)param->x_name);
     }
 
     memset(param, 0, sizeof(icalparameter));
 
     param->parent = 0;
     param->id[0] = 'X';
-    free(param);
+    icalmemory_free_buffer(param);
 }
 
 icalparameter *icalparameter_clone(const icalparameter *old)
@@ -141,7 +141,7 @@ icalparameter *icalparameter_new_from_string(const char *str)
 
     if (eq == 0) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        free(cpy);
+        icalmemory_free_buffer(cpy);
         return 0;
     }
 
@@ -153,7 +153,7 @@ icalparameter *icalparameter_new_from_string(const char *str)
 
     if (kind == ICAL_NO_PARAMETER) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        free(cpy);
+        icalmemory_free_buffer(cpy);
         return 0;
     }
 
@@ -165,7 +165,7 @@ icalparameter *icalparameter_new_from_string(const char *str)
         icalparameter_set_iana_name(param, cpy);
     }
 
-    free(cpy);
+    icalmemory_free_buffer(cpy);
 
     return param;
 }
@@ -297,7 +297,7 @@ char *icalparameter_as_ical_string_r(icalparameter *param)
         if (param->kind == ICAL_NO_PARAMETER ||
             param->kind == ICAL_ANY_PARAMETER || kind_string == 0) {
             icalerror_set_errno(ICAL_BADARG_ERROR);
-            free(buf);
+            icalmemory_free_buffer(buf);
             return 0;
         }
 
@@ -315,7 +315,7 @@ char *icalparameter_as_ical_string_r(icalparameter *param)
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, str);
     } else {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        free(buf);
+        icalmemory_free_buffer(buf);
         return 0;
     }
 
@@ -352,7 +352,7 @@ void icalparameter_set_xname(icalparameter *param, const char *v)
     icalerror_check_arg_rv((v != 0), "v");
 
     if (param->x_name != 0) {
-        free((void *)param->x_name);
+        icalmemory_free_buffer((void *)param->x_name);
     }
 
     param->x_name = icalmemory_strdup(v);
@@ -375,7 +375,7 @@ void icalparameter_set_xvalue(icalparameter *param, const char *v)
     icalerror_check_arg_rv((v != 0), "v");
 
     if (param->string != 0) {
-        free((void *)param->string);
+        icalmemory_free_buffer((void *)param->string);
     }
 
     param->string = icalmemory_strdup(v);

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -231,9 +231,9 @@ LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter)
  *
  * @par Ownership
  * Strings returned by this method are owned by the caller, thus they need
- * to be manually `free()`d after use. A version of this function which returns
- * strings that do not need to be freed manually is
- * icalparameter_as_ical_string().
+ * to be manually `icalmemory_free_buffer()`d after use.
+ * A version of this function which returns strings that do not
+ * need to be freed manually is icalparameter_as_ical_string().
  *
  * ### Usage
  * ```c
@@ -242,7 +242,7 @@ LIBICAL_ICAL_EXPORT char *icalparameter_as_ical_string(icalparameter *parameter)
  * if(param) {
  *     char *str = icalparameter_as_ical_string(param);
  *     printf("%s\n", str);
- *     free(str);
+ *     icalmemory_free_buffer(str);
  * }
  *
  * icalparameter_free(param);

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -102,7 +102,7 @@ icalparser *icalparser_new(void)
 {
     struct icalparser_impl *impl = 0;
 
-    if ((impl = (struct icalparser_impl *)malloc(sizeof(struct icalparser_impl))) == 0) {
+    if ((impl = (struct icalparser_impl *)icalmemory_new_buffer(sizeof(struct icalparser_impl))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -135,7 +135,7 @@ void icalparser_free(icalparser *parser)
 
     pvl_free(parser->components);
 
-    free(parser);
+    icalmemory_free_buffer(parser);
 }
 
 void icalparser_set_gen_data(icalparser *parser, void *data)
@@ -323,7 +323,7 @@ static char *parser_get_param_name_heap(char *line, char **end)
         *end = *end + 1;
         next = (**end == '"') ? *end : parser_get_next_char('"', *end, 0);
         if (next == 0) {
-            free(str);
+            icalmemory_free_buffer(str);
             *end = NULL;
             return 0;
         }
@@ -557,7 +557,7 @@ char *icalparser_get_line(icalparser *parser,
                 } else {
                     /* No data in output; return and signal that there
                        is no more input */
-                    free(line);
+                    icalmemory_free_buffer(line);
                     return 0;
                 }
             }

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -67,7 +67,7 @@ icalproperty *icalproperty_new_impl(icalproperty_kind kind)
     if (!icalproperty_kind_is_valid(kind))
         return NULL;
 
-    if ((prop = (icalproperty *) malloc(sizeof(icalproperty))) == 0) {
+    if ((prop = (icalproperty *) icalmemory_new_buffer(sizeof(icalproperty))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -160,7 +160,7 @@ icalproperty *icalproperty_new_from_string(const char *str)
 
     if (comp == 0) {
         icalerror_set_errno(ICAL_PARSE_ERROR);
-        free(buf);
+        icalmemory_free_buffer(buf);
         return 0;
     }
 
@@ -171,7 +171,7 @@ icalproperty *icalproperty_new_from_string(const char *str)
     icalcomponent_remove_property(comp, prop);
 
     icalcomponent_free(comp);
-    free(buf);
+    icalmemory_free_buffer(buf);
 
     if (errors > 0) {
         icalproperty_free(prop);
@@ -203,7 +203,7 @@ void icalproperty_free(icalproperty *p)
     pvl_free(p->parameters);
 
     if (p->x_name != 0) {
-        free(p->x_name);
+        icalmemory_free_buffer(p->x_name);
     }
 
     p->kind = ICAL_NO_PROPERTY;
@@ -213,7 +213,7 @@ void icalproperty_free(icalproperty *p)
     p->x_name = 0;
     p->id[0] = 'X';
 
-    free(p);
+    icalmemory_free_buffer(p);
 }
 
 /* This returns where the start of the next line should be. chars_left does
@@ -422,13 +422,13 @@ char *icalproperty_as_ical_string_r(icalproperty *prop)
         }
 
         if (kind == ICAL_VALUE_PARAMETER) {
-            free((char *)kind_string);
+            icalmemory_free_buffer((char *)kind_string);
             continue;
         }
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, ";");
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, kind_string);
-        free((char *)kind_string);
+        icalmemory_free_buffer((char *)kind_string);
     }
 
     /* Append value */
@@ -447,7 +447,7 @@ char *icalproperty_as_ical_string_r(icalproperty *prop)
             icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
 #endif
         }
-        free(str);
+        icalmemory_free_buffer(str);
     } else {
 #if ICAL_ALLOW_EMPTY_PROPERTIES == 0
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
@@ -600,13 +600,13 @@ char *icalproperty_get_parameter_as_string_r(icalproperty *prop, const char *nam
 
     if (t == 0) {
         icalerror_set_errno(ICAL_INTERNAL_ERROR);
-        free(str);
+        icalmemory_free_buffer(str);
         return 0;
     }
 
     /* Strip the property name and the equal sign */
     pv = icalmemory_strdup(t + 1);
-    free(str);
+    icalmemory_free_buffer(str);
 
     /* Is the string quoted? */
     pvql = strchr(pv, '"');
@@ -616,13 +616,13 @@ char *icalproperty_get_parameter_as_string_r(icalproperty *prop, const char *nam
 
     /* Strip everything up to the first quote */
     str = icalmemory_strdup(pvql + 1);
-    free(pv);
+    icalmemory_free_buffer(pv);
 
     /* Search for the end quote */
     pvqr = strrchr(str, '"');
     if (pvqr == 0) {
         icalerror_set_errno(ICAL_INTERNAL_ERROR);
-        free(str);
+        icalmemory_free_buffer(str);
         return 0;
     }
 
@@ -852,7 +852,7 @@ void icalproperty_set_x_name(icalproperty *prop, const char *name)
     icalerror_check_arg_rv((prop != 0), "prop");
 
     if (prop->x_name != 0) {
-        free(prop->x_name);
+        icalmemory_free_buffer(prop->x_name);
     }
 
     prop->x_name = icalmemory_strdup(name);

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -593,7 +593,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
         icalrecurrencetype_weekday wd;
 
         if (i == ICAL_BY_DAY_SIZE) {
-            free(vals_copy);
+            icalmemory_free_buffer(vals_copy);
             return -1;
         }
 
@@ -624,7 +624,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
 
         /* Sanity check value */
         if (wd == ICAL_NO_WEEKDAY || weekno >= ICAL_BY_WEEKNO_SIZE) {
-            free(vals_copy);
+            icalmemory_free_buffer(vals_copy);
             return -1;
         }
 
@@ -632,7 +632,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
         array[i] = ICAL_RECURRENCE_ARRAY_MAX;
     }
 
-    free(vals_copy);
+    icalmemory_free_buffer(vals_copy);
 
     sort_bydayrules(parser);
 
@@ -773,7 +773,7 @@ struct icalrecurrencetype icalrecurrencetype_from_string(const char *str)
                 icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
             }
             if (parser.rt.rscale) {
-                free(parser.rt.rscale);
+                icalmemory_free_buffer(parser.rt.rscale);
             }
             icalrecurrencetype_clear(&parser.rt);
             break;
@@ -791,7 +791,7 @@ struct icalrecurrencetype icalrecurrencetype_from_string(const char *str)
             if (rruleHandlingSetting == ICAL_RRULE_TREAT_AS_ERROR) {
                 icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
                 if (parser.rt.rscale) {
-                    free(parser.rt.rscale);
+                    icalmemory_free_buffer(parser.rt.rscale);
                 }
                 icalrecurrencetype_clear(&parser.rt);
                 break;
@@ -801,7 +801,7 @@ struct icalrecurrencetype icalrecurrencetype_from_string(const char *str)
         }
     }
 
-    free(parser.copy);
+    icalmemory_free_buffer(parser.copy);
 
     return parser.rt;
 }
@@ -1965,7 +1965,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype rule,
         return 0;
     }
 
-    if (!(impl = (icalrecur_iterator *)malloc(sizeof(icalrecur_iterator)))) {
+    if (!(impl = (icalrecur_iterator *)icalmemory_new_buffer(sizeof(icalrecur_iterator)))) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -2026,7 +2026,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype rule,
                 impl->orig_data[byrule] = 0;
             } else {
                 icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-                free(impl);
+                icalmemory_free_buffer(impl);
                 return 0;
             }
         }
@@ -2070,7 +2070,7 @@ void icalrecur_iterator_free(icalrecur_iterator *i)
     }
 #endif
 
-    free(i);
+    icalmemory_free_buffer(i);
 }
 
 /** Calculate the number of days between 2 dates */
@@ -3641,7 +3641,7 @@ int icalrecur_expand_recurrence(const char *rule,
         icalrecur_iterator_free(ritr);
     }
     if(recur.rscale)
-        free(recur.rscale);
+        icalmemory_free_buffer(recur.rscale);
 
     return 1;
 }

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -212,7 +212,7 @@ icaltimezone *icaltimezone_new(void)
 {
     icaltimezone *zone;
 
-    zone = (icaltimezone *) malloc(sizeof(icaltimezone));
+    zone = (icaltimezone *) icalmemory_new_buffer(sizeof(icaltimezone));
     if (!zone) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return NULL;
@@ -227,7 +227,7 @@ icaltimezone *icaltimezone_copy(icaltimezone *originalzone)
 {
     icaltimezone *zone;
 
-    zone = (icaltimezone *) malloc(sizeof(icaltimezone));
+    zone = (icaltimezone *) icalmemory_new_buffer(sizeof(icaltimezone));
     if (!zone) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return NULL;
@@ -235,13 +235,13 @@ icaltimezone *icaltimezone_copy(icaltimezone *originalzone)
 
     memcpy(zone, originalzone, sizeof(icaltimezone));
     if (zone->tzid != NULL) {
-        zone->tzid = strdup(zone->tzid);
+        zone->tzid = icalmemory_strdup(zone->tzid);
     }
     if (zone->location != NULL) {
-        zone->location = strdup(zone->location);
+        zone->location = icalmemory_strdup(zone->location);
     }
     if (zone->tznames != NULL) {
-        zone->tznames = strdup(zone->tznames);
+        zone->tznames = icalmemory_strdup(zone->tznames);
     }
 
     icaltimezone_changes_lock();
@@ -261,7 +261,7 @@ void icaltimezone_free(icaltimezone *zone, int free_struct)
 {
     icaltimezone_reset(zone);
     if (free_struct)
-        free(zone);
+        icalmemory_free_buffer(zone);
 }
 
 /** @brief Resets the icaltimezone to the initial state, freeing most of the
@@ -270,13 +270,13 @@ void icaltimezone_free(icaltimezone *zone, int free_struct)
 static void icaltimezone_reset(icaltimezone *zone)
 {
     if (zone->tzid)
-        free(zone->tzid);
+        icalmemory_free_buffer(zone->tzid);
 
     if (zone->location)
-        free(zone->location);
+        icalmemory_free_buffer(zone->location);
 
     if (zone->tznames)
-        free(zone->tznames);
+        icalmemory_free_buffer(zone->tznames);
 
     if (zone->component)
         icalcomponent_free(zone->component);
@@ -329,9 +329,9 @@ static int icaltimezone_get_vtimezone_properties(icaltimezone *zone, icalcompone
     }
 
     if (zone->tzid) {
-        free(zone->tzid);
+        icalmemory_free_buffer(zone->tzid);
     }
-    zone->tzid = strdup(tzid);
+    zone->tzid = icalmemory_strdup(tzid);
 
     if (zone->component) {
         icalcomponent_free(zone->component);
@@ -339,12 +339,12 @@ static int icaltimezone_get_vtimezone_properties(icaltimezone *zone, icalcompone
     zone->component = component;
 
     if (zone->location) {
-        free(zone->location);
+        icalmemory_free_buffer(zone->location);
     }
     zone->location = icaltimezone_get_location_from_vtimezone(component);
 
     if (zone->tznames) {
-        free(zone->tznames);
+        icalmemory_free_buffer(zone->tznames);
     }
     zone->tznames = icaltimezone_get_tznames_from_vtimezone(component);
 
@@ -361,7 +361,7 @@ char *icaltimezone_get_location_from_vtimezone(icalcomponent *component)
     if (prop) {
         location = icalproperty_get_location(prop);
         if (location)
-            return strdup(location);
+            return icalmemory_strdup(location);
     }
 
     prop = icalcomponent_get_first_property(component, ICAL_X_PROPERTY);
@@ -370,7 +370,7 @@ char *icaltimezone_get_location_from_vtimezone(icalcomponent *component)
         if (name && !strcasecmp(name, "X-LIC-LOCATION")) {
             location = icalproperty_get_x(prop);
             if (location)
-                return strdup(location);
+                return icalmemory_strdup(location);
         }
         prop = icalcomponent_get_next_property(component, ICAL_X_PROPERTY);
     }
@@ -463,11 +463,11 @@ char *icaltimezone_get_tznames_from_vtimezone(icalcomponent *component)
         char *tznames;
 
         if (!strcmp(standard_tzname, daylight_tzname))
-            return strdup(standard_tzname);
+            return icalmemory_strdup(standard_tzname);
 
         standard_len = strlen(standard_tzname);
         daylight_len = strlen(daylight_tzname);
-        tznames = malloc(standard_len + daylight_len + 2);
+        tznames = icalmemory_new_buffer(standard_len + daylight_len + 2);
         strcpy(tznames, standard_tzname);
         tznames[standard_len] = '/';
         strcpy(tznames + standard_len + 1, daylight_tzname);
@@ -477,7 +477,7 @@ char *icaltimezone_get_tznames_from_vtimezone(icalcomponent *component)
 
         /* If either of the TZNAMEs was found just return that, else NULL. */
         tznames = standard_tzname ? standard_tzname : daylight_tzname;
-        return tznames ? strdup(tznames) : NULL;
+        return tznames ? icalmemory_strdup(tznames) : NULL;
     }
 }
 
@@ -1605,7 +1605,7 @@ static int fetch_lat_long_from_string(const char *str,
         sptr++;
     }
     len = (ptrdiff_t) (sptr - temp);
-    lat = (char *)malloc(len + 1);
+    lat = (char *)icalmemory_new_buffer(len + 1);
     memset(lat, '\0', len + 1);
     strncpy(lat, temp, len);
     lat[len] = '\0';
@@ -1647,11 +1647,11 @@ static int fetch_lat_long_from_string(const char *str,
                     latitude_seconds) == 1 ||
         parse_coord(lon, (int)strlen(lon),
                     longitude_degrees, longitude_minutes, longitude_seconds) == 1) {
-        free(lat);
+        icalmemory_free_buffer(lat);
         return 1;
     }
 
-    free(lat);
+    icalmemory_free_buffer(lat);
 
     return 0;
 }
@@ -1704,7 +1704,7 @@ static void icaltimezone_parse_zone_tab(void)
     filename_len += strlen(zonetab);
     filename_len += 2; /* for dir separator and final '\0' */
 
-    filename = (char *)malloc(filename_len);
+    filename = (char *)icalmemory_new_buffer(filename_len);
     if (!filename) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return;
@@ -1712,7 +1712,7 @@ static void icaltimezone_parse_zone_tab(void)
     snprintf(filename, filename_len, "%s/%s", zonedir, zonetab);
 
     fp = fopen(filename, "r");
-    free(filename);
+    icalmemory_free_buffer(filename);
     icalerror_assert(fp, "Cannot open the zonetab file for reading");
     if (!fp) {
         icalerror_set_errno(ICAL_INTERNAL_ERROR);
@@ -1757,7 +1757,7 @@ static void icaltimezone_parse_zone_tab(void)
         }
 
         icaltimezone_init(&zone);
-        zone.location = strdup(location);
+        zone.location = icalmemory_strdup(location);
 
         if (latitude_degrees >= 0) {
             zone.latitude =
@@ -1803,7 +1803,7 @@ void icaltimezone_release_zone_tab(void)
 
     builtin_timezones = NULL;
     for (i = 0; i < mybuiltin_timezones->num_elements; i++) {
-        free(((icaltimezone *) icalarray_element_at(mybuiltin_timezones, i))->location);
+        icalmemory_free_buffer(((icaltimezone *) icalarray_element_at(mybuiltin_timezones, i))->location);
     }
     icalarray_free(mybuiltin_timezones);
 }
@@ -1839,7 +1839,7 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
 
         filename_len = strlen(get_zone_directory()) + strlen(zone->location) + 6;
 
-        filename = (char *)malloc(filename_len);
+        filename = (char *)icalmemory_new_buffer(filename_len);
         if (!filename) {
             icalerror_set_errno(ICAL_NEWFAILED_ERROR);
             goto out;
@@ -1848,7 +1848,7 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
         snprintf(filename, filename_len, "%s/%s.ics", get_zone_directory(), zone->location);
 
         fp = fopen(filename, "r");
-        free(filename);
+        icalmemory_free_buffer(filename);
         if (!fp) {
             icalerror_set_errno(ICAL_FILE_ERROR);
             goto out;
@@ -1880,11 +1880,11 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
                 const char *tzid_prefix = icaltimezone_tzid_prefix();
 
                 new_tzid_len = strlen(tzid_prefix) + strlen(zone->location) + 1;
-                new_tzid = (char *)malloc(sizeof(char) * (new_tzid_len + 1));
+                new_tzid = (char *)icalmemory_new_buffer(sizeof(char) * (new_tzid_len + 1));
                 if(new_tzid) {
                     snprintf(new_tzid, new_tzid_len, "%s%s", tzid_prefix, zone->location);
                     icalproperty_set_tzid(prop, new_tzid);
-                    free(new_tzid);
+                    icalmemory_free_buffer(new_tzid);
                 } else {
                     icalerror_set_errno(ICAL_NEWFAILED_ERROR);
                 }
@@ -2139,7 +2139,7 @@ static const char *get_zone_directory(void)
             zislashp1 = zislash + 1;
             strcat(dirname, (char *)zislashp1);
             if (stat(dirname, &st) == 0 && S_ISDIR(st.st_mode)) {
-                cache = strdup(dirname);
+                cache = icalmemory_strdup(dirname);
                 return cache;
             }
         }
@@ -2154,7 +2154,7 @@ void set_zone_directory(const char *path)
     if (zone_files_directory)
         free_zone_directory();
 
-    zone_files_directory = malloc(strlen(path) + 1);
+    zone_files_directory = icalmemory_new_buffer(strlen(path) + 1);
 
     if (zone_files_directory != NULL)
         strcpy(zone_files_directory, path);
@@ -2163,7 +2163,7 @@ void set_zone_directory(const char *path)
 void free_zone_directory(void)
 {
     if (zone_files_directory != NULL) {
-        free(zone_files_directory);
+        icalmemory_free_buffer(zone_files_directory);
         zone_files_directory = NULL;
     }
 }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -24,6 +24,7 @@
 #include "icaltz-util.h"
 #include "icalerror.h"
 #include "icaltimezone.h"
+#include "icalmemory.h"
 
 #include <stdlib.h>
 #include <limits.h>
@@ -190,7 +191,7 @@ static char *zname_from_stridx(char *str, size_t idx)
 
     size = i - idx;
     str += idx;
-    ret = (char *)malloc(size + 1);
+    ret = (char *)icalmemory_new_buffer(size + 1);
     ret = strncpy(ret, str, size);
     ret[size] = '\0';
 
@@ -484,7 +485,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
 
     size = strlen(zonedir) + strlen(location) + 2;
-    full_path = (char *)malloc(size);
+    full_path = (char *)icalmemory_new_buffer(size);
     if (full_path == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -548,17 +549,17 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
     }
 
     /* read data block */
-    transitions = calloc(num_trans+1, sizeof(time_t));  // +1 for TZ string
+    transitions = icalmemory_new_buffer((num_trans+1) * sizeof(time_t));  // +1 for TZ string
     if (transitions == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
     }
-    r_trans = calloc(num_trans, (size_t)trans_size);
+    r_trans = icalmemory_new_buffer(num_trans * (size_t)trans_size);
     if (r_trans == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
     }
-    trans_idx = calloc(num_trans+1, sizeof(int));  // +1 for TZ string
+    trans_idx = icalmemory_new_buffer((num_trans+1) * sizeof(int));  // +1 for TZ string
     if (trans_idx == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -583,7 +584,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         r_trans = temp;
     }
 
-    types = calloc(num_types+2, sizeof(ttinfo));  // +2 for TZ string
+    types = icalmemory_new_buffer((num_types+2) * sizeof(ttinfo));  // +2 for TZ string
     if (types == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -602,7 +603,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         types[i].gmtoff = decode(a);
     }
 
-    znames = (char *)malloc(num_chars);
+    znames = (char *)icalmemory_new_buffer(num_chars);
     if (znames == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -611,7 +612,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     /* We got all the information which we need */
 
-    leaps = calloc(num_leaps, sizeof(leap));
+    leaps = icalmemory_new_buffer(num_leaps * sizeof(leap));
     if (leaps == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -739,7 +740,7 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
 
     /* Add tzid property */
     size = strlen(icaltimezone_tzid_prefix()) + strlen(location) + 1;
-    tzid = (char *)malloc(size);
+    tzid = (char *)icalmemory_new_buffer(size);
     if (tzid == NULL) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         goto error;
@@ -915,34 +916,34 @@ icalcomponent *icaltzutil_fetch_timezone(const char *location)
         fclose(f);
 
     if (full_path)
-        free(full_path);
+        icalmemory_free_buffer(full_path);
 
     if (transitions)
-        free(transitions);
+        icalmemory_free_buffer(transitions);
 
     if (r_trans)
-        free(r_trans);
+        icalmemory_free_buffer(r_trans);
 
     if (trans_idx)
-        free(trans_idx);
+        icalmemory_free_buffer(trans_idx);
 
     if (types) {
         for (i = 0; i < num_types; i++) {
             if (types[i].zname) {
-                free(types[i].zname);
+                icalmemory_free_buffer(types[i].zname);
             }
         }
-        free(types);
+        icalmemory_free_buffer(types);
     }
 
     if (znames)
-        free(znames);
+        icalmemory_free_buffer(znames);
 
     if (leaps)
-        free(leaps);
+        icalmemory_free_buffer(leaps);
 
     if (tzid)
-        free(tzid);
+        icalmemory_free_buffer(tzid);
 
     return tz_comp;
 }

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -42,7 +42,7 @@ LIBICAL_ICAL_EXPORT struct icalvalue_impl *icalvalue_new_impl(icalvalue_kind kin
     if (!icalvalue_kind_is_valid(kind))
         return NULL;
 
-    if ((v = (struct icalvalue_impl *)malloc(sizeof(struct icalvalue_impl))) == 0) {
+    if ((v = (struct icalvalue_impl *)icalmemory_new_buffer(sizeof(struct icalvalue_impl))) == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
         return 0;
     }
@@ -174,7 +174,7 @@ icalvalue *icalvalue_new_clone(const icalvalue *old)
 static char *icalmemory_strdup_and_dequote(const char *str)
 {
     const char *p;
-    char *out = (char *)malloc(sizeof(char) * strlen(str) + 1);
+    char *out = (char *)icalmemory_new_buffer(sizeof(char) * strlen(str) + 1);
     char *pout;
     int wroteNull = 0;
 
@@ -570,7 +570,7 @@ static icalvalue *icalvalue_new_from_string_with_error(icalvalue_kind kind,
             char *dequoted_str = icalmemory_strdup_and_dequote(str);
 
             value = icalvalue_new_text(dequoted_str);
-            free(dequoted_str);
+            icalmemory_free_buffer(dequoted_str);
             break;
         }
 
@@ -641,7 +641,7 @@ static icalvalue *icalvalue_new_from_string_with_error(icalvalue_kind kind,
             if (rt.freq != ICAL_NO_RECURRENCE) {
                 value = icalvalue_new_recur(rt);
             }
-            free(rt.rscale);
+            icalmemory_free_buffer(rt.rscale);
             break;
         }
 
@@ -728,7 +728,7 @@ static icalvalue *icalvalue_new_from_string_with_error(icalvalue_kind kind,
             char *dequoted_str = icalmemory_strdup_and_dequote(str);
 
             value = icalvalue_new_x(dequoted_str);
-            free(dequoted_str);
+            icalmemory_free_buffer(dequoted_str);
         }
         break;
 
@@ -782,7 +782,7 @@ void icalvalue_free(icalvalue *v)
     }
 
     if (v->x_value != 0) {
-        free(v->x_value);
+        icalmemory_free_buffer(v->x_value);
     }
 
     switch (v->kind) {
@@ -802,7 +802,7 @@ void icalvalue_free(icalvalue *v)
     case ICAL_QUERY_VALUE:
         {
             if (v->data.v_string != 0) {
-                free((void *)v->data.v_string);
+                icalmemory_free_buffer((void *)v->data.v_string);
                 v->data.v_string = 0;
             }
             break;
@@ -810,8 +810,8 @@ void icalvalue_free(icalvalue *v)
     case ICAL_RECUR_VALUE:
         {
             if (v->data.v_recur != 0) {
-                free(v->data.v_recur->rscale);
-                free((void *)v->data.v_recur);
+                icalmemory_free_buffer(v->data.v_recur->rscale);
+                icalmemory_free_buffer((void *)v->data.v_recur);
                 v->data.v_recur = 0;
             }
             break;
@@ -828,7 +828,7 @@ void icalvalue_free(icalvalue *v)
     v->parent = 0;
     memset(&(v->data), 0, sizeof(v->data));
     v->id[0] = 'X';
-    free(v);
+    icalmemory_free_buffer(v);
 }
 
 int icalvalue_is_valid(const icalvalue *value)
@@ -1076,7 +1076,7 @@ static char *icalvalue_float_as_ical_string_r(const icalvalue *value)
     /* bypass current locale in order to make
        sure snprintf uses a '.' as a separator
        set locate to 'C' and keep old locale */
-    old_locale = strdup(setlocale(LC_NUMERIC, NULL));
+    old_locale = icalmemory_strdup(setlocale(LC_NUMERIC, NULL));
     (void)setlocale(LC_NUMERIC, "C");
 
     str = (char *)icalmemory_new_buffer(40);
@@ -1085,7 +1085,7 @@ static char *icalvalue_float_as_ical_string_r(const icalvalue *value)
 
     /* restore saved locale */
     (void)setlocale(LC_NUMERIC, old_locale);
-    free(old_locale);
+    icalmemory_free_buffer(old_locale);
 
     return str;
 }
@@ -1103,7 +1103,7 @@ static char *icalvalue_geo_as_ical_string_r(const icalvalue *value)
     /* bypass current locale in order to make
      * sure snprintf uses a '.' as a separator
      * set locate to 'C' and keep old locale */
-    old_locale = strdup(setlocale(LC_NUMERIC, NULL));
+    old_locale = icalmemory_strdup(setlocale(LC_NUMERIC, NULL));
     (void)setlocale(LC_NUMERIC, "C");
 
     str = (char *)icalmemory_new_buffer(80);
@@ -1112,7 +1112,7 @@ static char *icalvalue_geo_as_ical_string_r(const icalvalue *value)
 
     /* restore saved locale */
     (void)setlocale(LC_NUMERIC, old_locale);
-    free(old_locale);
+    icalmemory_free_buffer(old_locale);
 
     return str;
 }
@@ -1394,8 +1394,8 @@ icalparameter_xliccomparetype icalvalue_compare(const icalvalue *a, const icalva
             temp1 = icalvalue_as_ical_string_r(a);
             temp2 = icalvalue_as_ical_string_r(b);
             r = strcmp(temp1, temp2);
-            free(temp1);
-            free(temp2);
+            icalmemory_free_buffer(temp1);
+            icalmemory_free_buffer(temp2);
 
             if (r > 0) {
                 return ICAL_XLICCOMPARETYPE_GREATER;
@@ -1501,12 +1501,12 @@ int icalvalue_encode_ical_string(const char *szText, char *szEncText, int nMaxBu
 
     if ((int)strlen(ptr) >= nMaxBufferLen) {
         icalvalue_free(value);
-        free(ptr);
+        icalmemory_free_buffer(ptr);
         return 0;
     }
 
     strcpy(szEncText, ptr);
-    free(ptr);
+    icalmemory_free_buffer(ptr);
 
     icalvalue_free((icalvalue *) value);
 

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -22,6 +22,8 @@
 
 #include "pvl.h"
 
+#include "icalmemory.h"
+
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -80,7 +82,7 @@ pvl_list pvl_newlist()
 {
     struct pvl_list_t *L;
 
-    if ((L = (struct pvl_list_t *)malloc(sizeof(struct pvl_list_t))) == 0) {
+    if ((L = (struct pvl_list_t *)icalmemory_new_buffer(sizeof(struct pvl_list_t))) == 0) {
         errno = ENOMEM;
         return 0;
     }
@@ -102,7 +104,7 @@ void pvl_free(pvl_list l)
 
     pvl_clear(l);
 
-    free(L);
+    icalmemory_free_buffer(L);
 }
 
 /**
@@ -124,7 +126,7 @@ pvl_elem pvl_new_element(void *d, pvl_elem next, pvl_elem prior)
 {
     struct pvl_elem_t *E;
 
-    if ((E = (struct pvl_elem_t *)malloc(sizeof(struct pvl_elem_t))) == 0) {
+    if ((E = (struct pvl_elem_t *)icalmemory_new_buffer(sizeof(struct pvl_elem_t))) == 0) {
         errno = ENOMEM;
         return 0;
     }
@@ -384,7 +386,7 @@ void *pvl_remove(pvl_list L, pvl_elem E)
     E->next = 0;
     E->d = 0;
 
-    free(E);
+    icalmemory_free_buffer(E);
 
     return data;
 }

--- a/src/libical/sspm.c
+++ b/src/libical/sspm.c
@@ -35,6 +35,8 @@
 
 #include "sspm.h"
 
+#include "icalmemory.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -136,7 +138,7 @@ static char *sspm_strdup(const char *str)
 {
     char *s;
 
-    s = strdup(str);
+    s = icalmemory_strdup(str);
     return s;
 }
 
@@ -426,11 +428,11 @@ static enum sspm_major_type sspm_find_major_content_type(char *type)
     for (i = 0; major_content_type_map[i].type != SSPM_UNKNOWN_MAJOR_TYPE; i++) {
         if (strncmp(ltype, major_content_type_map[i].str,
                     strlen(major_content_type_map[i].str)) == 0) {
-            free(ltype);
+            icalmemory_free_buffer(ltype);
             return major_content_type_map[i].type;
         }
     }
-    free(ltype);
+    icalmemory_free_buffer(ltype);
     return major_content_type_map[i].type;      /* Should return SSPM_UNKNOWN_MINOR_TYPE */
 }
 
@@ -442,7 +444,7 @@ static enum sspm_minor_type sspm_find_minor_content_type(char *type)
     char *p = strchr(ltype, '/');
 
     if (p == 0) {
-        free(ltype);
+        icalmemory_free_buffer(ltype);
         return SSPM_UNKNOWN_MINOR_TYPE;
     }
 
@@ -450,12 +452,12 @@ static enum sspm_minor_type sspm_find_minor_content_type(char *type)
 
     for (i = 0; minor_content_type_map[i].type != SSPM_UNKNOWN_MINOR_TYPE; i++) {
         if (strncmp(p, minor_content_type_map[i].str, strlen(minor_content_type_map[i].str)) == 0) {
-            free(ltype);
+            icalmemory_free_buffer(ltype);
             return minor_content_type_map[i].type;
         }
     }
 
-    free(ltype);
+    icalmemory_free_buffer(ltype);
     return minor_content_type_map[i].type;      /* Should return SSPM_UNKNOWN_MINOR_TYPE */
 }
 
@@ -523,7 +525,7 @@ static void sspm_build_header(struct sspm_header *header, char *line)
             char *p = strchr(val, '/');
 
             if (header->minor_text != 0) {
-                free(header->minor_text);
+                icalmemory_free_buffer(header->minor_text);
             }
             if (p != 0) {
                 p++;    /* Skip the '/' */
@@ -536,7 +538,7 @@ static void sspm_build_header(struct sspm_header *header, char *line)
         }
         if (boundary != 0) {
             if (header->boundary != 0) {
-                free(header->boundary);
+                icalmemory_free_buffer(header->boundary);
             }
             header->boundary = sspm_strdup(boundary);
         }
@@ -559,7 +561,7 @@ static void sspm_build_header(struct sspm_header *header, char *line)
             header->encoding = SSPM_UNKNOWN_ENCODING;
         }
 
-        free(lencoding);
+        icalmemory_free_buffer(lencoding);
 
         header->def = 0;
 
@@ -567,13 +569,13 @@ static void sspm_build_header(struct sspm_header *header, char *line)
         char *cid = sspm_value(line);
 
         if (header->content_id != 0) {
-            free(header->content_id);
+            icalmemory_free_buffer(header->content_id);
         }
         header->content_id = sspm_strdup(cid);
         header->def = 0;
     }
-    free(val);
-    free(prop);
+    icalmemory_free_buffer(val);
+    icalmemory_free_buffer(prop);
 }
 
 static char *sspm_get_next_line(struct mime_impl *impl)
@@ -603,7 +605,7 @@ static void sspm_set_error(struct sspm_header *header, enum sspm_error error, ch
     header->error = error;
 
     if (header->error_text != 0) {
-        free(header->error_text);
+        icalmemory_free_buffer(header->error_text);
     }
 
     header->def = 0;
@@ -742,7 +744,7 @@ static void sspm_make_part(struct mime_impl *impl,
                 sspm_set_error(header, SSPM_UNEXPECTED_BOUNDARY_ERROR, line);
 
                 /* Read until the paired terminating boundary */
-                if ((boundary = (char *)malloc(strlen(line) + 5)) == 0) {
+                if ((boundary = (char *)icalmemory_new_buffer(strlen(line) + 5)) == 0) {
                     fprintf(stderr, "Out of memory");
                     abort();
                 }
@@ -754,7 +756,7 @@ static void sspm_make_part(struct mime_impl *impl,
                         break;
                     }
                 }
-                free(boundary);
+                icalmemory_free_buffer(boundary);
 
                 break;
             }
@@ -780,7 +782,7 @@ static void sspm_make_part(struct mime_impl *impl,
                 sspm_set_error(parent_header, SSPM_WRONG_BOUNDARY_ERROR, msg);
 
                 /* Read until the paired terminating boundary */
-                if ((boundary = (char *)malloc(strlen(line) + 5)) == 0) {
+                if ((boundary = (char *)icalmemory_new_buffer(strlen(line) + 5)) == 0) {
                     fprintf(stderr, "Out of memory");
                     abort();
                 }
@@ -791,7 +793,7 @@ static void sspm_make_part(struct mime_impl *impl,
                         break;
                     }
                 }
-                free(boundary);
+                icalmemory_free_buffer(boundary);
             }
         } else {
             char *data = 0;
@@ -799,7 +801,7 @@ static void sspm_make_part(struct mime_impl *impl,
 
             *size = strlen(line);
 
-            data = (char *)malloc(*size + 2);
+            data = (char *)icalmemory_new_buffer(*size + 2);
             assert(data != 0);
             if (header->encoding == SSPM_BASE64_ENCODING) {
                 rtrn = decode_base64(data, line, size);
@@ -818,7 +820,7 @@ static void sspm_make_part(struct mime_impl *impl,
 
             action.add_line(part, header, data, *size);
 
-            free(data);
+            icalmemory_free_buffer(data);
         }
     }
 
@@ -899,7 +901,7 @@ static void *sspm_make_multipart_subpart(struct mime_impl *impl, struct sspm_hea
                     sspm_set_error(parent_header, SSPM_WRONG_BOUNDARY_ERROR, msg);
 
                     /* Read until the paired terminating boundary */
-                    if ((boundary = (char *)malloc(strlen(line) + 5)) == 0) {
+                    if ((boundary = (char *)icalmemory_new_buffer(strlen(line) + 5)) == 0) {
                         fprintf(stderr, "Out of memory");
                         abort();
                     }
@@ -910,7 +912,7 @@ static void *sspm_make_multipart_subpart(struct mime_impl *impl, struct sspm_hea
                             break;
                         }
                     }
-                    free(boundary);
+                    icalmemory_free_buffer(boundary);
 
                     return 0;
                 }
@@ -1024,22 +1026,22 @@ int sspm_parse_mime(struct sspm_part *parts,
 static void sspm_free_header(struct sspm_header *header)
 {
     if (header->boundary != 0) {
-        free(header->boundary);
+        icalmemory_free_buffer(header->boundary);
     }
     if (header->minor_text != 0) {
-        free(header->minor_text);
+        icalmemory_free_buffer(header->minor_text);
     }
     if (header->charset != 0) {
-        free(header->charset);
+        icalmemory_free_buffer(header->charset);
     }
     if (header->filename != 0) {
-        free(header->filename);
+        icalmemory_free_buffer(header->filename);
     }
     if (header->content_id != 0) {
-        free(header->content_id);
+        icalmemory_free_buffer(header->content_id);
     }
     if (header->error_text != 0) {
-        free(header->error_text);
+        icalmemory_free_buffer(header->error_text);
     }
 }
 
@@ -1226,7 +1228,7 @@ static void sspm_append_char(struct sspm_buffer *buf, char ch)
 
         buf->buf_size = (buf->buf_size) * 2 + final_length + 1;
 
-        new_buf = realloc(buf->buffer, buf->buf_size);
+        new_buf = icalmemory_resize_buffer(buf->buffer, buf->buf_size);
 
         new_pos = (void *)((size_t) new_buf + data_length);
 
@@ -1255,7 +1257,7 @@ void sspm_append_string(struct sspm_buffer *buf, const char *string)
 
         buf->buf_size = (buf->buf_size) * 2 + final_length;
 
-        new_buf = realloc(buf->buffer, buf->buf_size);
+        new_buf = icalmemory_resize_buffer(buf->buffer, buf->buf_size);
 
         new_pos = (void *)((size_t) new_buf + data_length);
 
@@ -1529,7 +1531,7 @@ int sspm_write_mime(struct sspm_part *parts, size_t num_parts,
 
     _unused(num_parts);
 
-    buf.buffer = malloc(4096);
+    buf.buffer = icalmemory_new_buffer(4096);
     buf.buffer[0] = '\0';
     buf.pos = buf.buffer;
     buf.buf_size = 10;

--- a/src/libicalss/icalclassify.c
+++ b/src/libicalss/icalclassify.c
@@ -49,7 +49,7 @@ char *icalclassify_lowercase(const char *str)
         return 0;
     }
 
-    xnew = icalmemory_strdup(str);
+    xnew = strdup(str);
     for (p = xnew; *p != 0; p++) {
         *p = tolower((int)*p);
     }
@@ -292,8 +292,8 @@ int icalssutil_is_rescheduled(icalcomponent *a, icalcomponent *b)
         temp1 = icalproperty_as_ical_string_r(p1);
         temp2 = icalproperty_as_ical_string_r(p2);
         cmp = strcmp(temp1, temp2);
-        free(temp1);
-        free(temp2);
+        icalmemory_free_buffer(temp1);
+        icalmemory_free_buffer(temp2);
 
         if (p1 && cmp != 0) {
             return 1;

--- a/src/libicalss/icalfileset.c
+++ b/src/libicalss/icalfileset.c
@@ -27,6 +27,7 @@
 #include "icalfilesetimpl.h"
 #include "icalparser.h"
 #include "icalvalue.h"
+#include "icalmemory.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -397,11 +398,11 @@ icalerrorenum icalfileset_commit(icalset *set)
         if (sz != (IO_SSIZE_T) strlen(str)) {
             perror("write");
             icalerror_set_errno(ICAL_FILE_ERROR);
-            free(str);
+            icalmemory_free_buffer(str);
             return ICAL_FILE_ERROR;
         }
 
-        free(str);
+        icalmemory_free_buffer(str);
         write_size += sz;
     }
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -806,7 +806,7 @@ void test_memory()
 
     ok("final buffer size == 806", (bufsize == 806));
 
-    free(f);
+    icalmemory_free_buffer(f);
 
     bufsize = 4;
 
@@ -895,7 +895,7 @@ void test_memory()
     if (VERBOSE)
         printf("Char-by-Char buffer: %s\n", f);
 
-    free(f);
+    icalmemory_free_buffer(f);
 
     for (i = 0; i < 100; i++) {
         f = icalmemory_tmp_buffer(bufsize);
@@ -2730,7 +2730,7 @@ void test_recur_parser()
     rt = icalrecurrencetype_from_string(str);
     icalerror_restore("MALFORMEDDATA", es);
     ok(str, rt.freq == ICAL_NO_RECURRENCE);
-    free(v);
+    icalmemory_free_buffer(v);
 }
 
 
@@ -4672,7 +4672,7 @@ void test_timezone_from_builtin(void)
     comp = icaltimezone_get_component(zone);
     strcomp = icalcomponent_as_ical_string_r(comp);
     comp = icalcomponent_new_from_string(strcomp);
-    free(strcomp);
+    icalmemory_free_buffer(strcomp);
 
     ok("VTIMEZONE icalcomponent_new_from_string()", (comp != NULL));
 


### PR DESCRIPTION
In the libical core code the use of functions from `icalmemory.h` is somewhat inconsistent. In some places memory is managed using the functinos from icalmemory while in others the functions from stdlib (malloc/free, etc.) are used and in some places the usage is mixed. This PR replaces the use of memory management functions from stdlib with equivalents from `icalmemory.h` to improve overall consistency, at least in the code under `src/libical`. I.e. the following functions are replaced

| old     | new |
| --------- | --- | 
| calloc()  | icalmemory_new_buffer() |
| malloc()  | icalmemory_new_buffer() |
| realloc() | icalmemory_resize_buffer() |
| free()    | icalmemory_free_buffer() |
| strdup()  | icalmemory_strdup() |

Besides making the code more consistent, this also has the following benefits:
* Projects consuming libical as source code can more easily replace the memory management functions if necessary. This especially makes sense for code running on embedded systems, where malloc et al. might not be available.
* `icalmemory.h` could easily be extended such that memory management functions could also be replaced at runtime. I would actually contribute such code in a subsequent PR.
* The memory management functions could easily be replaced in the automated tests in order to detect memory leaks and inconsistent use of memory functions. I would also contribute such in a subsequent PR.

As the functions in icalmemory still make use of the same functions from stdlib internally, this PR doesn't introduce any functional change. I.e. clients which today are freeing libical-allocated memory using `free()` can safely continue to do so.