### PR TITLE
libical-glib: Add get_zone_directory

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -5,6 +5,8 @@ Version 3.0.17 (UNRELEASED):
 ----------------------------
  * Improved Android support
  * Escape commas in x-property TEXT values
+ * New publicly available functions:
+     + get_zone_directory()
 
 Version 3.0.16 (17 October 2022):
 ---------------------------------

--- a/src/libical-glib/api/i-cal-timezone.xml
+++ b/src/libical-glib/api/i-cal-timezone.xml
@@ -180,6 +180,10 @@
         <returns type="gchar *" comment="The name of vtimezone."/>
         <comment xml:space="preserve">Gets the name of the vtimezone in component.</comment>
     </method>
+    <method name="i_cal_timezone_get_zone_directory" corresponds="get_zone_directory" kind="others" since="3.0.17">
+        <returns type="const gchar *" comment="The path to look for the zonefiles"/>
+        <comment xml:space="preserve">Gets the directory to look for the zonefiles.</comment>
+    </method>
     <method name="i_cal_timezone_set_zone_directory" corresponds="set_zone_directory" kind="others" since="1.0">
         <parameter type="const gchar *" name="path" comment="The path to look for the zonefiles"/>
         <comment xml:space="preserve">Sets the directory to look for the zonefiles.</comment>

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -170,7 +170,7 @@ static void icaltimezone_parse_zone_tab(void);
 static char *icaltimezone_load_get_line_fn(char *s, size_t size, void *data);
 
 static void format_utc_offset(int utc_offset, char *buffer, size_t buffer_size);
-static const char *get_zone_directory(void);
+static const char *get_zone_directory_builtin(void);
 
 static void icaltimezone_builtin_lock(void)
 {
@@ -1686,7 +1686,7 @@ static void icaltimezone_parse_zone_tab(void)
         zonedir = icaltzutil_get_zone_directory();
         zonetab = ZONES_TAB_SYSTEM_FILENAME;
     } else {
-        zonedir = get_zone_directory();
+        zonedir = get_zone_directory_builtin();
         zonetab = ZONES_TAB_FILENAME;
     }
 
@@ -1837,7 +1837,7 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
         FILE *fp;
         icalparser *parser;
 
-        filename_len = strlen(get_zone_directory()) + strlen(zone->location) + 6;
+        filename_len = strlen(get_zone_directory_builtin()) + strlen(zone->location) + 6;
 
         filename = (char *)malloc(filename_len);
         if (!filename) {
@@ -1845,7 +1845,7 @@ static void icaltimezone_load_builtin_timezone(icaltimezone *zone)
             goto out;
         }
 
-        snprintf(filename, filename_len, "%s/%s.ics", get_zone_directory(), zone->location);
+        snprintf(filename, filename_len, "%s/%s.ics", get_zone_directory_builtin(), zone->location);
 
         fp = fopen(filename, "r");
         free(filename);
@@ -2014,7 +2014,7 @@ static void format_utc_offset(int utc_offset, char *buffer, size_t buffer_size)
     }
 }
 
-static const char *get_zone_directory(void)
+static const char *get_zone_directory_builtin(void)
 {
 #if !defined(_WIN32)
     return zone_files_directory == NULL ? ZONEINFO_DIRECTORY : zone_files_directory;
@@ -2147,6 +2147,15 @@ static const char *get_zone_directory(void)
 #endif
     return ZONEINFO_DIRECTORY;
 #endif
+}
+
+const char *get_zone_directory(void)
+{
+    if (use_builtin_tzdata) {
+        return get_zone_directory_builtin();
+    } else {
+        return icaltzutil_get_zone_directory();
+    }
 }
 
 void set_zone_directory(const char *path)

--- a/src/libical/icaltimezone.h
+++ b/src/libical/icaltimezone.h
@@ -199,6 +199,9 @@ LIBICAL_ICAL_EXPORT void icaltimezone_truncate_vtimezone(icalcomponent *vtz,
  * @par Handling the default location the timezone files
  */
 
+/** Gets the directory to look for the zonefiles */
+LIBICAL_ICAL_EXPORT const char *get_zone_directory(void);
+
 /** Sets the directory to look for the zonefiles */
 LIBICAL_ICAL_EXPORT void set_zone_directory(const char *path);
 


### PR DESCRIPTION
This will be useful for evolution-data-server to use the same zone directory as libical.