### PR TITLE
parameters.csv: Fix enum value clashing

### DIFF
--- a/design-data/parameters.csv
+++ b/design-data/parameters.csv
@@ -51,15 +51,14 @@
 "SIZE","41","const char*",
 "FILENAME","42","const char*",
 "#Task Extension Parameters","draft-apthorp-ical-tasks"
-"REASON","43","const char*",
+"REASON","47","const char*",
 "MODIFIED","44","const char*",
 "SUBSTATE","45","icalparameter_substate",X=21900;OK;ERROR;SUSPENDED;NONE=21999",
 "#Parameters from New Properties for iCalendar","RFC 7986 Section 6"
 "DISPLAY","46","icalparameter_display",X=22000;BADGE;GRAPHIC;FULLSIZE;THUMBNAIL;NONE=22099",
-"EMAIL","47","const char*",
+"EMAIL","50","const char*",
 "FEATURE","48","icalparameter_feature",X=22100;AUDIO;CHAT;FEED;MODERATOR;PHONE;SCREEN;VIDEO;NONE=22199",
 "LABEL","49","const char*",
-"EMAIL","50","const char*",
 "#VPATCH Extension Parameters","draft-daboo-icalendar-vpatch"
 "PATCH-ACTION","51","icalparameter_patchaction",X=22200;CREATE;BYNAME;BYVALUE;BYPARAM;NONE=22299",
 "#NOTE for updaters.  Preserve the icalparameter_kind Enum values to aid forward compatibility"


### PR DESCRIPTION
Two problems:
* EMAIL being defined twice
* REASON and REQUIRED use the same value

The effect of this patch is that only the ICAL_REASON_PARAMETER
value changes from 43 to 47, the ICAL_EMAIL_PARAMETER value
stays unchanged.