### PR TITLE
Link RFCs to README using Doxygen link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Appveyor status](https://ci.appveyor.com/api/projects/status/github/libical/libical?branch=master?svg=true)](https://ci.appveyor.com/api/projects/status/github/libical/libical)
 [![Packaging status](https://repology.org/badge/tiny-repos/libical.svg)](https://repology.org/metapackage/libical)
 
-## About
+## About {#about}
 
 Libical — an implementation of iCalendar protocols and data formats
 

--- a/doc/UsingLibical.md
+++ b/doc/UsingLibical.md
@@ -11,23 +11,10 @@ and protocol data units. The iCalendar specification describes how
 calendar clients can communicate with calendar servers so users can
 store their calendar data and arrange meetings with other users.
 
-Libical implements [RFC5545][], [RFC5546][], [RFC7529][];
-the CalDav scheduling extensions in [RFC6638][];
-the iCalendar extensions in [RFC7986][], [RFC9073][], [RFC9074][];
-and some of [RFC6047][].
-
+Libical implements multiple [RFC calendar standards](@ref about).
 This documentation assumes that you are familiar with the iCalendar
 standards RFC5545 and RFC5546. These specifications are available
-at the [IETF Tools][] website:
-
-[RFC5545]: https://tools.ietf.org/html/rfc5545
-[RFC5546]: https://tools.ietf.org/html/rfc5546
-[RFC7529]: https://tools.ietf.org/html/rfc7529
-[RFC6638]: https://tools.ietf.org/html/rfc6638
-[RFC7986]: https://tools.ietf.org/html/rfc7986
-[RFC9073]: https://tools.ietf.org/html/rfc9073
-[RFC9074]: https://tools.ietf.org/html/rfc9074
-[RFC6047]: https://tools.ietf.org/html/rfc6047
+at the [IETF Tools][] website.
 
 [IETF Tools]: https://tools.ietf.org/
 


### PR DESCRIPTION
Fixes #566 

Following the suggestion there, move all RFC information to `README.md` and link from `UsingLibical.md` instead.

This version uses Doxygen header anchors, which are incompatible with GitHub. It will reintroduce artifacts to the GitHub-rendered version of the README, as previously seen in #576. Alternative solutions given in #566, which I could change to.