### PR TITLE
regression: avoid SIGSEGV in test_timezone_from_builtin()

### DIFF
--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4674,6 +4674,10 @@ void test_timezone_from_builtin(void)
     char *strcomp, *tzidprefix, *prevslash = NULL, *prevprevslash = NULL, *p;
     size_t len;
 
+    /* Builtins are not enabled, zone loading will fail. */
+    if (!icaltimezone_get_builtin_tzdata())
+        return;
+
     zone = icaltimezone_get_builtin_timezone("America/New_York");
     tzidprefix = strdup(icaltimezone_get_tzid (zone));
     p = tzidprefix;


### PR DESCRIPTION
When builtin timezones are not enabled 'regression' test SIGSEGVs due to strdup(NULL) in test_timezone_from_builtin():

    =================================================================
    ==6477==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7ffff7a1aae6 bp 0x7fffffffb6c0 sp 0x7fffffffae68 T0)
    ==6477==The signal is caused by a READ memory access.
    ==6477==Hint: address points to the zero page.
        #0 0x7ffff7a1aae6 in __sanitizer::internal_strlen(char const*) (...gcc-13.0.0-lib/lib/libasan.so.8+0xebae6)
        #1 0x7ffff79aceb0 in __interceptor_strdup (...gcc-13.0.0-lib/lib/libasan.so.8+0x7deb0)
        #2 0x41db71 in test_timezone_from_builtin /build/libical/src/test/regression.c:4682
        #3 0x42beff in test_run /build/libical/src/test/regression-utils.c:236
        #4 0x40b962 in main /build/libical/src/test/regression.c:5475
        #5 0x7ffff6d2858d in __libc_start_call_main (...glibc-2.35-163/lib/libc.so.6+0x2958d)
        #6 0x7ffff6d28648 in __libc_start_main_impl (...glibc-2.35-163/lib/libc.so.6+0x29648)
        #7 0x40bc84 in _start (/build/libical/build/src/test/regression+0x40bc84)
    AddressSanitizer can not provide additional info.
    SUMMARY: AddressSanitizer: SEGV (...gcc-13.0.0-lib/lib/libasan.so.8+0xebae6) in __sanitizer::internal_strlen(char const*)

The change disables the test if builtin zimezone tables are not enabled.