### PR TITLE
Fix argument guards in icaltime_as_timet to match documentation and tests.

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Release Highlights
 Version 3.0.16 (UNRELEASED):
 ----------------------------
  * Fix a regression in 3.0.15 that limited how many lines could be processed in one call to icalparser_parse()
+ * Fix argument guards in icaltime_as_timet to match documentation and tests.
 
 Version 3.0.15 (06 October 2022):
 ---------------------------------

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -120,10 +120,13 @@ static time_t make_time(struct tm *tm, int tzm)
     if (tm->tm_mon < 0 || tm->tm_mon > 11)
         return ((time_t) - 1);
 
+    if (tm->tm_year < 2)
+        return ((time_t)-1);
+
 #if (SIZEOF_TIME_T == 4)
     /* check that year specification within range */
 
-    if (tm->tm_year < 70 || tm->tm_year > 138)
+    if (tm->tm_year > 138)
         return ((time_t) - 1);
 
     /* check for upper bound of Jan 17, 2038 (to avoid possibility of
@@ -135,6 +138,11 @@ static time_t make_time(struct tm *tm, int tzm)
         } else if (tm->tm_mday > 17) {
             return ((time_t) - 1);
         }
+    }
+#else
+    /* We don't support years >= 10000, because the function has not been tested at this range. */
+    if (tm->tm_year >= 8100) {
+        return ((time_t)-1);
     }
 #endif /* SIZEOF_TIME_T */
 

--- a/src/libical/icaltime.h
+++ b/src/libical/icaltime.h
@@ -199,7 +199,8 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_from_day_of_year(const int doy,
  * only pass an icaltime in UTC, since no conversion is done.  Even in that case,
  * it's probably better to just use icaltime_as_timet_with_zone().
  *
- * The return value is defined for dates starting with 1902-01-01 until 10000-01-01 (excl.).
+ * The return value is defined for dates ranging from 1902-01-01 (incl.) up to 10000-01-01 (excl.)
+ * if time_t has a size of 64 bit and up to 2038-01-18 (excl.) if it has a size of 32 bit.
  */
 LIBICAL_ICAL_EXPORT time_t icaltime_as_timet(const struct icaltimetype);
 


### PR DESCRIPTION
With 3.0.15 we introduced tests for `icaltime_as_timet`, checking for values starting with 1902. With 64-bit time_t this works just fine, but with 32-bit version the tests fail due to a more strict validation of input parameters that doesn't allow for dates < year 1970. With this PR we change the argument validation of `icaltime_as_timet`. We now allow dates starting with 1902 also for 32-bit time_t and we also validate the date for 64-bit time_t, allowing for 1902-01-01 through 10000-01-01 (excl.).
