### PR TITLE
Centrally #define `fprintf` and `assert` to allow easy replacement.

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -548,3 +548,6 @@ typedef ssize_t IO_SSIZE_T;
 #define _unused(x) (void)x
 #endif
 #endif
+
+#define icalassert(...) assert(__VA_ARGS__)
+#define icalerrprintf(...) fprintf(stderr, __VA_ARGS__)

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -73,7 +73,7 @@ void icalcomponent_add_children(icalcomponent *impl, va_list args)
 
     while ((vp = va_arg(args, void *)) != 0)
     {
-        assert(icalcomponent_isa_component(vp) != 0 || icalproperty_isa_property(vp) != 0);
+        icalassert(icalcomponent_isa_component(vp) != 0 || icalproperty_isa_property(vp) != 0);
 
         if (icalcomponent_isa_component(vp) != 0) {
             icalcomponent_add_component(impl, (icalcomponent *) vp);
@@ -1991,8 +1991,8 @@ void icalcomponent_merge_component(icalcomponent *comp, icalcomponent *comp_to_m
     size_t i;
 
     /* Check that both components are VCALENDAR components. */
-    assert(icalcomponent_isa(comp) == ICAL_VCALENDAR_COMPONENT);
-    assert(icalcomponent_isa(comp_to_merge) == ICAL_VCALENDAR_COMPONENT);
+    icalassert(icalcomponent_isa(comp) == ICAL_VCALENDAR_COMPONENT);
+    icalassert(icalcomponent_isa(comp_to_merge) == ICAL_VCALENDAR_COMPONENT);
 
     /* Step through each subcomponent of comp_to_merge, looking for VTIMEZONEs.
        For each VTIMEZONE found, check if we need to add it to comp and if we

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -91,7 +91,7 @@ void icalerror_crash_here(void)
     *p = 1;
 
     /* cppcheck-suppress nullPointer */
-    assert(*p);
+    icalassert(*p);
 #endif
 }
 
@@ -124,7 +124,7 @@ void icalerror_set_errno(icalerrorenum x)
         (icalerror_get_error_state(x) == ICAL_ERROR_DEFAULT && icalerror_errors_are_fatal == 1)) {
         icalerror_warn(icalerror_strerror(x));
         ical_bt();
-        assert(0);
+        icalassert(0);
     }
 }
 
@@ -273,9 +273,9 @@ void ical_bt(void)
     strings = backtrace_symbols(stack_frames, num);
     for (i = 0; i < num; i++) {
         if (strings != NULL) {
-            fprintf(stderr, "%s\n", strings[i]);
+            icalerrprintf("%s\n", strings[i]);
         } else {
-            fprintf(stderr, "%p\n", stack_frames[i]);
+            icalerrprintf("%p\n", stack_frames[i]);
         }
     }
     icalmemory_free_buffer(strings);

--- a/src/libical/icalerror.h
+++ b/src/libical/icalerror.h
@@ -187,10 +187,10 @@ LIBICAL_ICAL_EXPORT int icalerror_get_errors_are_fatal(void);
 
 #ifdef __GNUC__ca
 #define icalerror_warn(message) \
-{fprintf(stderr, "%s(), %s:%d: %s\n", __FUNCTION__, __FILE__, __LINE__, message);}
+{icalerrprintf("%s(), %s:%d: %s\n", __FUNCTION__, __FILE__, __LINE__, message);}
 #else /* __GNU_C__ */
 #define icalerror_warn(message) \
-{fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, message);}
+{icalerrprintf("%s:%d: %s\n", __FILE__, __LINE__, message);}
 #endif /* __GNU_C__ */
 
 /**
@@ -343,7 +343,7 @@ if(icalerror_get_error_state(x) == ICAL_ERROR_FATAL || \
     icalerror_get_errors_are_fatal() == 1)){              \
    icalerror_warn(icalerror_strerror(x)); \
    ical_bt(); \
-   assert(0); \
+   icalassert(0); \
 } }
 #else
 /**
@@ -405,13 +405,13 @@ LIBICAL_ICAL_EXPORT void icalerror_set_errno(icalerrorenum x);
 #ifdef __GNUC__
 #define icalerror_assert(test,message) \
 if (!(test)) { \
-    fprintf(stderr, "%s(), %s:%d: %s\n", __FUNCTION__, __FILE__, __LINE__, message); \
+    icalerrprintf("%s(), %s:%d: %s\n", __FUNCTION__, __FILE__, __LINE__, message); \
     icalerror_stop_here(); \
     abort();}
 #else /*__GNUC__*/
 #define icalerror_assert(test,message) \
 if (!(test)) { \
-    fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, message); \
+    icalerrprintf("%s:%d: %s\n", __FILE__, __LINE__, message); \
     icalerror_stop_here(); \
     abort();}
 #endif /*__GNUC__*/
@@ -518,7 +518,7 @@ if (!(test)) { \
 #define icalerror_check_arg_re(test,arg,error) \
 if (!(test)) { \
     icalerror_stop_here(); \
-    assert(0); \
+    icalassert(0); \
     return error; \
 }
 

--- a/src/libical/icalmime.c
+++ b/src/libical/icalmime.c
@@ -185,7 +185,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
         const char *minor = sspm_minor_type_string(parts[i].header.minor);
 
         if (parts[i].header.minor == SSPM_UNKNOWN_MINOR_TYPE) {
-            assert(parts[i].header.minor_text != 0);
+            icalassert(parts[i].header.minor_text != 0);
             minor = parts[i].header.minor_text;
         }
 
@@ -195,7 +195,7 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
 
         if (comp == 0) {
             /* HACK Handle Error */
-            assert(0);
+            icalassert(0);
         }
 
         if (parts[i].header.error != SSPM_NO_ERROR) {
@@ -322,12 +322,12 @@ icalcomponent *icalmime_parse(char *(*get_string) (char *s, size_t size, void *d
 
             icalcomponent_add_component(parent, comp);
         } else {
-            assert(0);
+            icalassert(0);
         }
 
         last = comp;
         last_level = parts[i].level;
-        assert(parts[i].data == 0);
+        icalassert(parts[i].data == 0);
     }
 
     sspm_free_parts(parts, NUM_PARTS);

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -661,8 +661,8 @@ icalcomponent *icalparser_parse(icalparser *parser,
                 /* This is bad news... assert? */
             }
 
-            assert(parser->root_component == 0);
-            assert(pvl_count(parser->components) == 0);
+            icalassert(parser->root_component == 0);
+            icalassert(pvl_count(parser->components) == 0);
 
             if (root == 0) {
                 /* Just one component */
@@ -682,7 +682,7 @@ icalcomponent *icalparser_parse(icalparser *parser,
 
             } else {
                 /* Badness */
-                assert(0);
+                icalassert(0);
             }
 
             c = 0;
@@ -820,7 +820,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
                 (void)icalparser_clean(parser); /* may reset parser->root_component */
             }
 
-            assert(pvl_count(parser->components) == 0);
+            icalassert(pvl_count(parser->components) == 0);
 
             parser->state = ICALPARSER_SUCCESS;
             rtrn = parser->root_component;
@@ -1247,7 +1247,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
     if (pvl_data(pvl_tail(parser->components)) == 0 && parser->level == 0) {
         /* HACK. Does this clause ever get executed? */
         parser->state = ICALPARSER_SUCCESS;
-        assert(0);
+        icalassert(0);
         return parser->root_component;
     } else {
         parser->state = ICALPARSER_IN_PROGRESS;

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -812,7 +812,7 @@ void icalproperty_set_value_from_string(icalproperty *prop, const char *str, con
 
     if (nval == 0) {
         /* icalvalue_new_from_string sets errno */
-        assert(icalerrno != ICAL_NO_ERROR);
+        icalassert(icalerrno != ICAL_NO_ERROR);
         return;
     }
 

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -2180,7 +2180,7 @@ static int next_unit(icalrecur_iterator *impl,
 
     int end_of_data = 0;
 
-    assert(has_by_unit || this_frequency);
+    icalassert(has_by_unit || this_frequency);
 
     if (next_sub_unit && next_sub_unit(impl) == 0) {
         return 0;
@@ -2252,7 +2252,7 @@ static int prev_unit(icalrecur_iterator *impl,
 
     int end_of_data = 0;
 
-    assert(has_by_unit || this_frequency);
+    icalassert(has_by_unit || this_frequency);
 
     if (prev_sub_unit && prev_sub_unit(impl) == 0) {
         return 0;

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -1575,7 +1575,7 @@ static int parse_coord(char *coord, int len, int *degrees, int *minutes, int *se
     } else if (len == 8) {
         sscanf(coord + 1, "%3d%2d%2d", degrees, minutes, seconds);
     } else {
-        fprintf(stderr, "Invalid coordinate: %s\n", coord);
+        icalerrprintf("Invalid coordinate: %s\n", coord);
         return 1;
     }
 
@@ -1732,7 +1732,7 @@ static void icaltimezone_parse_zone_tab(void)
                 if (sscanf(buf, "%1000s", location) != 1) {     /*limit location to 1000chars */
                     /*increase as needed */
                     /*see location and buf declarations */
-                    fprintf(stderr, "Invalid timezone description line: %s\n", buf);
+                    icalerrprintf("Invalid timezone description line: %s\n", buf);
                     continue;
                 }
             } else if (sscanf(buf, "%4d%2d%2d %4d%2d%2d %1000s", /*limit location to 1000chars */
@@ -1742,7 +1742,7 @@ static void icaltimezone_parse_zone_tab(void)
                               &latitude_seconds,
                               &longitude_degrees, &longitude_minutes,
                               &longitude_seconds, location) != 7) {
-                fprintf(stderr, "Invalid timezone description line: %s\n", buf);
+                icalerrprintf("Invalid timezone description line: %s\n", buf);
                 continue;
             }
         } else {
@@ -1751,7 +1751,7 @@ static void icaltimezone_parse_zone_tab(void)
                                            &latitude_seconds,
                                            &longitude_degrees, &longitude_minutes,
                                            &longitude_seconds, location)) {
-                fprintf(stderr, "Invalid timezone description line: %s\n", buf);
+                icalerrprintf("Invalid timezone description line: %s\n", buf);
                 continue;
             }
         }
@@ -1856,7 +1856,7 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
 
         /* ##### B.# Sun, 11 Nov 2001 04:04:29 +1100
            this is where the MALFORMEDDATA error is being set, after the call to 'icalparser_parse'
-           fprintf(stderr, "** WARNING ** %s: %d %s\n",
+           icalerrprintf("** WARNING ** %s: %d %s\n",
                    __FILE__, __LINE__, icalerror_strerror(icalerrno));
          */
 
@@ -2003,7 +2003,7 @@ static void format_utc_offset(int utc_offset, char *buffer, size_t buffer_size)
        hours, and daylight saving shouldn't change it by more than a few hours.
        (The maximum offset is 15 hours 56 minutes at present.) */
     if (hours < 0 || hours >= 24 || minutes < 0 || minutes >= 60 || seconds < 0 || seconds >= 60) {
-        fprintf(stderr, "Warning: Strange timezone offset: H:%i M:%i S:%i\n",
+        icalerrprintf("Warning: Strange timezone offset: H:%i M:%i S:%i\n",
                 hours, minutes, seconds);
     }
 

--- a/src/libical/icptrholder_cxx.h
+++ b/src/libical/icptrholder_cxx.h
@@ -106,13 +106,13 @@ public:
 
     T *operator->() const
     {
-        assert(ptr);
+        icalassert(ptr);
         return ptr;
     }
 
     T &operator*()
     {
-        assert(ptr);
+        icalassert(ptr);
         return *ptr;
     }
 

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -277,7 +277,7 @@ void pvl_insert_ordered(pvl_list L, pvl_comparef f, void *d)
 
     /* badness, choke */
 #if !defined(lint)
-    assert(0);
+    icalassert(0);
 #endif
 }
 

--- a/src/libical/sspm.c
+++ b/src/libical/sspm.c
@@ -399,7 +399,7 @@ static struct sspm_action_map get_action(struct mime_impl *impl,
             return sspm_action_map[i];
         }
     }
-    assert(i < len);    /*should return before now */
+    icalassert(i < len);    /*should return before now */
     return sspm_action_map[0];
 }
 
@@ -654,7 +654,7 @@ static void sspm_read_header(struct mime_impl *impl, struct sspm_header *header)
                 impl->state = IN_HEADER;
                 current_line++;
 
-                assert(strlen(buf) < TMP_BUF_SIZE);
+                icalassert(strlen(buf) < TMP_BUF_SIZE);
 
                 strncpy(header_lines[current_line], buf, TMP_BUF_SIZE);
                 header_lines[current_line][TMP_BUF_SIZE - 1] = '\0';
@@ -686,7 +686,7 @@ static void sspm_read_header(struct mime_impl *impl, struct sspm_header *header)
                     buf_start++;
                 }
 
-                assert(strlen(buf_start) + strlen(last_line) < TMP_BUF_SIZE);
+                icalassert(strlen(buf_start) + strlen(last_line) < TMP_BUF_SIZE);
 
                 strncat(last_line, buf_start, TMP_BUF_SIZE - strlen(last_line) - 1);
 
@@ -745,7 +745,7 @@ static void sspm_make_part(struct mime_impl *impl,
 
                 /* Read until the paired terminating boundary */
                 if ((boundary = (char *)icalmemory_new_buffer(strlen(line) + 5)) == 0) {
-                    fprintf(stderr, "Out of memory");
+                    icalerrprintf("Out of memory");
                     abort();
                 }
                 strcpy(boundary, line);
@@ -783,7 +783,7 @@ static void sspm_make_part(struct mime_impl *impl,
 
                 /* Read until the paired terminating boundary */
                 if ((boundary = (char *)icalmemory_new_buffer(strlen(line) + 5)) == 0) {
-                    fprintf(stderr, "Out of memory");
+                    icalerrprintf("Out of memory");
                     abort();
                 }
                 strcpy(boundary, line);
@@ -802,7 +802,7 @@ static void sspm_make_part(struct mime_impl *impl,
             *size = strlen(line);
 
             data = (char *)icalmemory_new_buffer(*size + 2);
-            assert(data != 0);
+            icalassert(data != 0);
             if (header->encoding == SSPM_BASE64_ENCODING) {
                 rtrn = decode_base64(data, line, size);
             } else if (header->encoding == SSPM_QUOTED_PRINTABLE_ENCODING) {
@@ -882,7 +882,7 @@ static void *sspm_make_multipart_subpart(struct mime_impl *impl, struct sspm_hea
         while ((line = sspm_get_next_line(impl)) != 0) {
             if (sspm_is_mime_boundary(line)) {
 
-                assert(parent_header != 0);
+                icalassert(parent_header != 0);
 
                 /* Check if it is the right boundary */
                 if (!sspm_is_mime_terminating_boundary(line) &&
@@ -902,7 +902,7 @@ static void *sspm_make_multipart_subpart(struct mime_impl *impl, struct sspm_hea
 
                     /* Read until the paired terminating boundary */
                     if ((boundary = (char *)icalmemory_new_buffer(strlen(line) + 5)) == 0) {
-                        fprintf(stderr, "Out of memory");
+                        icalerrprintf("Out of memory");
                         abort();
                     }
                     strcpy(boundary, line);
@@ -1144,7 +1144,7 @@ char *decode_base64(char *dest, char *src, size_t *size)
             cc = -1;
         }
 
-        assert(cc < 64);
+        icalassert(cc < 64);
 
         /* If we've reached the end, fill the remaining slots in
            the bucket and do a final conversion */
@@ -1352,7 +1352,7 @@ static void sspm_write_base64(struct sspm_buffer *buf, char *inbuf, int size)
         break;
 
     default:
-        assert(0);
+        icalassert(0);
     }
 
     for (i = 0; i < 4; i++) {
@@ -1387,7 +1387,7 @@ static void sspm_encode_base64(struct sspm_buffer *buf, char *data, size_t size)
             inbuf[0] = inbuf[1] = inbuf[2] = 0;
         }
 
-        assert(lpos % 4 == 0);
+        icalassert(lpos % 4 == 0);
 
         if (lpos == 72) {
             sspm_append_string(buf, "\n");
@@ -1425,7 +1425,7 @@ static void sspm_write_header(struct sspm_buffer *buf, struct sspm_header *heade
     minor = sspm_minor_type_string(header->minor);
 
     if (header->minor == SSPM_UNKNOWN_MINOR_TYPE) {
-        assert(header->minor_text != 0);
+        icalassert(header->minor_text != 0);
         minor = header->minor_text;
     }
 
@@ -1473,7 +1473,7 @@ static void sspm_write_part(struct sspm_buffer *buf, struct sspm_part *part, int
     }
 
     if (part->header.encoding == SSPM_BASE64_ENCODING) {
-        assert(part->data_size != 0);
+        icalassert(part->data_size != 0);
         sspm_encode_base64(buf, part->data, part->data_size);
     } else if (part->header.encoding == SSPM_QUOTED_PRINTABLE_ENCODING) {
         sspm_encode_quoted_printable(buf, part->data);
@@ -1501,7 +1501,7 @@ static void sspm_write_multipart_part(struct sspm_buffer *buf,
 
     while (parts[*part_num].header.major != SSPM_NO_MAJOR_TYPE && level == parent_level + 1) {
 
-        assert(header->boundary != NULL);
+        icalassert(header->boundary != NULL);
         sspm_append_string(buf, header->boundary);
         sspm_append_char(buf, '\n');
 


### PR DESCRIPTION
This PR centralizes the use of `fprintf(err, ...)` and `assert()` within `src/libical` to allow easy replacement where necessary. E.g. when compiling for resource-constrained devices, linking `fprintf()` might not be desirable due to the imposed program size. By using centrally defined macros instead, the functions can easily be replaced by no-ops. We could also easily add flags for this to the CMAKE config in a future PR if deemed required.