### PR TITLE
regression-cxx.cpp: fix test by explicitly setting errno

### DIFF
--- a/src/test/regression-cxx.cpp
+++ b/src/test/regression-cxx.cpp
@@ -159,6 +159,7 @@ void test_cxx(void)
 
     int caughtException = 0;
     try {
+        icalerrno = ICAL_NO_ERROR;
         VComponent v = VComponent(string("HFHFHFHF"));
     } catch (icalerrorenum err) {
         if (err == ICAL_BADARG_ERROR) {


### PR DESCRIPTION
When embedded timezone data is not enabled errors from previous tests set icalerrno to non-default and cause exception handling to throw wrong exception:

    not ok 1186 - Testing exception handling
    # test failed: ""
    #          at: /build/libical/src/test/regression-cxx.cpp:170
    #      got: 0
    # expected: 1

The change explicitly drops icalerrno to isolate the test result from other tests.