### PR TITLE
Test for consistent use of icalmemory_new_buffer() et al and make the inner memory management functions configurable.

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -551,3 +551,7 @@ typedef ssize_t IO_SSIZE_T;
 
 #define icalassert(...) assert(__VA_ARGS__)
 #define icalerrprintf(...) fprintf(stderr, __VA_ARGS__)
+
+#define ICALMEMORY_DEFAULT_MALLOC malloc
+#define ICALMEMORY_DEFAULT_REALLOC realloc
+#define ICALMEMORY_DEFAULT_FREE free

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -281,6 +281,44 @@ char *icalmemory_strdup(const char *s)
     return res;
 }
 
+#if defined(ICALMEMORY_DEFAULT_MALLOC)
+static icalmemory_malloc_f global_icalmem_malloc = &ICALMEMORY_DEFAULT_MALLOC;
+#else
+static icalmemory_malloc_f global_icalmem_malloc = NULL;
+#endif
+
+#if defined(ICALMEMORY_DEFAULT_REALLOC)
+static icalmemory_realloc_f global_icalmem_realloc = &ICALMEMORY_DEFAULT_REALLOC;
+#else
+static icalmemory_realloc_f global_icalmem_realloc = NULL;
+#endif
+
+#if defined(ICALMEMORY_DEFAULT_FREE)
+static icalmemory_free_f global_icalmem_free = &ICALMEMORY_DEFAULT_FREE;
+#else
+static icalmemory_free_f global_icalmem_free = NULL;
+#endif
+
+
+void icalmemory_set_mem_alloc_funcs(icalmemory_malloc_f f_malloc, icalmemory_realloc_f f_realloc, icalmemory_free_f f_free)
+{
+    global_icalmem_malloc = f_malloc;
+    global_icalmem_realloc = f_realloc;
+    global_icalmem_free = f_free;
+}
+
+void icalmemory_get_mem_alloc_funcs(icalmemory_malloc_f* f_malloc, icalmemory_realloc_f* f_realloc, icalmemory_free_f* f_free) {
+    if (f_malloc) {
+        *f_malloc = global_icalmem_malloc;
+    }
+    if (f_realloc) {
+        *f_realloc = global_icalmem_realloc;
+    }
+    if (f_free) {
+        *f_free = global_icalmem_free;
+    }
+}
+
 /*
  * These buffer routines create memory the old fashioned way -- so the
  * caller will have to deallocate the new memory
@@ -288,7 +326,14 @@ char *icalmemory_strdup(const char *s)
 
 void *icalmemory_new_buffer(size_t size)
 {
-    void *b = malloc(size);
+    void *b;
+
+    if (global_icalmem_malloc == NULL) {
+        icalerror_set_errno(ICAL_NEWFAILED_ERROR);
+        return 0;
+    }
+
+    b = global_icalmem_malloc(size);
 
     if (b == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
@@ -302,7 +347,14 @@ void *icalmemory_new_buffer(size_t size)
 
 void *icalmemory_resize_buffer(void *buf, size_t size)
 {
-    void *b = realloc(buf, size);
+    void *b;
+
+    if (global_icalmem_realloc == NULL) {
+        icalerror_set_errno(ICAL_NEWFAILED_ERROR);
+        return 0;
+    }
+
+    b = global_icalmem_realloc(buf, size);
 
     if (b == 0) {
         icalerror_set_errno(ICAL_NEWFAILED_ERROR);
@@ -314,7 +366,12 @@ void *icalmemory_resize_buffer(void *buf, size_t size)
 
 void icalmemory_free_buffer(void *buf)
 {
-    free(buf);
+    if (global_icalmem_free == NULL) {
+        icalerror_set_errno(ICAL_NEWFAILED_ERROR);
+        return;
+    }
+
+    global_icalmem_free(buf);
 }
 
 void icalmemory_append_string(char **buf, char **pos, size_t *buf_size, const char *string)

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -271,7 +271,7 @@ static char *parse_posix_zone(char *p, ttinfo *type)
         size = strcspn(p, "-+0123456789,\n");
     }
 
-    type->zname = (char *) malloc(size + 1);
+    type->zname = (char *) icalmemory_new_buffer(size + 1);
     strncpy(type->zname, p, size);
     type->zname[size] = '\0';
     p += size;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -96,6 +96,8 @@ set(regression_SRCS
   regression-utils.c
   regression-recur.c
   regression-storage.c
+  test-malloc.c
+  test-malloc.h
 )
 if(WITH_CXX_BINDINGS)
   list(APPEND regression_SRCS regression-cxx.cpp)

--- a/src/test/regression-utils.c
+++ b/src/test/regression-utils.c
@@ -23,6 +23,8 @@
 
 #include "libical/ical.h"
 
+#include "test-malloc.h"
+
 #include <stdlib.h>
 
 int QUIET = 0;
@@ -212,7 +214,19 @@ void test_run(const char *test_name, void (*test_fcn) (void), int do_test, int h
         test_header(test_name, test_set);
 
     if (!headeronly && (do_test == 0 || do_test == test_set)) {
+        testmalloc_reset();
         (*test_fcn) ();
+
+        /* TODO: Check for memory leaks here. We could do a check like the
+        following but we would have to implement the test-cases in a way
+        that all memory is freed at the end of each test. This would include
+        freeing built in and cached timezones.
+
+            ok("no memory leaked",
+                (global_testmalloc_statistics.mem_allocated_current == 0)
+                && (global_testmalloc_statistics.blocks_allocated == 0));
+        */
+
         if (!QUIET)
             printf("\n");
     }

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -27,6 +27,7 @@
 
 #include "regression.h"
 #include "libical/astime.h"
+#include "test-malloc.h"
 #include "libical/ical.h"
 #include "libicalss/icalss.h"
 #include "libicalvcal/icalvcal.h"
@@ -5204,6 +5205,12 @@ int main(int argc, char *argv[])
     int do_test = 0;
     int do_header = 0;
     int failed_count = 0;
+
+    // We specify special versions of malloc et al. that perform some extra verifications.
+    // Most notably they ensure, that memory allocated with icalmemory_new_buffer() is freed
+    // using icalmemory_free() rather than using free() directly and vice versa. Failing to
+    // do so would cause the test to fail with assertions or access violations.
+    icalmemory_set_mem_alloc_funcs(&test_malloc, &test_realloc, &test_free);
 
     set_zone_directory(TEST_ZONEDIR);
     icaltimezone_set_tzid_prefix(TESTS_TZID_PREFIX);

--- a/src/test/test-malloc.c
+++ b/src/test/test-malloc.c
@@ -1,0 +1,180 @@
+/*======================================================================
+FILE: test-malloc.c
+
+(C) COPYRIGHT 2018-2022, Markus Minichmayr <markus@tapkey.com>
+
+ This library is free software; you can redistribute it and/or modify
+ it under the terms of either:
+
+    The LGPL as published by the Free Software Foundation, version
+    2.1, available at: https://www.gnu.org/licenses/lgpl-2.1.html
+
+ Or:
+
+    The Mozilla Public License Version 2.0. You may obtain a copy of
+    the License at https://www.mozilla.org/MPL/
+======================================================================*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "test-malloc.h"
+#include "regression.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+
+
+struct testmalloc_statistics global_testmalloc_statistics;
+static int global_testmalloc_remaining_attempts = -1;
+
+#define TESTMALLOC_MAGIC_NO 0x1234abcd
+struct testmalloc_hdr {
+    uint32_t magic_no;
+    size_t size;
+};
+
+struct testmalloc_hdrlayout {
+
+    struct testmalloc_hdr hdr;
+    int data;
+};
+
+#define TESTMALLOC_HDR_SIZE ((size_t) &((struct testmalloc_hdrlayout*) 0)->data)
+
+
+void *test_malloc(size_t size) {
+
+    void* block;
+    struct testmalloc_hdr* hdr;
+
+    global_testmalloc_statistics.malloc_cnt++;
+    if (global_testmalloc_remaining_attempts == 0) {
+        global_testmalloc_statistics.malloc_failed_cnt++;
+        return NULL;
+    }
+
+    block = malloc(size + TESTMALLOC_HDR_SIZE);
+    if (block == NULL) {
+        global_testmalloc_statistics.malloc_failed_cnt++;
+        return NULL;
+    }
+
+    hdr = (struct testmalloc_hdr*) block;
+    hdr->magic_no = TESTMALLOC_MAGIC_NO;
+    hdr->size = size;
+
+    global_testmalloc_statistics.mem_allocated_current += size;
+    if (global_testmalloc_statistics.mem_allocated_current > global_testmalloc_statistics.mem_allocated_max) {
+        global_testmalloc_statistics.mem_allocated_max = global_testmalloc_statistics.mem_allocated_current;
+    }
+
+    global_testmalloc_statistics.blocks_allocated++;
+
+    if (global_testmalloc_remaining_attempts > 0) {
+        global_testmalloc_remaining_attempts--;
+    }
+
+    // cppcheck-suppress memleak
+    return (void*) &((struct testmalloc_hdrlayout *) hdr)->data;
+}
+
+void *test_realloc(void* p, size_t size) {
+
+    struct testmalloc_hdr* hdr;
+    size_t old_size;
+
+    global_testmalloc_statistics.realloc_cnt++;
+    if (global_testmalloc_remaining_attempts == 0) {
+        global_testmalloc_statistics.realloc_failed_cnt++;
+        return NULL;
+    }
+
+    if (p == NULL) {
+        global_testmalloc_statistics.realloc_failed_cnt++;
+        return NULL;
+    }
+
+    hdr = (struct testmalloc_hdr *) (((uint8_t *) p) - TESTMALLOC_HDR_SIZE);
+    if (hdr->magic_no != TESTMALLOC_MAGIC_NO) {
+        global_testmalloc_statistics.realloc_failed_cnt++;
+        return NULL;
+    }
+
+    old_size = hdr->size;
+    hdr->magic_no = 0;
+
+    // cppcheck-suppress memleakOnRealloc; the mem block p passed to this function stays valid.
+    hdr = (struct testmalloc_hdr*) realloc(hdr, size + TESTMALLOC_HDR_SIZE);
+    if (hdr == NULL) {
+        global_testmalloc_statistics.realloc_failed_cnt++;
+        return NULL;
+    }
+
+    hdr->magic_no = TESTMALLOC_MAGIC_NO;
+    hdr->size = size;
+
+    global_testmalloc_statistics.mem_allocated_current += size - old_size;
+    if (global_testmalloc_statistics.mem_allocated_current > global_testmalloc_statistics.mem_allocated_max) {
+        global_testmalloc_statistics.mem_allocated_max = global_testmalloc_statistics.mem_allocated_current;
+    }
+
+    if (global_testmalloc_remaining_attempts > 0) {
+        global_testmalloc_remaining_attempts--;
+    }
+
+    return (void*) &((struct testmalloc_hdrlayout*)hdr)->data;
+}
+
+void test_free(void* p) {
+
+    struct testmalloc_hdr* hdr;
+    size_t old_size;
+
+    if (p == NULL) {
+        return;
+    }
+
+    global_testmalloc_statistics.free_cnt++;
+
+    hdr = (struct testmalloc_hdr *) (((uint8_t *) p) - TESTMALLOC_HDR_SIZE);
+
+    // The main objective of this check is to ensure, that only memory, that has been allocated via icalmemory is freed
+    // via icalmemory_free(). A side objective is to make sure, the block of memory hasn't been corrupted.
+    if (hdr->magic_no != TESTMALLOC_MAGIC_NO) {
+
+        // If we end up here, then probably either of the following happened:
+        // * The calling code tries to free a block of memory via icalmemory_free() that has been allocated outside of
+        //   icalmemory, e.g. via malloc().
+        // * The header in front of the memory block being freed has been corrupted.
+
+        ok("freed memory was allocated via icalmemory and has not been corrupted", hdr->magic_no == TESTMALLOC_MAGIC_NO);
+        assert(hdr->magic_no == TESTMALLOC_MAGIC_NO);
+        global_testmalloc_statistics.free_failed_cnt++;
+        return;
+    }
+
+    old_size = hdr->size;
+    hdr->magic_no = 0;
+
+    free(hdr);
+
+    global_testmalloc_statistics.mem_allocated_current -= old_size;
+    global_testmalloc_statistics.blocks_allocated--;
+}
+
+
+
+void testmalloc_reset() {
+    memset(&global_testmalloc_statistics, 0, sizeof(global_testmalloc_statistics));
+    global_testmalloc_remaining_attempts = -1;
+}
+
+/** Sets the maximum number of malloc or realloc attemts that will succeed. If
+* the number is negative, no limit will be applied. */
+void testmalloc_set_max_successful_allocs(int n) {
+    global_testmalloc_remaining_attempts = n;
+}

--- a/src/test/test-malloc.h
+++ b/src/test/test-malloc.h
@@ -1,0 +1,67 @@
+/*======================================================================
+FILE: test-malloc.h
+
+(C) COPYRIGHT 2018-2022, Markus Minichmayr <markus@tapkey.com>
+
+ This library is free software; you can redistribute it and/or modify
+ it under the terms of either:
+
+    The LGPL as published by the Free Software Foundation, version
+    2.1, available at: https://www.gnu.org/licenses/lgpl-2.1.html
+
+ Or:
+
+    The Mozilla Public License Version 2.0. You may obtain a copy of
+    the License at https://www.mozilla.org/MPL/
+======================================================================*/
+
+#ifndef TESTMALLOC_H
+#define TESTMALLOC_H
+
+#include <stdint.h>
+
+
+struct testmalloc_statistics {
+    int malloc_cnt;
+    int realloc_cnt;
+    int free_cnt;
+
+    int malloc_failed_cnt;
+    int realloc_failed_cnt;
+    int free_failed_cnt;
+
+    size_t mem_allocated_max;
+    size_t mem_allocated_current;
+    int blocks_allocated;
+};
+
+extern struct testmalloc_statistics global_testmalloc_statistics;
+
+/** Allocates the specified amount of memory and returns a pointer to the allocated memory.
+  * Memory allocated using this function must be freed using test_free().
+  * The number of allocations that can be made using this function can be limited via
+  * testmalloc_set_max_successful_allocs().
+  */
+void *test_malloc(size_t size);
+
+/** Resizes the specified buffer.
+ * Can only be used with memory that has previously been allocated using test_malloc().
+ */
+void *test_realloc(void* p, size_t size);
+
+/** Frees a block of memory that has previously been allocated via the test_malloc() function. Specifying memory that
+ * has not been allocated via test_malloc() causes an assertion.
+ */
+void test_free(void* p);
+
+/** Resets the memory management statistics and sets the number of successful
+  * allocations limit to infinite.
+  */
+void testmalloc_reset();
+
+/** Sets the maximum number of malloc or realloc attemts that will succeed. If 
+  * the number is negative, no limit will be applied.
+  */
+void testmalloc_set_max_successful_allocs(int n);
+
+#endif /* !TESTMALLOC_H */


### PR DESCRIPTION
This is a follow-up to libical/libical#542. It allows configuring the memory management functions (malloc, ...) used within `icalmemory` at runtime. The functionality is used to configure special versions of the functions during certain tests that ensure consistent use of memory allocation functions from icalmemory.

## `icalmemory`
The new functions `icalmemory_get_mem_alloc_funcs()` and `icalmemory_set_mem_alloc_funcs()` are introduced that allow getting and setting custom versions of `malloc()`, `realloc()` and  `free()`. The default versions are configured via `config.h.cmake`.

The changes are quite streight-forward and therefore not very risky.

## Tests
The regression tests are extended to use special test-versions of the mem-management functions that ensure consistent use of the memory management functions from `icalmemory()`. I.e. they ensure that:
* Memory allocated via `icalmemory` is not freed via stdlib `free()`, as otherwise an access violation would be raised.
* Memory allocated outside of `icalmemory` is not freed via `icalmemory`, as otherwise an assertion would be raised.

The test functions could also be used for verifying that the number of allocations matches the number of deallocations, but this would require some tweaking, as many tests load time zone data into the internal cache, which isn't freed at the end of each test as of today.

For now the test memory management funcs are only used in regression.c. It would certainly make sense to use them throughout all of the tests, but this would require some tweaking in the CMAKE build scripts. Any suggestion on how to best implement this in a fairly generic manner would be welcome.