### PR TITLE
ical_bt(): use free() to free memory, not the libical wrapper

### DIFF
--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -269,6 +269,6 @@ void ical_bt(void)
             icalerrprintf("%p\n", stack_frames[i]);
         }
     }
-    icalmemory_free_buffer(strings);
+    free(strings); /* Not icalmemory_free_buffer(), allocated by backtrace_symbols() */
 #endif
 }


### PR DESCRIPTION
We can't use local free() as buffer was not allocated by local malloc(): backtrace_symbols() is a glibc function. Noticed when was debugging unrelated test failure under `-fsanitize=address`:

    ==6354==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xf0401578 at pc 0x080765af bp 0xffff5168 sp 0xffff515c
    READ of size 4 at 0xf0401578 thread T0
        #0 0x80765ae in test_free src/test/test-malloc.c:136
        #1 0xf729d0e4 in ical_bt src/libical/icalerror.c:272
        #2 0xf729d376 in icalerror_set_errno src/libical/icalerror.c:117
        #3 0xf72cde81 in icaltimezone_parse_zone_tab src/libical/icaltimezone.c:1692
        #4 0xf72d69f4 in icaltimezone_init_builtin_timezones src/libical/icaltimezone.c:1554
        #5 0xf72d69f4 in icaltimezone_get_utc_timezone src/libical/icaltimezone.c:1537
        #6 0xf72c46d8 in icaltime_from_string src/libical/icaltime.c:359
        #7 0xf72bed2d in icalrecurrencetype_from_string src/libical/icalrecur.c:714
        #8 0xf72e44e0 in icalvalue_new_from_string_with_error src/libical/icalvalue.c:632
        #9 0xf72a3a9e in icalparser_add_line src/libical/icalparser.c:1157
        #10 0xf72a59ef in icalparser_parse src/libical/icalparser.c:642
        #11 0xf72a5bf0 in icalparser_parse_string src/libical/icalparser.c:1359
        #12 0xf72932f7 in icalcomponent_new_from_string src/libical/icalcomponent.c:129
        #13 0x8063526 in test_tzid_with_utc_time src/test/regression.c:4496
        #14 0x8073f02 in test_run src/test/regression-utils.c:236
        #15 0x8051c79 in main src/test/regression.c:5467
        #16 0xf6cf12f9 in __libc_start_call_main (...glibc-2.35-163/lib/libc.so.6+0x212f9)
        #17 0xf6cf13d3 in __libc_start_main_alias_1 (...glibc-2.35-163/lib/libc.so.6+0x213d3)
        #18 0x805202b in _start (build/src/test/regression+0x805202b)
    0xf0401578 is located 8 bytes to the left of 1553-byte region [0xf0401580,0xf0401b91)
    allocated by thread T0 here:
        #0 0xf7a6906b in malloc (...gcc-13.0.0-lib/lib/libasan.so.8+0xd706b)
        #1 0xf6dfd1ae in backtrace_symbols (...glibc-2.35-163/lib/libc.so.6+0x12d1ae)
        #2 0xf7a1d808 in __interceptor_backtrace_symbols.part.0 (...gcc-13.0.0-lib/lib/libasan.so.8+0x8b808)
        #3 0xf729d01f in ical_bt src/libical/icalerror.c:264
    SUMMARY: AddressSanitizer: heap-buffer-overflow src/test/test-malloc.c:136 in test_free