### PR TITLE
Use plain Markdown link to UsingLibical.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See the top-level [Install.txt](Install.txt) file.
 
 Documentation is hosted at <https://libical.github.io/libical/apidocs/>.
 
-For a conceptual overview of the library, see [UsingLibical.md](@ref UsingLibical).
+For a conceptual overview of the library, see [Using Libical](doc/UsingLibical.md).
 There is other rudimentary, unfinished documentation in the `doc/` directory of
 the source distribution,
 and annotated examples in `examples/` and the test code in `src/test/`.

--- a/doc/UsingLibical.md
+++ b/doc/UsingLibical.md
@@ -1,4 +1,4 @@
-# Using Libical {#UsingLibical}
+# Using Libical
 
 > Author: Eric Busboom <eric@civicknowledge.com>
 >


### PR DESCRIPTION
Fixes another issue in #576 

Seemingly requires Doxygen 1.9.3 to generate the link properly. I do not have 1.9.3 available on my system. Could you check to make sure that the link is working?

This is probably as far as we're going to get in terms of fixing Doxygen-specific Markdown artifacts. But with this change, at least README.md should render properly on GitHub.