### PR TITLE
Add UsingLibical.md to Doxygen

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -18,7 +18,7 @@ set_package_properties(Doxygen PROPERTIES
   PURPOSE "Needed to build the API documentation."
 )
 if(DOXYGEN_FOUND)
-  file(GLOB _dox_deps *.dox *.html)
+  file(GLOB _dox_deps *.dox *.html *.md)
   file(GLOB _all_hdrs
     ${CMAKE_SOURCE_DIR}/src/libical/*.h
     ${CMAKE_SOURCE_DIR}/src/libical/*.c

--- a/doc/Doxyfile.cmake
+++ b/doc/Doxyfile.cmake
@@ -86,6 +86,7 @@ FILE_PATTERNS          = *.cpp \
                          *.hh \
                          *.hxx \
                          *.hpp \
+                         *.md \
                          *.dox
 RECURSIVE              = YES
 EXCLUDE                = @CMAKE_SOURCE_DIR@/src/java \
@@ -106,7 +107,7 @@ EXCLUDE_PATTERNS       = */.svn/* \
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = @CMAKE_SOURCE_DIR@/docs
+IMAGE_PATH             = @CMAKE_SOURCE_DIR@/doc
 INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO

--- a/doc/Mainpage.dox
+++ b/doc/Mainpage.dox
@@ -13,6 +13,9 @@ the CalDav scheduling extensions in RFC6638;
 iCalendar extensions in RFC7986, RFC9073, RFC9074;
 plus the iCalendar iMIP protocol in RFC6047.
 
+For a conceptual overview of the library, see 
+[Using Libical](@ref UsingLibical).
+
 @section license License
 
 The code and datafiles in this distribution are licensed under the

--- a/doc/UsingLibical.md
+++ b/doc/UsingLibical.md
@@ -1,4 +1,4 @@
-# Using Libical
+# Using Libical {#UsingLibical}
 
 >   Author: Eric Busboom <eric@civicknowledge.com>
 >   


### PR DESCRIPTION
I'm not quite sure if the changes I made to the build system are appropriate, since I am largely unfamiliar with cmake. They do get the documentation to build properly for me, though.

I found an issue in the doxyfile where the logs were warning about a nonexistent directory "docs". I changed it to "doc", since I assume that's what it's referring to.

Unfortunately, adding the header marker does break the rendering in GitHub flavored Markdown. I'm not sure why, since from what I can tell it's supposed to use the same `{#label}` syntax, but that is a negative effect of this PR.