### PR TITLE
Fixes to x-property comma handling and escaping

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -409,8 +409,8 @@ static char *parser_get_next_value(char *line, char **end, icalvalue_kind kind)
                 continue;
             }
         }
-        /* ignore all , for query value. select dtstart, dtend etc ... */
-        else if (kind == ICAL_QUERY_VALUE) {
+        /* ignore all commas for query and x values. select dtstart, dtend etc ... */
+        else if (kind == ICAL_QUERY_VALUE || kind == ICAL_X_VALUE) {
             if (next != 0) {
                 p = next + 1;
                 continue;

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -306,7 +306,8 @@ static char *icalmemory_strdup_and_quote(const icalvalue *value, const char *unq
                https://tools.ietf.org/html/rfc5545#section-3.8.1.2 */
             if ((icalproperty_isa(value->parent) == ICAL_CATEGORIES_PROPERTY) ||
                 (icalproperty_isa(value->parent) == ICAL_RESOURCES_PROPERTY) ||
-                (icalproperty_isa(value->parent) == ICAL_POLLPROPERTIES_PROPERTY)) {
+                (icalproperty_isa(value->parent) == ICAL_POLLPROPERTIES_PROPERTY) ||
+                (icalproperty_isa(value->parent) == ICAL_X_PROPERTY)) {
                 icalmemory_append_char(&str, &str_p, &buf_sz, *p);
                 break;
             }

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4926,6 +4926,24 @@ test_icalvalue_resets_timezone_on_set(void)
 
 static void test_remove_tzid_from_due(void)
 {
+    icalproperty *xproperty = icalproperty_new_from_string("X-TEST-PROPERTY:test,test");
+    icalcomponent *c;
+
+    c = icalcomponent_vanew(
+            ICAL_VCALENDAR_COMPONENT,
+                icalcomponent_vanew(
+                    ICAL_VEVENT_COMPONENT,
+                    xproperty,
+                    0),
+            0);
+
+    str_is("icalproperty_as_ical_string()", "X-TEST-PROPERTY:test,test\r\n", icalproperty_as_ical_string(icalcomponent_get_first_property(icalcomponent_get_inner(c), ICAL_X_PROPERTY)));
+
+    icalcomponent_free(c);
+}
+
+static void test_comma_in_xproperty(void)
+{
     icalproperty *due = icalproperty_vanew_due(icaltime_from_string("20220120T120000"), 0);
     icalcomponent *c;
 
@@ -5087,6 +5105,7 @@ int main(int argc, char *argv[])
     test_run("Test implicit DTEND and DURATION for VEVENT and VTODO", test_implicit_dtend_duration, do_test, do_header);
     test_run("Test icalvalue resets timezone on set", test_icalvalue_resets_timezone_on_set, do_test, do_header);
     test_run("Test removing TZID from DUE with icalcomponent_set_due", test_remove_tzid_from_due, do_test, do_header);
+    test_run("Test commas in x-property", test_comma_in_xproperty, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 


### PR DESCRIPTION
- Don't allow x-properties to be split into multiple values since RFC 5545 says that only explicitly documented properties should be split
- Don't escape text in x-property values since RFC 5545 says that the value should be *VALUE-CHAR rather than *SAFE-CHAR

These changes allow Apple's x-properties (such as X-CALENDARSERVER-ATTENDEE-COMMENT and X-APPLE-TRAVEL-START) to be round-tripped safely.

Fixes #592.