### PR TITLE
Concurrency mode thread-local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,13 @@
 #  Build with the undefined sanitizer (requires gcc or clang)
 #  Default=false
 #
+# -DLIBICAL_SYNCMODE_THREADLOCAL=[true|false]
+#  Experimental: If set to true, global variables are marked as thread-local. This allows accessing
+#  libical from multiple threads without the need for synchronization. However, any global settings
+#  must be applied per thread.
+#  If set to false, the default synchronization mechanism is applied. That is, if the pthreads library
+#  is available, it will be used, otherwise no synchronization is applied.
+#  Default: false.
 
 cmake_minimum_required(VERSION 3.11.0) #first line, to shutup a cygwin warning
 project(libical C) #CXX is optional for the bindings
@@ -735,6 +742,9 @@ if(LIBICAL_DEVMODE_UNDEFINED_SANITIZER)
     set(ICAL_GLIB False)
   endif()
 endif()
+
+mark_as_advanced(LIBICAL_SYNCMODE_THREADLOCAL)
+libical_option(LIBICAL_SYNCMODE_THREADLOCAL "Experimental: Mark global variables as thread-local." False)
 
 libical_option(ENABLE_LTO_BUILD "Build a link-time optimized version." False)
 if(ENABLE_LTO_BUILD)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -582,3 +582,6 @@ typedef ssize_t IO_SSIZE_T;
 #define ICALMEMORY_DEFAULT_MALLOC malloc
 #define ICALMEMORY_DEFAULT_REALLOC realloc
 #define ICALMEMORY_DEFAULT_FREE free
+
+/* ICAL_GLOBAL_VAR is applied to global variables, therefore allows specifying custom storage attributes. */
+#define ICAL_GLOBAL_VAR

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -583,5 +583,34 @@ typedef ssize_t IO_SSIZE_T;
 #define ICALMEMORY_DEFAULT_REALLOC realloc
 #define ICALMEMORY_DEFAULT_FREE free
 
-/* ICAL_GLOBAL_VAR is applied to global variables, therefore allows specifying custom storage attributes. */
+
+#cmakedefine LIBICAL_SYNCMODE_THREADLOCAL 1
+
+#define ICAL_SYNC_MODE_NONE 1
+#define ICAL_SYNC_MODE_PTHREAD 2
+#define ICAL_SYNC_MODE_THREADLOCAL 3
+
+#ifdef LIBICAL_SYNCMODE_THREADLOCAL
+#define ICAL_SYNC_MODE ICAL_SYNC_MODE_THREADLOCAL
+#elif HAVE_PTHREAD == 1
+#define ICAL_SYNC_MODE ICAL_SYNC_MODE_PTHREAD
+#else
+#define ICAL_SYNC_MODE ICAL_SYNC_MODE_NONE
+#endif
+
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_THREADLOCAL
+#if defined(_MSC_VER)
+#define ICAL_GLOBAL_VAR __declspec(thread)
+#endif
+#if defined(__GNUC__)
+#define ICAL_GLOBAL_VAR __thread
+#endif
+#ifndef ICAL_GLOBAL_VAR
+/* thread_local has been introduced with C11. Starting with C23 it will become a keyword and
+   we won't need to include threads.h then. */
+#include <threads.h>
+#define ICAL_GLOBAL_VAR thread_local
+#endif
+#else
 #define ICAL_GLOBAL_VAR
+#endif

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1134,7 +1134,7 @@ void icalcomponent_set_parent(icalcomponent *component, icalcomponent *parent)
     component->parent = parent;
 }
 
-static icalcompiter icalcompiter_null = { ICAL_NO_COMPONENT, 0 };
+static const icalcompiter icalcompiter_null = { ICAL_NO_COMPONENT, 0 };
 
 struct icalcomponent_kind_map
 {

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -22,7 +22,7 @@
 #include <execinfo.h>
 #endif
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 #include <pthread.h>
 
 static pthread_key_t icalerrno_key;

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -57,7 +57,7 @@ icalerrorenum *icalerrno_return(void)
 
 #else
 
-static icalerrorenum icalerrno_storage = ICAL_NO_ERROR;
+static ICAL_GLOBAL_VAR icalerrorenum icalerrno_storage = ICAL_NO_ERROR;
 
 icalerrorenum *icalerrno_return(void)
 {
@@ -66,7 +66,7 @@ icalerrorenum *icalerrno_return(void)
 
 #endif
 
-static int foo;
+static ICAL_GLOBAL_VAR int foo;
 
 void icalerror_stop_here(void)
 {
@@ -92,9 +92,9 @@ void icalerror_clear_errno(void)
 }
 
 #if ICAL_ERRORS_ARE_FATAL == 1
-static int icalerror_errors_are_fatal = 1;
+static ICAL_GLOBAL_VAR int icalerror_errors_are_fatal = 1;
 #else
-static int icalerror_errors_are_fatal = 0;
+static ICAL_GLOBAL_VAR int icalerror_errors_are_fatal = 0;
 #endif
 
 void icalerror_set_errors_are_fatal(int fatal)
@@ -127,7 +127,7 @@ struct icalerror_state
     icalerrorstate state;
 };
 
-static struct icalerror_state error_state_map[] = {
+static ICAL_GLOBAL_VAR struct icalerror_state error_state_map[] = {
     {ICAL_BADARG_ERROR, ICAL_ERROR_DEFAULT},
     {ICAL_NEWFAILED_ERROR, ICAL_ERROR_DEFAULT},
     {ICAL_ALLOCATION_ERROR, ICAL_ERROR_DEFAULT},

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -43,7 +43,7 @@ typedef struct
 /**
  * @private
  */
-static buffer_ring *global_buffer_ring = 0;
+static ICAL_GLOBAL_VAR buffer_ring *global_buffer_ring = 0;
 #endif
 
 /**
@@ -265,27 +265,27 @@ char *icalmemory_strdup(const char *s)
 }
 
 #if defined(MEMORY_CONSISTENCY)
-static icalmemory_malloc_f global_icalmem_malloc = &test_malloc;
+static ICAL_GLOBAL_VAR icalmemory_malloc_f global_icalmem_malloc = &test_malloc;
 #elif defined(ICALMEMORY_DEFAULT_MALLOC) && !defined(S_SPLINT_S)
-static icalmemory_malloc_f global_icalmem_malloc = &ICALMEMORY_DEFAULT_MALLOC;
+static ICAL_GLOBAL_VAR icalmemory_malloc_f global_icalmem_malloc = &ICALMEMORY_DEFAULT_MALLOC;
 #else
-static icalmemory_malloc_f global_icalmem_malloc = NULL;
+static ICAL_GLOBAL_VAR icalmemory_malloc_f global_icalmem_malloc = NULL;
 #endif
 
 #if defined(MEMORY_CONSISTENCY)
-static icalmemory_realloc_f global_icalmem_realloc = &test_realloc;
+static ICAL_GLOBAL_VAR icalmemory_realloc_f global_icalmem_realloc = &test_realloc;
 #elif defined(ICALMEMORY_DEFAULT_REALLOC) && !defined(S_SPLINT_S)
-static icalmemory_realloc_f global_icalmem_realloc = &ICALMEMORY_DEFAULT_REALLOC;
+static ICAL_GLOBAL_VAR icalmemory_realloc_f global_icalmem_realloc = &ICALMEMORY_DEFAULT_REALLOC;
 #else
-static icalmemory_realloc_f global_icalmem_realloc = NULL;
+static ICAL_GLOBAL_VAR icalmemory_realloc_f global_icalmem_realloc = NULL;
 #endif
 
 #if defined(MEMORY_CONSISTENCY)
-static icalmemory_free_f global_icalmem_free = &test_free;
+static ICAL_GLOBAL_VAR icalmemory_free_f global_icalmem_free = &test_free;
 #elif defined(ICALMEMORY_DEFAULT_FREE) && !defined(S_SPLINT_S)
-static icalmemory_free_f global_icalmem_free = &ICALMEMORY_DEFAULT_FREE;
+static ICAL_GLOBAL_VAR icalmemory_free_f global_icalmem_free = &ICALMEMORY_DEFAULT_FREE;
 #else
-static icalmemory_free_f global_icalmem_free = NULL;
+static ICAL_GLOBAL_VAR icalmemory_free_f global_icalmem_free = NULL;
 #endif
 
 void icalmemory_set_mem_alloc_funcs(icalmemory_malloc_f f_malloc,

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -39,7 +39,7 @@ typedef struct
     void *ring[BUFFER_RING_SIZE];
 } buffer_ring;
 
-#if !defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE != ICAL_SYNC_MODE_PTHREAD
 /**
  * @private
  */
@@ -63,7 +63,7 @@ static void icalmemory_free_ring_byval(buffer_ring * br)
     icalmemory_free_buffer(br);
 }
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 #include <pthread.h>
 
 static pthread_key_t ring_key;
@@ -116,7 +116,7 @@ static buffer_ring *buffer_ring_new(void)
     return (br);
 }
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 /**
  * @private
  */
@@ -156,7 +156,7 @@ static buffer_ring *get_buffer_ring_global(void)
  */
 static buffer_ring *get_buffer_ring(void)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     return (get_buffer_ring_pthread());
 #else
     return get_buffer_ring_global();
@@ -221,7 +221,7 @@ void icalmemory_free_ring(void)
         return;
 
     icalmemory_free_ring_byval(br);
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_setspecific(ring_key, 0);
 #else
     global_buffer_ring = 0;

--- a/src/libical/icalmemory.h
+++ b/src/libical/icalmemory.h
@@ -120,8 +120,8 @@ LIBICAL_ICAL_EXPORT void icalmemory_add_tmp_buffer(void *buf);
 /**
  * @brief Frees all memory used in the ring
  *
- * Frees all memory used in the ring. Depending on if HAVE_PTHREAD is set or
- * not, the ring buffer is allocated on a per-thread basis, meaning that if all
+ * Frees all memory used in the ring. If PTHREAD is used or thread-local mode is configured,
+ * the ring buffer is allocated on a per-thread basis, meaning that if all
  * rings are to be released, it must be called once in every thread.
  *
  * @par Usage

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -375,7 +375,7 @@ static const struct expand_split_map_struct expand_map[] = {
     {ICAL_NO_RECURRENCE,       { 0, 0, 0, 0, 0, 0, 0, 0, 0 }} //krazy:exclude=style
 };
 
-static struct recur_map
+static const struct recur_map
 {
     const char *str;
     size_t offset;

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -134,7 +134,7 @@
 #include <stddef.h>     /* For offsetof() macro */
 #include <stdlib.h>
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 #include <pthread.h>
 static pthread_mutex_t invalid_rrule_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
@@ -3642,13 +3642,13 @@ ical_invalid_rrule_handling ical_get_invalid_rrule_handling_setting(void)
 {
     ical_invalid_rrule_handling myHandling;
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_lock(&invalid_rrule_mutex);
 #endif
 
     myHandling = invalidRruleHandling;
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_unlock(&invalid_rrule_mutex);
 #endif
 
@@ -3657,13 +3657,13 @@ ical_invalid_rrule_handling ical_get_invalid_rrule_handling_setting(void)
 
 void ical_set_invalid_rrule_handling_setting(ical_invalid_rrule_handling newSetting)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_lock(&invalid_rrule_mutex);
 #endif
 
     invalidRruleHandling = newSetting;
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_unlock(&invalid_rrule_mutex);
 #endif
 }

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -139,7 +139,7 @@
 static pthread_mutex_t invalid_rrule_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
-static ical_invalid_rrule_handling invalidRruleHandling = ICAL_RRULE_TREAT_AS_ERROR;
+static ICAL_GLOBAL_VAR ical_invalid_rrule_handling invalidRruleHandling = ICAL_RRULE_TREAT_AS_ERROR;
 
 #if defined(HAVE_LIBICU)
 #include <unicode/ucal.h>

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -104,7 +104,7 @@ static icaltime_t make_time(struct tm *tm, int tzm)
     icaltime_t tim;
     int febs;
 
-    static int days[] = { -1, 30, 58, 89, 119, 150, 180, 211, 242, 272, 303, 333, 364 };
+    static const int days[] = { -1, 30, 58, 89, 119, 150, 180, 211, 242, 272, 303, 333, 364 };
 
     /* check that month specification within range */
 

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <limits.h>
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 #include <pthread.h>
 #if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
 // It seems the same thread can attempt to lock builtin_mutex multiple times
@@ -166,28 +166,28 @@ static const char *get_zone_directory(void);
 
 static void icaltimezone_builtin_lock(void)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_lock(&builtin_mutex);
 #endif
 }
 
 static void icaltimezone_builtin_unlock(void)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_unlock(&builtin_mutex);
 #endif
 }
 
 static void icaltimezone_changes_lock(void)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_lock(&changes_mutex);
 #endif
 }
 
 static void icaltimezone_changes_unlock(void)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_unlock(&changes_mutex);
 #endif
 }

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -67,7 +67,7 @@ static const struct _compat_tzids {
 };
 
 /* The prefix to be used for tzid's generated from system tzdata */
-static char s_ical_tzid_prefix[BUILTIN_TZID_PREFIX_LEN] = {0};
+static ICAL_GLOBAL_VAR char s_ical_tzid_prefix[BUILTIN_TZID_PREFIX_LEN] = {0};
 
 /** This is the filename of the file containing the city names and
     coordinates of all the builtin timezones. */
@@ -112,17 +112,17 @@ struct _icaltimezonechange
 };
 
 /** An array of icaltimezones for the builtin timezones. */
-static icalarray *builtin_timezones = NULL;
+static ICAL_GLOBAL_VAR icalarray *builtin_timezones = NULL;
 
 /** This is the special UTC timezone, which isn't in builtin_timezones. */
-static icaltimezone utc_timezone = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static ICAL_GLOBAL_VAR icaltimezone utc_timezone = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-static char *zone_files_directory = NULL;
+static ICAL_GLOBAL_VAR char *zone_files_directory = NULL;
 
 #if defined(USE_BUILTIN_TZDATA)
-static int use_builtin_tzdata = 1;
+static ICAL_GLOBAL_VAR int use_builtin_tzdata = 1;
 #else
-static int use_builtin_tzdata = 0;
+static ICAL_GLOBAL_VAR int use_builtin_tzdata = 0;
 #endif
 
 static void icaltimezone_reset(icaltimezone *zone);
@@ -477,7 +477,7 @@ static void icaltimezone_ensure_coverage(icaltimezone *zone, int end_year)
 {
     /* When we expand timezone changes we always expand at least up to this
        year, plus ICALTIMEZONE_EXTRA_COVERAGE. */
-    static int icaltimezone_minimum_expansion_year = -1;
+    static ICAL_GLOBAL_VAR int icaltimezone_minimum_expansion_year = -1;
 
     int changes_end_year;
 
@@ -2019,7 +2019,7 @@ static const char *get_zone_directory(void)
     wchar_t zoneinfodir[1000], dirname[1000];
 #endif
     int used_default;
-    static char *cache = NULL;
+    static ICAL_GLOBAL_VAR char *cache = NULL;
 
 #if !defined(_WIN32_WCE)
     unsigned char *dirslash, *zislash, *zislashp1;

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -56,7 +56,7 @@ static pthread_mutex_t changes_mutex = PTHREAD_MUTEX_INITIALIZER;
 #define BUILTIN_TZID_PREFIX     "/freeassociation.sourceforge.net/"
 
 /* Known prefixes from the old versions of libical */
-static struct _compat_tzids {
+static const struct _compat_tzids {
     const char *tzid;
     int slashes;
 } glob_compat_tzids[] = {

--- a/src/libical/icaltypes.c
+++ b/src/libical/icaltypes.c
@@ -22,7 +22,7 @@
 static pthread_mutex_t unk_token_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
-static ical_unknown_token_handling unknownTokenHandling = ICAL_TREAT_AS_ERROR;
+static ICAL_GLOBAL_VAR ical_unknown_token_handling unknownTokenHandling = ICAL_TREAT_AS_ERROR;
 
 int icaltriggertype_is_null_trigger(struct icaltriggertype tr)
 {

--- a/src/libical/icaltypes.c
+++ b/src/libical/icaltypes.c
@@ -17,7 +17,7 @@
 
 #define TMP_BUF_SIZE 1024
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 #include <pthread.h>
 static pthread_mutex_t unk_token_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
@@ -174,13 +174,13 @@ ical_unknown_token_handling ical_get_unknown_token_handling_setting(void)
 {
     ical_unknown_token_handling myHandling;
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_lock(&unk_token_mutex);
 #endif
 
     myHandling = unknownTokenHandling;
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_unlock(&unk_token_mutex);
 #endif
 
@@ -189,13 +189,13 @@ ical_unknown_token_handling ical_get_unknown_token_handling_setting(void)
 
 void ical_set_unknown_token_handling_setting(ical_unknown_token_handling newSetting)
 {
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_lock(&unk_token_mutex);
 #endif
 
     unknownTokenHandling = newSetting;
 
-#if defined(HAVE_PTHREAD)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     pthread_mutex_unlock(&unk_token_mutex);
 #endif
 }

--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -89,7 +89,7 @@ typedef struct
 } tzinfo;
 
 /* fullpath to the system zoneinfo directory (where zone.tab lives) */
-static char s_zoneinfopath[MAXPATHLEN] = {0};
+static ICAL_GLOBAL_VAR char s_zoneinfopath[MAXPATHLEN] = {0};
 
 /* A few well-known locations for system zoneinfo; can be overridden with TZDIR environment */
 static const char *s_zoneinfo_search_paths[] = {

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -43,8 +43,8 @@ static void pvl_global_unlock(void)
  * Globals incremented for each call to pvl_new_element(); each list gets a unique id.
  */
 
-static int pvl_elem_count = 0;
-static int pvl_list_count = 0;
+static ICAL_GLOBAL_VAR int pvl_elem_count = 0;
+static ICAL_GLOBAL_VAR int pvl_list_count = 0;
 
 /**
   struct pvl_list_t

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 
 /* To mute a ThreadSanitizer claim */
-#if defined(HAVE_PTHREAD) && defined(THREAD_SANITIZER)
+#if (ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD) && defined(THREAD_SANITIZER)
 #include <pthread.h>
 static pthread_mutex_t pvl_mutex = PTHREAD_MUTEX_INITIALIZER;
 

--- a/src/libical/sspm.c
+++ b/src/libical/sspm.c
@@ -63,7 +63,7 @@ struct mime_impl
 static void *sspm_make_multipart_part(struct mime_impl *impl, struct sspm_header *header);
 static void *sspm_make_multipart_subpart(struct mime_impl *impl, struct sspm_header *parent_header);
 
-static struct major_content_type_map
+static const struct major_content_type_map
 {
     enum sspm_major_type type;
     const char *str;
@@ -81,7 +81,7 @@ static struct major_content_type_map
     {SSPM_UNKNOWN_MAJOR_TYPE, ""}
 };
 
-static struct minor_content_type_map
+static const struct minor_content_type_map
 {
     enum sspm_minor_type type;
     const char *str;
@@ -99,7 +99,7 @@ static struct minor_content_type_map
     {SSPM_UNKNOWN_MINOR_TYPE, ""}
 };
 
-static struct encoding_map
+static const struct encoding_map
 {
     enum sspm_encoding encoding;
     const char *str;
@@ -252,7 +252,7 @@ static void sspm_default_free_part(void *part)
     _unused(part);
 }
 
-static struct sspm_action_map sspm_action_map[] = {
+static const struct sspm_action_map sspm_action_map[] = {
     {SSPM_UNKNOWN_MAJOR_TYPE, SSPM_UNKNOWN_MINOR_TYPE, sspm_default_new_part, sspm_default_add_line,
      sspm_default_end_part, sspm_default_free_part},
 };

--- a/src/libical/sspm.c
+++ b/src/libical/sspm.c
@@ -125,7 +125,7 @@ static char *sspm_strdup(const char *str)
 static char *sspm_get_parameter(const char *line, const char *parameter)
 {
     char *p, *s, *q;
-    static char name[1024];
+    static ICAL_GLOBAL_VAR char name[1024];
 
     /* Find where the parameter name is in the line */
     p = strstr(line, parameter);
@@ -173,7 +173,7 @@ static char *sspm_get_parameter(const char *line, const char *parameter)
 
 static char *sspm_property_name(const char *line)
 {
-    static char name[1024];
+    static ICAL_GLOBAL_VAR char name[1024];
     char *c = strchr(line, ':');
 
     if (c != 0) {
@@ -187,7 +187,7 @@ static char *sspm_property_name(const char *line)
 
 static char *sspm_value(char *line)
 {
-    static char value[1024];
+    static ICAL_GLOBAL_VAR char value[1024];
 
     char *c, *s, *p;
 

--- a/src/test/builtin_timezones.c
+++ b/src/test/builtin_timezones.c
@@ -12,7 +12,7 @@
 #include <config.h>
 #endif
 
-#ifdef HAVE_PTHREAD_H
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 #include <pthread.h>
 #include <assert.h>
 #endif
@@ -21,7 +21,7 @@
 
 #include <stdio.h>
 
-#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD) && defined(HAVE_PTHREAD_CREATE)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
 
 #define N_THREADS 20
 
@@ -82,7 +82,7 @@ int main(void)
     set_zone_directory("../../zoneinfo");
     icaltimezone_set_tzid_prefix("/softwarestudio.org/");
 
-#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD) && defined(HAVE_PTHREAD_CREATE)
+#if ICAL_SYNC_MODE == ICAL_SYNC_MODE_PTHREAD
     test_get_component_threadsafety();
 #endif
 


### PR DESCRIPTION
Today it is not easily possible to use multiple instances of libical in parallel, mainly due to the state being stored in global variables. With pthreads we have a way of synchronizing access, so the internal state doesn't get corrupted in case of concurrent access. But on a higher level additional synchronization is still required, because individual threads might modify the global state independently.

With this PR libical can be built in the new 'thread-local' concurrency mode. If enabled, all global variables are marked as `thread_local` (or the compiler-specific equivalent). This way any code accessing libical can do so without additional synchronization, which makes access easier and faster. However, initialization of the library needs to be done for each thread.

The functionality may especially be helpful when writing high-level wrappers. In future work this might be a good mode for implementing the GLIB or Java wrappers. It can also be helpful to allow unit tests to run in parallel.

The feature can be enabled via the `LIBICAL_SYNCMODE_THREADLOCAL=[true|false]` CMAKE option. It's marked as experimental for now, so we can make adjustments if helpful. It would be better to have something like `LIBICAL_SYNCMODE=[none|pthread|threadlocal]` but I'm not sufficiently into CMAKE to implement this quickly. Help would be appreciated.

Could also be back-ported to 3.1 if deemed helpful.