### PR TITLE
cmake: Do not export CC into gir compiler

### DIFF
--- a/cmake/modules/GObjectIntrospectionMacros.cmake
+++ b/cmake/modules/GObjectIntrospectionMacros.cmake
@@ -50,8 +50,7 @@ macro(gir_add_introspections introspections_girs)
     set(_gir_libtool "--no-libtool")
 
     add_custom_command(
-      COMMAND ${CMAKE_COMMAND} -E env "CC='${CMAKE_C_COMPILER}'"
-              ${GObjectIntrospection_SCANNER}
+      COMMAND ${GObjectIntrospection_SCANNER}
               ${GObjectIntrospection_SCANNER_ARGS}
               --namespace=${_gir_namespace}
               --nsversion=${_gir_version}


### PR DESCRIPTION
Since bare compiler in OE will not work, it has to have the needed
options from HOST_CC_ARCH and TOOLCHAIN_OPTIONS appended to it

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>