### PR TITLE
Make icalmemory & icalarray more robust against out of memory

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -236,7 +236,8 @@ char *icalcomponent_as_ical_string(icalcomponent *impl)
     char *buf;
 
     buf = icalcomponent_as_ical_string_r(impl);
-    icalmemory_add_tmp_buffer(buf);
+    if (buf)
+        icalmemory_add_tmp_buffer(buf);
     return buf;
 }
 
@@ -269,6 +270,9 @@ char *icalcomponent_as_ical_string_r(icalcomponent *impl)
     icalerror_check_arg_rz((kind_string != 0), "Unknown kind of component");
 
     buf = icalmemory_new_buffer(buf_size);
+    if (buf == NULL)
+        return NULL;
+
     buf_ptr = buf;
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, "BEGIN:");
@@ -289,9 +293,10 @@ char *icalcomponent_as_ical_string_r(icalcomponent *impl)
         c = (icalcomponent *) pvl_data(itr);
 
         tmp_buf = icalcomponent_as_ical_string_r(c);
-
-        icalmemory_append_string(&buf, &buf_ptr, &buf_size, tmp_buf);
-        icalmemory_free_buffer(tmp_buf);
+        if (tmp_buf != NULL) {
+            icalmemory_append_string(&buf, &buf_ptr, &buf_size, tmp_buf);
+            icalmemory_free_buffer(tmp_buf);
+        }
     }
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, "END:");
@@ -532,7 +537,8 @@ void icalcomponent_add_component(icalcomponent *parent, icalcomponent *child)
         if (!parent->timezones)
             parent->timezones = icaltimezone_array_new();
 
-        icaltimezone_array_append_from_vtimezone(parent->timezones, child);
+        if (parent->timezones)
+            icaltimezone_array_append_from_vtimezone(parent->timezones, child);
 
         /* Flag that we need to sort it before doing any binary searches. */
         parent->timezones_sorted = 0;
@@ -796,7 +802,8 @@ int icalproperty_recurrence_is_excluded(icalcomponent *comp,
                   /** exrule_time > recurtime **/
         }
 
-        icalrecur_iterator_free(exrule_itr);
+        if (exrule_itr)
+            icalrecur_iterator_free(exrule_itr);
     }
     comp->property_iterator = property_iterator;
 
@@ -1998,6 +2005,9 @@ void icalcomponent_merge_component(icalcomponent *comp, icalcomponent *comp_to_m
        For each VTIMEZONE found, check if we need to add it to comp and if we
        need to rename it and all TZID references to it. */
     tzids_to_rename = icalarray_new(sizeof(char *), 16);
+    if (!tzids_to_rename)
+        return;
+
     subcomp = icalcomponent_get_first_component(comp_to_merge, ICAL_VTIMEZONE_COMPONENT);
     while (subcomp) {
         next_subcomp = icalcomponent_get_next_component(comp_to_merge, ICAL_VTIMEZONE_COMPONENT);

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -123,6 +123,8 @@ static buffer_ring *buffer_ring_new(void)
     int i;
 
     br = (buffer_ring *) icalmemory_new_buffer(sizeof(buffer_ring));
+    if (!br)
+        return NULL;
 
     for (i = 0; i < BUFFER_RING_SIZE; i++) {
         br->ring[i] = 0;
@@ -182,6 +184,9 @@ static buffer_ring *get_buffer_ring(void)
 void icalmemory_add_tmp_buffer(void *buf)
 {
     buffer_ring *br = get_buffer_ring();
+    if (!br) {
+        return;
+    }
 
     /* Wrap around the ring */
     if (++(br->pos) == BUFFER_RING_SIZE) {
@@ -229,6 +234,8 @@ void icalmemory_free_ring()
     buffer_ring *br;
 
     br = get_buffer_ring();
+    if (!br)
+        return;
 
     icalmemory_free_ring_byval(br);
 #if defined(HAVE_PTHREAD)
@@ -241,7 +248,15 @@ void icalmemory_free_ring()
 /* Like strdup, but the buffer is on the ring. */
 char *icalmemory_tmp_copy(const char *str)
 {
-    char *b = icalmemory_tmp_buffer(strlen(str) + 1);
+    char *b;
+    
+    if (!str)
+        return NULL;
+
+    b = icalmemory_tmp_buffer(strlen(str) + 1);
+
+    if (!b)
+        return NULL;
 
     strcpy(b, str);
 
@@ -328,6 +343,10 @@ void icalmemory_append_string(char **buf, char **pos, size_t *buf_size, const ch
         *buf_size = (*buf_size) * 2 + final_length;
 
         new_buf = icalmemory_resize_buffer(*buf, *buf_size);
+        if (!new_buf) {
+            // an error was set in the resize function, so we just return here.
+            return;
+        }
 
         new_pos = (void *)((size_t) new_buf + data_length);
 
@@ -365,6 +384,10 @@ void icalmemory_append_char(char **buf, char **pos, size_t *buf_size, char ch)
         *buf_size = (*buf_size) * 2 + final_length + 1;
 
         new_buf = icalmemory_resize_buffer(*buf, *buf_size);
+        if (!new_buf) {
+            // an error was set in the resize function, so we just return here.
+            return;
+        }
 
         new_pos = (void *)((size_t) new_buf + data_length);
 

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1365,6 +1365,9 @@ icalcomponent *icalparser_parse_string(const char *str)
     d.str = str;
 
     p = icalparser_new();
+    if (!p)
+        return NULL;
+
     icalparser_set_gen_data(p, &d);
 
     icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, ICAL_ERROR_NONFATAL);


### PR DESCRIPTION
This PR makes some functions from icalmemory, icalarray and some other files somewhat more robust against out of memory errors. This is especially, but not only relevant for resource-constrained devices like embedded devices. The PR covers just a few functions I came across but there's certainly more to find. It would probably be a good idea to do a more comprehensive analysis as errors in memory management could easily cause security issues.