### PR TITLE
Basic validation + ignore leading spaces when parsing .ics string

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1335,8 +1335,14 @@ char *icalparser_string_line_generator(char *out, size_t buf_size, void *d)
 
 icalcomponent *icalparser_parse_string(const char *str)
 {
+    icalcomponent *c;
+    struct slg_data d;
+    icalparser *p;
+
+    icalerrorstate es = icalerror_get_error_state(ICAL_MALFORMEDDATA_ERROR);
+  
     if (str == 0) {
-        return 0;
+      goto error;
     }
   
     // Ignore leading space / form-feeds / new-lines
@@ -1347,21 +1353,15 @@ icalcomponent *icalparser_parse_string(const char *str)
   
     // All spaces?
     if (*strStart == 0) {
-      return 0;
+      goto error;
     }
   
     // basic validation
     size_t beginSize = strlen("BEGIN");
     int startIndex = strncasecmp(strStart, "BEGIN", beginSize);
     if (startIndex != 0) {
-      return 0;
+      goto error;
     }
-  
-    icalcomponent *c;
-    struct slg_data d;
-    icalparser *p;
-
-    icalerrorstate es = icalerror_get_error_state(ICAL_MALFORMEDDATA_ERROR);
 
     d.pos = 0;
     d.str = strStart;
@@ -1381,4 +1381,9 @@ icalcomponent *icalparser_parse_string(const char *str)
     icalparser_free(p);
 
     return c;
+  
+  error:
+    icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, es);
+    icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
+    return NULL;
 }

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1335,6 +1335,28 @@ char *icalparser_string_line_generator(char *out, size_t buf_size, void *d)
 
 icalcomponent *icalparser_parse_string(const char *str)
 {
+    if (str == 0) {
+        return 0;
+    }
+  
+    // Ignore leading space / form-feeds / new-lines
+    const char *strStart = str;
+    while (isspace((unsigned char) *strStart) || *strStart == '\f' || *strStart == '\n' || *strStart == '\r') {
+      strStart++;
+    }
+  
+    // All spaces?
+    if (*strStart == 0) {
+      return 0;
+    }
+  
+    // basic validation
+    size_t beginSize = strlen("BEGIN");
+    int startIndex = strncasecmp(strStart, "BEGIN", beginSize);
+    if (startIndex != 0) {
+      return 0;
+    }
+  
     icalcomponent *c;
     struct slg_data d;
     icalparser *p;
@@ -1342,7 +1364,7 @@ icalcomponent *icalparser_parse_string(const char *str)
     icalerrorstate es = icalerror_get_error_state(ICAL_MALFORMEDDATA_ERROR);
 
     d.pos = 0;
-    d.str = str;
+    d.str = strStart;
 
     p = icalparser_new();
     if (!p)


### PR DESCRIPTION
- Ignores leading spaces / line-breaks when fed poorly generated .ics files (some automated tools add spaces / leading line breaks)
- Performs basic validation before trying to parse a potentially malformed .ics string