### PR TITLE
Escape comma in x-property TEXT values

### DIFF
--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -307,7 +307,8 @@ static char *icalmemory_strdup_and_quote(const icalvalue *value, const char *unq
             if ((icalproperty_isa(value->parent) == ICAL_CATEGORIES_PROPERTY) ||
                 (icalproperty_isa(value->parent) == ICAL_RESOURCES_PROPERTY) ||
                 (icalproperty_isa(value->parent) == ICAL_POLLPROPERTIES_PROPERTY) ||
-                (icalproperty_isa(value->parent) == ICAL_X_PROPERTY)) {
+                ((icalproperty_isa(value->parent) == ICAL_X_PROPERTY) &&
+                 icalvalue_isa(value) != ICAL_TEXT_VALUE)) {
                 icalmemory_append_char(&str, &str_p, &buf_sz, *p);
                 break;
             }

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4919,7 +4919,7 @@ test_icalvalue_resets_timezone_on_set(void)
     icalerror_clear_errno();
 }
 
-static void test_remove_tzid_from_due(void)
+static void test_comma_in_xproperty(void)
 {
     icalproperty *xproperty = icalproperty_new_from_string("X-TEST-PROPERTY:test,test");
     icalcomponent *c;
@@ -4937,7 +4937,7 @@ static void test_remove_tzid_from_due(void)
     icalcomponent_free(c);
 }
 
-static void test_comma_in_xproperty(void)
+static void test_remove_tzid_from_due(void)
 {
     icalproperty *due = icalproperty_vanew_due(icaltime_from_string("20220120T120000"), (void *)0);
     icalcomponent *c;

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -4921,6 +4921,7 @@ test_icalvalue_resets_timezone_on_set(void)
 
 static void test_comma_in_xproperty(void)
 {
+    // X-property value without explicit value type
     icalproperty *xproperty = icalproperty_new_from_string("X-TEST-PROPERTY:test,test");
     icalcomponent *c;
 
@@ -4933,6 +4934,21 @@ static void test_comma_in_xproperty(void)
             0);
 
     str_is("icalproperty_as_ical_string()", "X-TEST-PROPERTY:test,test\r\n", icalproperty_as_ical_string(icalcomponent_get_first_property(icalcomponent_get_inner(c), ICAL_X_PROPERTY)));
+
+    icalcomponent_free(c);
+
+    // X-property value with TEXT value type
+    xproperty = icalproperty_new_from_string("X-TEST-PROPERTY;VALUE=TEXT:test\\,test");
+
+    c = icalcomponent_vanew(
+            ICAL_VCALENDAR_COMPONENT,
+                icalcomponent_vanew(
+                    ICAL_VEVENT_COMPONENT,
+                    xproperty,
+                    0),
+            0);
+
+    str_is("icalproperty_as_ical_string()", "X-TEST-PROPERTY;VALUE=TEXT:test\\,test\r\n", icalproperty_as_ical_string(icalcomponent_get_first_property(icalcomponent_get_inner(c), ICAL_X_PROPERTY)));
 
     icalcomponent_free(c);
 }


### PR DESCRIPTION
Recent pull request https://github.com/libical/libical/pull/593 updated libical to not escape the COMMA character for x-properties. While this in general seems like a sane choice, it is wrong if the value of the x-property is TEXT.