### PR TITLE
Avoid {#mainpage} in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Libical — an implementation of iCalendar protocols and data formats {#mainpage}
+# Libical — an implementation of iCalendar protocols and data formats
 
 [![Appveyor status](https://ci.appveyor.com/api/projects/status/github/libical/libical?branch=master?svg=true)](https://ci.appveyor.com/api/projects/status/github/libical/libical)
 [![Packaging status](https://repology.org/badge/tiny-repos/libical.svg)](https://repology.org/metapackage/libical)

--- a/doc/Doxyfile.cmake
+++ b/doc/Doxyfile.cmake
@@ -81,6 +81,7 @@ WARN_LOGFILE           = doxygen.log
 # configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = @DOXYGEN_INPUT@
+USE_MDFILE_AS_MAINPAGE = README.md
 FILE_PATTERNS          = *.cpp \
                          *.c \
                          *.cc \


### PR DESCRIPTION
This fixes at least one of the issues in #576, by removing the need for the `{#mainpage}` tag in the header of `README.md`.

I haven't found a fix for the issues with the link syntax in the readme.