### PR TITLE
Add missing API to libical-glib

### DIFF
--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -96,6 +96,7 @@ add_custom_command (
     ${LIBICAL_GLIB_SOURCES}
     ${CMAKE_CURRENT_BINARY_DIR}/libical-glib-private.h
     ${CMAKE_CURRENT_BINARY_DIR}/i-cal-forward-declarations.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ical-glib-build-check.c
   COMMAND
     ${ical-glib-src-generator_EXE} "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${CMAKE_CURRENT_SOURCE_DIR}/api"
   DEPENDS ${ical-glib-src-generator_EXE} ${xml_files}
@@ -142,6 +143,20 @@ if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
     -DLIBICAL_GLIB_COMPILATION
   )
   target_link_libraries(ical-glib-static ${GLIB_LIBRARIES})
+endif()
+
+include(CheckCCompilerFlag)
+
+check_c_compiler_flag(-Wswitch-enum c_flag_Wswitch_enum_supported)
+check_c_compiler_flag(-Wswitch c_flag_Wswitch_supported)
+if(c_flag_Wswitch_enum_supported AND c_flag_Wswitch_supported)
+  add_executable(ical-glib-build-check ${CMAKE_CURRENT_BINARY_DIR}/ical-glib-build-check.c)
+  add_dependencies(ical-glib-build-check ical-glib)
+  target_link_libraries(ical-glib-build-check PRIVATE ical-glib ${GLIB_LIBRARIES})
+  target_compile_options(ical-glib-build-check PRIVATE ${GLIB_CFLAGS}
+    -DLIBICAL_GLIB_UNSTABLE_API=1 -Wswitch-enum -Wswitch)
+else()
+  message(WARNING "compiler does not support both -Wswitch-enum and -Wswitch, skipping libical-glib-build-check")
 endif()
 
 # GObject Introspection

--- a/src/libical-glib/api/i-cal-component.xml
+++ b/src/libical-glib/api/i-cal-component.xml
@@ -616,4 +616,24 @@ static void foreach_recurrence_cb(icalcomponent *in_comp, struct icaltime_span *
         <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
         <comment xml:space="preserve">Creates a #ICalComponent with the type to be xvote.</comment>
     </method>
+    <method name="i_cal_component_new_vpatch" corresponds="icalcomponent_new_vpatch" kind="constructor" since="3.1">
+        <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
+        <comment xml:space="preserve">Creates a #ICalComponent of type %I_CAL_VPATCH_COMPONENT.</comment>
+    </method>
+    <method name="i_cal_component_new_xpatch" corresponds="icalcomponent_new_xpatch" kind="constructor" since="3.1">
+        <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
+        <comment xml:space="preserve">Creates a #ICalComponent of type %I_CAL_XPATCH_COMPONENT.</comment>
+    </method>
+    <method name="i_cal_component_new_participant" corresponds="icalcomponent_new_participant" kind="constructor" since="3.1">
+        <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
+        <comment xml:space="preserve">Creates a #ICalComponent of type %I_CAL_PARTICIPANT_COMPONENT.</comment>
+    </method>
+    <method name="i_cal_component_new_vlocation" corresponds="icalcomponent_new_vlocation" kind="constructor" since="3.1">
+        <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
+        <comment xml:space="preserve">Creates a #ICalComponent of type %I_CAL_VLOCATION_COMPONENT.</comment>
+    </method>
+    <method name="i_cal_component_new_vresource" corresponds="icalcomponent_new_vresource" kind="constructor" since="3.1">
+        <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
+        <comment xml:space="preserve">Creates a #ICalComponent of type %I_CAL_VRESOURCE_COMPONENT.</comment>
+    </method>
 </structure>

--- a/src/libical-glib/api/i-cal-derived-parameter.xml
+++ b/src/libical-glib/api/i-cal-derived-parameter.xml
@@ -167,6 +167,7 @@
         <element name="ICAL_RELTYPE_CHILD"/>
         <element name="ICAL_RELTYPE_SIBLING"/>
         <element name="ICAL_RELTYPE_POLL"/>
+        <element name="ICAL_RELTYPE_SNOOZE"/>
         <element name="ICAL_RELTYPE_NONE"/>
     </enum>
     <enum name="ICalParameterRequired" native_name="icalparameter_required" default_native="I_CAL_REQUIRED_NONE">

--- a/src/libical-glib/api/i-cal-derived-parameter.xml
+++ b/src/libical-glib/api/i-cal-derived-parameter.xml
@@ -15,6 +15,7 @@
         <element name="ICAL_CUTYPE_PARAMETER"/>
         <element name="ICAL_DELEGATEDFROM_PARAMETER"/>
         <element name="ICAL_DELEGATEDTO_PARAMETER"/>
+        <element name="ICAL_DERIVED_PARAMETER"/>
         <element name="ICAL_DIR_PARAMETER"/>
         <element name="ICAL_DISPLAY_PARAMETER"/>
         <element name="ICAL_EMAIL_PARAMETER"/>
@@ -35,6 +36,7 @@
         <element name="ICAL_MEMBER_PARAMETER"/>
         <element name="ICAL_MODIFIED_PARAMETER"/>
         <element name="ICAL_OPTIONS_PARAMETER"/>
+        <element name="ICAL_ORDER_PARAMETER"/>
         <element name="ICAL_PARTSTAT_PARAMETER"/>
         <element name="ICAL_PATCHACTION_PARAMETER"/>
         <element name="ICAL_PUBLICCOMMENT_PARAMETER"/>
@@ -49,6 +51,7 @@
         <element name="ICAL_SCHEDULEAGENT_PARAMETER"/>
         <element name="ICAL_SCHEDULEFORCESEND_PARAMETER"/>
         <element name="ICAL_SCHEDULESTATUS_PARAMETER"/>
+        <element name="ICAL_SCHEMA_PARAMETER"/>
         <element name="ICAL_SENTBY_PARAMETER"/>
         <element name="ICAL_SIZE_PARAMETER"/>
         <element name="ICAL_STAYINFORMED_PARAMETER"/>
@@ -74,6 +77,12 @@
         <element name="ICAL_CUTYPE_ROOM"/>
         <element name="ICAL_CUTYPE_UNKNOWN"/>
         <element name="ICAL_CUTYPE_NONE"/>
+    </enum>
+    <enum name="ICalParameterDerived" native_name="icalparameter_derived" default_native="I_CAL_DERIVED_NONE">
+        <element name="ICAL_DERIVED_X"/>
+        <element name="ICAL_DERIVED_TRUE"/>
+        <element name="ICAL_DERIVED_FALSE"/>
+        <element name="ICAL_DERIVED_NONE"/>
     </enum>
     <enum name="ICalParameterDisplay" native_name="icalparameter_display" default_native="I_CAL_DISPLAY_NONE">
         <element name="ICAL_DISPLAY_X"/>
@@ -353,6 +362,21 @@
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
         <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_new_derived" corresponds="icalparameter_new_derived" kind="constructor" since="3.1">
+        <parameter type="ICalParameterDerived" name="v" comment="An initial value for the new #ICalParameter"/>
+        <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
+        <comment xml:space="preserve">Creates a new #ICalParameter of kind %I_CAL_DERIVED_PARAMETER holding value @v of type #ICalParameterDerived</comment>
+    </method>
+    <method name="i_cal_parameter_get_derived" corresponds="icalparameter_get_derived" kind="get" since="3.1">
+        <parameter type="const ICalParameter *" name="param" comment="An #ICalParameter to be queried"/>
+        <returns type="ICalParameterDerived" comment="The value of the @param of type #ICalParameterDerived"/>
+        <comment xml:space="preserve">Gets value of the @param of kind %I_CAL_DERIVED_PARAMETER</comment>
+    </method>
+    <method name="i_cal_parameter_set_derived" corresponds="icalparameter_set_derived" kind="set" since="3.1">
+        <parameter type="ICalParameter *" name="param" comment="An #ICalParameter"/>
+        <parameter type="ICalParameterDerived" name="v" comment="The value of type #ICalParameterDerived to be set"/>
+        <comment xml:space="preserve">Sets value @v to parameter @param of kind %I_CAL_DERIVED_PARAMETER</comment>
     </method>
     <method name="i_cal_parameter_new_dir" corresponds="icalparameter_new_dir" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The string used to create the new #ICalParameter"/>
@@ -654,6 +678,21 @@
         <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
     </method>
+    <method name="i_cal_parameter_new_order" corresponds="icalparameter_new_order" kind="constructor" since="3.1">
+        <parameter type="gint" name="v" comment="An initial value for the new #ICalParameter"/>
+        <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
+        <comment xml:space="preserve">Creates a new #ICalParameter of kind %I_CAL_ORDER_PARAMETER holding value @v.</comment>
+    </method>
+    <method name="i_cal_parameter_get_order" corresponds="icalparameter_get_order" kind="get" since="3.1">
+        <parameter type="const ICalParameter *" name="param" comment="An #ICalParameter to be queried"/>
+        <returns type="gint" comment="The value of the @param" />
+        <comment xml:space="preserve">Gets value of the @param of kind %I_CAL_ORDER_PARAMETER</comment>
+    </method>
+    <method name="i_cal_parameter_set_order" corresponds="icalparameter_set_order" kind="set" since="3.1">
+        <parameter type="ICalParameter *" name="param" comment="An #ICalParameter"/>
+        <parameter type="gint" name="v" comment="The value to set"/>
+        <comment xml:space="preserve">Sets value @v to parameter @param of kind %I_CAL_ORDER_PARAMETER</comment>
+    </method>
     <method name="i_cal_parameter_new_partstat" corresponds="icalparameter_new_partstat" kind="constructor" since="1.0">
         <parameter type="ICalParameterPartstat" name="v" comment="The type of #ICalParameter to be created"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
@@ -863,6 +902,21 @@
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
         <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_new_schema" corresponds="icalparameter_new_schema" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalParameter"/>
+        <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
+        <comment xml:space="preserve">Creates a new #ICalParameter of kind %I_CAL_SCHEMA_PARAMETER holding value @v.</comment>
+    </method>
+    <method name="i_cal_parameter_get_schema" corresponds="icalparameter_get_schema" kind="get" since="3.1">
+        <parameter type="const ICalParameter *" name="param" comment="An #ICalParameter to be queried"/>
+        <returns type="const gchar *" comment="The value of the @param" />
+        <comment xml:space="preserve">Gets value of the @param of kind %I_CAL_SCHEMA_PARAMETER</comment>
+    </method>
+    <method name="i_cal_parameter_set_schema" corresponds="icalparameter_set_schema" kind="set" since="3.1">
+        <parameter type="ICalParameter *" name="param" comment="An #ICalParameter"/>
+        <parameter type="const gchar *" name="v" comment="The value to set"/>
+        <comment xml:space="preserve">Sets value @v to parameter @param of kind %I_CAL_SCHEMA_PARAMETER</comment>
     </method>
     <method name="i_cal_parameter_new_sentby" corresponds="icalparameter_new_sentby" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The string used to create the new #ICalParameter"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -75,6 +75,7 @@
         <element name="ICAL_POLLWINNER_PROPERTY"/>
         <element name="ICAL_PRIORITY_PROPERTY"/>
         <element name="ICAL_PRODID_PROPERTY"/>
+        <element name="ICAL_PROXIMITY_PROPERTY"/>
         <element name="ICAL_QUERY_PROPERTY"/>
         <element name="ICAL_QUERYLEVEL_PROPERTY"/>
         <element name="ICAL_QUERYID_PROPERTY"/>
@@ -1133,6 +1134,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the prodid of #ICalProperty."/>
         <comment>Gets the prodid of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_proximity" corresponds="icalproperty_new_proximity" kind="constructor" since="3.1">
+        <parameter type="ICalPropertyProximity" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PROXIMITY_PROPERTY holding value @v of type #ICalPropertyProximity</comment>
+    </method>
+    <method name="i_cal_property_get_proximity" corresponds="icalproperty_get_proximity" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="ICalPropertyProximity" comment="The value of the @prop of type #ICalPropertyProximity"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PROXIMITY_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_proximity" corresponds="icalproperty_set_proximity" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="ICalPropertyProximity" name="v" comment="The value of type #ICalPropertyProximity to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PROXIMITY_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_query" corresponds="icalproperty_new_query" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The query"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -110,6 +110,7 @@
         <element name="ICAL_SOURCE_PROPERTY"/>
         <element name="ICAL_STATUS_PROPERTY"/>
         <element name="ICAL_STORESEXPANDED_PROPERTY"/>
+        <element name="ICAL_STRUCTUREDDATA_PROPERTY"/>
         <element name="ICAL_SUMMARY_PROPERTY"/>
         <element name="ICAL_TARGET_PROPERTY"/>
         <element name="ICAL_TASKMODE_PROPERTY"/>
@@ -1675,6 +1676,25 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the storesexpanded of #ICalProperty."/>
         <comment>Gets the storesexpanded of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_structureddata" corresponds="CUSTOM" kind="constructor" since="3.1">
+        <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_STRUCTUREDDATA_PROPERTY holding value @v of type #ICalAttach</comment>
+        <custom>	ICalProperty *property;
+	g_return_val_if_fail (I_CAL_IS_ATTACH (v), NULL);
+	property = i_cal_property_new_full (icalproperty_new_structureddata (i_cal_object_get_native ((ICalObject *)v)), NULL);
+	return property;</custom>
+    </method>
+    <method name="i_cal_property_get_structureddata" corresponds="icalproperty_get_structureddata" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="ICalAttach *" annotation="transfer full" translator_argus="(GObject *)prop" comment="The value of the @prop of type #ICalAttach"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_STRUCTUREDDATA_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_structureddata" corresponds="icalproperty_set_structureddata" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="The value of type #ICalAttach to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_STRUCTUREDDATA_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_summary" corresponds="icalproperty_new_summary" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The summary"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -107,6 +107,7 @@
         <element name="ICAL_RRULE_PROPERTY"/>
         <element name="ICAL_SCOPE_PROPERTY"/>
         <element name="ICAL_SEQUENCE_PROPERTY"/>
+        <element name="ICAL_SOURCE_PROPERTY"/>
         <element name="ICAL_STATUS_PROPERTY"/>
         <element name="ICAL_STORESEXPANDED_PROPERTY"/>
         <element name="ICAL_SUMMARY_PROPERTY"/>
@@ -1629,6 +1630,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="gint" comment="Get the sequence of #ICalProperty."/>
         <comment>Gets the sequence of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_source" corresponds="icalproperty_new_source" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_SOURCE_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_source" corresponds="icalproperty_get_source" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_SOURCE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_source" corresponds="icalproperty_set_source" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_SOURCE_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_status" corresponds="icalproperty_new_status" kind="constructor" since="1.0">
         <parameter type="ICalPropertyStatus" name="v" comment="The status"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -65,6 +65,7 @@
         <element name="ICAL_NAME_PROPERTY"/>
         <element name="ICAL_ORGANIZER_PROPERTY"/>
         <element name="ICAL_OWNER_PROPERTY"/>
+        <element name="ICAL_PARTICIPANTTYPE_PROPERTY"/>
         <element name="ICAL_PERCENTCOMPLETE_PROPERTY"/>
         <element name="ICAL_PERMISSION_PROPERTY"/>
         <element name="ICAL_POLLCOMPLETION_PROPERTY"/>
@@ -982,6 +983,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the owner of #ICalProperty."/>
         <comment>Gets the owner of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_participanttype" corresponds="icalproperty_new_participanttype" kind="constructor" since="3.1">
+        <parameter type="ICalPropertyParticipanttype" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PARTICIPANTTYPE_PROPERTY holding value @v of type #ICalPropertyParticipanttype</comment>
+    </method>
+    <method name="i_cal_property_get_participanttype" corresponds="icalproperty_get_participanttype" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="ICalPropertyParticipanttype" comment="The value of the @prop of type #ICalPropertyParticipanttype"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PARTICIPANTTYPE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_participanttype" corresponds="icalproperty_set_participanttype" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="ICalPropertyParticipanttype" name="v" comment="The value of type #ICalPropertyParticipanttype to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PARTICIPANTTYPE_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_percentcomplete" corresponds="icalproperty_new_percentcomplete" kind="constructor" since="1.0">
         <parameter type="gint" name="v" comment="The percentcomplete"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -111,6 +111,7 @@
         <element name="ICAL_STATUS_PROPERTY"/>
         <element name="ICAL_STORESEXPANDED_PROPERTY"/>
         <element name="ICAL_STRUCTUREDDATA_PROPERTY"/>
+        <element name="ICAL_STYLEDDESCRIPTION_PROPERTY"/>
         <element name="ICAL_SUMMARY_PROPERTY"/>
         <element name="ICAL_TARGET_PROPERTY"/>
         <element name="ICAL_TASKMODE_PROPERTY"/>
@@ -1695,6 +1696,21 @@
         <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
         <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="The value of type #ICalAttach to be set"/>
         <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_STRUCTUREDDATA_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_new_styleddescription" corresponds="icalproperty_new_styleddescription" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_STYLEDDESCRIPTION_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_styleddescription" corresponds="icalproperty_get_styleddescription" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_STYLEDDESCRIPTION_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_styleddescription" corresponds="icalproperty_set_styleddescription" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_STYLEDDESCRIPTION_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_summary" corresponds="icalproperty_new_summary" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The summary"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -54,6 +54,7 @@
         <element name="ICAL_FREEBUSY_PROPERTY"/>
         <element name="ICAL_GEO_PROPERTY"/>
         <element name="ICAL_GRANT_PROPERTY"/>
+        <element name="ICAL_IMAGE_PROPERTY"/>
         <element name="ICAL_ITIPVERSION_PROPERTY"/>
         <element name="ICAL_LASTMODIFIED_PROPERTY"/>
         <element name="ICAL_LOCATION_PROPERTY"/>
@@ -822,6 +823,25 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the grant of #ICalProperty."/>
         <comment>Gets the grant of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_image" corresponds="CUSTOM" kind="constructor" since="3.1">
+        <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_IMAGE_PROPERTY holding value @v of type #ICalAttach</comment>
+        <custom>	ICalProperty *property;
+	g_return_val_if_fail (I_CAL_IS_ATTACH (v), NULL);
+	property = i_cal_property_new_full (icalproperty_new_image (i_cal_object_get_native ((ICalObject *)v)), NULL);
+	return property;</custom>
+    </method>
+    <method name="i_cal_property_get_image" corresponds="icalproperty_get_image" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="ICalAttach *" annotation="transfer full" translator_argus="(GObject *)prop" comment="The value of the @prop of type #ICalAttach"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_IMAGE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_image" corresponds="icalproperty_set_image" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="The value of type #ICalAttach to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_IMAGE_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_itipversion" corresponds="icalproperty_new_itipversion" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The itipversion"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -91,6 +91,7 @@
         <element name="ICAL_REPLYURL_PROPERTY"/>
         <element name="ICAL_REQUESTSTATUS_PROPERTY"/>
         <element name="ICAL_RESOURCES_PROPERTY"/>
+        <element name="ICAL_RESOURCETYPE_PROPERTY"/>
         <element name="ICAL_RESPONSE_PROPERTY"/>
         <element name="ICAL_RESTRICTION_PROPERTY"/>
         <element name="ICAL_RRULE_PROPERTY"/>
@@ -1374,6 +1375,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the resources of #ICalProperty."/>
         <comment>Gets the resources of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_resourcetype" corresponds="icalproperty_new_resourcetype" kind="constructor" since="3.1">
+        <parameter type="ICalPropertyResourcetype" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_RESOURCETYPE_PROPERTY holding value @v of type #ICalPropertyResourcetype</comment>
+    </method>
+    <method name="i_cal_property_get_resourcetype" corresponds="icalproperty_get_resourcetype" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="ICalPropertyResourcetype" comment="The value of the @prop of type #ICalPropertyResourcetype"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_RESOURCETYPE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_resourcetype" corresponds="icalproperty_set_resourcetype" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="ICalPropertyResourcetype" name="v" comment="The value of type #ICalPropertyResourcetype to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_RESOURCETYPE_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_response" corresponds="icalproperty_new_response" kind="constructor" since="2.0">
         <parameter type="gint" name="v" comment="The response"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -58,6 +58,7 @@
         <element name="ICAL_ITIPVERSION_PROPERTY"/>
         <element name="ICAL_LASTMODIFIED_PROPERTY"/>
         <element name="ICAL_LOCATION_PROPERTY"/>
+        <element name="ICAL_LOCATIONTYPE_PROPERTY"/>
         <element name="ICAL_MAXCOMPONENTSIZE_PROPERTY"/>
         <element name="ICAL_MAXDATE_PROPERTY"/>
         <element name="ICAL_MAXRESULTS_PROPERTY"/>
@@ -887,6 +888,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the location of #ICalProperty."/>
         <comment>Gets the location of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_locationtype" corresponds="icalproperty_new_locationtype" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_LOCATIONTYPE_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_locationtype" corresponds="icalproperty_get_locationtype" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_LOCATIONTYPE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_locationtype" corresponds="icalproperty_set_locationtype" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_LOCATIONTYPE_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_maxcomponentsize" corresponds="icalproperty_new_maxcomponentsize" kind="constructor" since="1.0">
         <parameter type="gint" name="v" comment="The maxcomponentsize"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -70,6 +70,11 @@
         <element name="ICAL_ORGANIZER_PROPERTY"/>
         <element name="ICAL_OWNER_PROPERTY"/>
         <element name="ICAL_PARTICIPANTTYPE_PROPERTY"/>
+        <element name="ICAL_PATCHDELETE_PROPERTY"/>
+        <element name="ICAL_PATCHORDER_PROPERTY"/>
+        <element name="ICAL_PATCHPARAMETER_PROPERTY"/>
+        <element name="ICAL_PATCHTARGET_PROPERTY"/>
+        <element name="ICAL_PATCHVERSION_PROPERTY"/>
         <element name="ICAL_PERCENTCOMPLETE_PROPERTY"/>
         <element name="ICAL_PERMISSION_PROPERTY"/>
         <element name="ICAL_POLLCOMPLETION_PROPERTY"/>
@@ -1068,6 +1073,81 @@
         <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
         <parameter type="ICalPropertyParticipanttype" name="v" comment="The value of type #ICalPropertyParticipanttype to be set"/>
         <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PARTICIPANTTYPE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_new_patchdelete" corresponds="icalproperty_new_patchdelete" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PATCHDELETE_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_patchdelete" corresponds="icalproperty_get_patchdelete" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PATCHDELETE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_patchdelete" corresponds="icalproperty_set_patchdelete" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PATCHDELETE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_new_patchorder" corresponds="icalproperty_new_patchorder" kind="constructor" since="3.1">
+        <parameter type="gint" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PATCHORDER_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_patchorder" corresponds="icalproperty_get_patchorder" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="gint" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PATCHORDER_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_patchorder" corresponds="icalproperty_set_patchorder" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="gint" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PATCHORDER_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_new_patchparameter" corresponds="icalproperty_new_patchparameter" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PATCHPARAMETER_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_patchparameter" corresponds="icalproperty_get_patchparameter" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PATCHPARAMETER_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_patchparameter" corresponds="icalproperty_set_patchparameter" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PATCHPARAMETER_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_new_patchtarget" corresponds="icalproperty_new_patchtarget" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PATCHTARGET_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_patchtarget" corresponds="icalproperty_get_patchtarget" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PATCHTARGET_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_patchtarget" corresponds="icalproperty_set_patchtarget" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PATCHTARGET_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_new_patchversion" corresponds="icalproperty_new_patchversion" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_PATCHVERSION_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_patchversion" corresponds="icalproperty_get_patchversion" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_PATCHVERSION_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_patchversion" corresponds="icalproperty_set_patchversion" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_PATCHVERSION_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_percentcomplete" corresponds="icalproperty_new_percentcomplete" kind="constructor" since="1.0">
         <parameter type="gint" name="v" comment="The percentcomplete"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -29,6 +29,7 @@
         <element name="ICAL_COMMENT_PROPERTY"/>
         <element name="ICAL_COMPLETED_PROPERTY"/>
         <element name="ICAL_COMPONENTS_PROPERTY"/>
+        <element name="ICAL_CONFERENCE_PROPERTY"/>
         <element name="ICAL_CONTACT_PROPERTY"/>
         <element name="ICAL_CREATED_PROPERTY"/>
         <element name="ICAL_CSID_PROPERTY"/>
@@ -446,6 +447,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the components of #ICalProperty."/>
         <comment>Gets the components of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_conference" corresponds="icalproperty_new_conference" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_CONFERENCE_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_conference" corresponds="icalproperty_get_conference" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_CONFERENCE_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_conference" corresponds="icalproperty_set_conference" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_CONFERENCE_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_contact" corresponds="icalproperty_new_contact" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The contact"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -94,6 +94,7 @@
         <element name="ICAL_RECUREXPAND_PROPERTY"/>
         <element name="ICAL_RECURLIMIT_PROPERTY"/>
         <element name="ICAL_RECURRENCEID_PROPERTY"/>
+        <element name="ICAL_REFRESHINTERVAL_PROPERTY"/>
         <element name="ICAL_RELATEDTO_PROPERTY"/>
         <element name="ICAL_RELCALID_PROPERTY"/>
         <element name="ICAL_REPEAT_PROPERTY"/>
@@ -1433,6 +1434,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="ICalTime *" annotation="transfer full" comment="Get the recurrenceid time of #ICalProperty."/>
         <comment>Gets the recurrenceid time of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_refreshinterval" corresponds="icalproperty_new_refreshinterval" kind="constructor" since="3.1">
+        <parameter type="ICalDuration *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_REFRESHINTERVAL_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_refreshinterval" corresponds="icalproperty_get_refreshinterval" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="ICalDuration *" annotation="transfer full" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_REFRESHINTERVAL_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_refreshinterval" corresponds="icalproperty_set_refreshinterval" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="ICalDuration *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_REFRESHINTERVAL_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_relatedto" corresponds="icalproperty_new_relatedto" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The relatedto"/>

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -15,6 +15,7 @@
         <element name="ICAL_ATTACH_PROPERTY"/>
         <element name="ICAL_ATTENDEE_PROPERTY"/>
         <element name="ICAL_BUSYTYPE_PROPERTY"/>
+        <element name="ICAL_CALENDARADDRESS_PROPERTY"/>
         <element name="ICAL_CALID_PROPERTY"/>
         <element name="ICAL_CALMASTER_PROPERTY"/>
         <element name="ICAL_CALSCALE_PROPERTY"/>
@@ -235,6 +236,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="ICalPropertyBusytype" comment="Get the busytype of #ICalProperty."/>
         <comment>Gets the busytype of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_calendaraddress" corresponds="icalproperty_new_calendaraddress" kind="constructor" since="3.1">
+        <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
+        <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_CALENDARADDRESS_PROPERTY holding value @v</comment>
+    </method>
+    <method name="i_cal_property_get_calendaraddress" corresponds="icalproperty_get_calendaraddress" kind="get" since="3.1">
+        <parameter type="const ICalProperty *" name="prop" comment="An #ICalProperty to be queried"/>
+        <returns type="const gchar *" comment="The value of the @prop"/>
+        <comment xml:space="preserve">Gets value of the @prop of kind %I_CAL_CALENDARADDRESS_PROPERTY</comment>
+    </method>
+    <method name="i_cal_property_set_calendaraddress" corresponds="icalproperty_set_calendaraddress" kind="set" since="3.1">
+        <parameter type="ICalProperty *" name="prop" comment="An #ICalProperty"/>
+        <parameter type="const gchar *" name="v" comment="The value to be set"/>
+        <comment xml:space="preserve">Sets value @v to @prop of kind %I_CAL_CALENDARADDRESS_PROPERTY</comment>
     </method>
     <method name="i_cal_property_new_calid" corresponds="icalproperty_new_calid" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The calid"/>

--- a/src/libical-glib/api/i-cal-derived-value.xml
+++ b/src/libical-glib/api/i-cal-derived-value.xml
@@ -30,6 +30,7 @@
 	    <element name="ICAL_PERIOD_VALUE"/>
 	    <element name="ICAL_POLLCOMPLETION_VALUE"/>
 	    <element name="ICAL_POLLMODE_VALUE"/>
+	    <element name="ICAL_PROXIMITY_VALUE"/>
 	    <element name="ICAL_QUERY_VALUE"/>
 	    <element name="ICAL_QUERYLEVEL_VALUE"/>
 	    <element name="ICAL_RECUR_VALUE"/>
@@ -138,6 +139,14 @@
 	    <element name="ICAL_POLLMODE_X"/>
 	    <element name="ICAL_POLLMODE_BASIC"/>
 	    <element name="ICAL_POLLMODE_NONE"/>
+	</enum>
+	<enum name="ICalPropertyProximity" native_name="icalproperty_proximity" default_native="I_CAL_PROXIMITY_NONE">
+	    <element name="ICAL_PROXIMITY_X"/>
+	    <element name="ICAL_PROXIMITY_ARRIVE"/>
+	    <element name="ICAL_PROXIMITY_DEPART"/>
+	    <element name="ICAL_PROXIMITY_CONNECT"/>
+	    <element name="ICAL_PROXIMITY_DISCONNECT"/>
+	    <element name="ICAL_PROXIMITY_NONE"/>
 	</enum>
 	<enum name="ICalPropertyQuerylevel" native_name="icalproperty_querylevel" default_native="I_CAL_QUERYLEVEL_NONE">
 	    <element name="ICAL_QUERYLEVEL_X"/>
@@ -465,6 +474,21 @@
 		<parameter type="ICalValue *" name="val" comment="An #ICalValue"/>
 		<parameter type="ICalPropertyParticipanttype" name="v" comment="The value of type #ICalPropertyParticipanttype to be set"/>
 		<comment xml:space="preserve">Sets value @v to @val of kind %I_CAL_PARTICIPANTTYPE_VALUE</comment>
+	</method>
+	<method name="i_cal_value_new_proximity" corresponds="icalvalue_new_proximity" kind="constructor" since="3.1">
+		<parameter type="ICalPropertyProximity" name="v" comment="An initial value for the new #ICalValue"/>
+		<returns type="ICalValue *" annotation="transfer full" comment="The newly created #ICalValue." />
+		<comment xml:space="preserve">Creates a new #ICalValue of kind %I_CAL_PROXIMITY_VALUE holding value @v of type #ICalPropertyProximity</comment>
+	</method>
+	<method name="i_cal_value_get_proximity" corresponds="icalvalue_get_proximity" kind="get" since="3.1">
+		<parameter type="const ICalValue *" name="val" comment="An #ICalValue to be queried"/>
+		<returns type="ICalPropertyProximity" comment="The value of the @val of type #ICalPropertyProximity"/>
+		<comment xml:space="preserve">Gets value of the @val of kind %I_CAL_PROXIMITY_VALUE</comment>
+	</method>
+	<method name="i_cal_value_set_proximity" corresponds="icalvalue_set_proximity" kind="set" since="3.1">
+		<parameter type="ICalValue *" name="val" comment="An #ICalValue"/>
+		<parameter type="ICalPropertyProximity" name="v" comment="The value of type #ICalPropertyProximity to be set"/>
+		<comment xml:space="preserve">Sets value @v to @val of kind %I_CAL_PROXIMITY_VALUE</comment>
 	</method>
 	<method name="i_cal_value_set_caladdress" corresponds="icalvalue_set_caladdress" kind="set" since="1.0">
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>

--- a/src/libical-glib/api/i-cal-derived-value.xml
+++ b/src/libical-glib/api/i-cal-derived-value.xml
@@ -31,6 +31,7 @@
 	    <element name="ICAL_POLLCOMPLETION_VALUE"/>
 	    <element name="ICAL_POLLMODE_VALUE"/>
 	    <element name="ICAL_PROXIMITY_VALUE"/>
+	    <element name="ICAL_RESOURCETYPE_VALUE"/>
 	    <element name="ICAL_QUERY_VALUE"/>
 	    <element name="ICAL_QUERYLEVEL_VALUE"/>
 	    <element name="ICAL_RECUR_VALUE"/>
@@ -153,6 +154,14 @@
 	    <element name="ICAL_QUERYLEVEL_CALQL1"/>
 	    <element name="ICAL_QUERYLEVEL_CALQLNONE"/>
 	    <element name="ICAL_QUERYLEVEL_NONE"/>
+	</enum>
+	<enum name="ICalPropertyResourcetype" native_name="icalproperty_resourcetype" default_native="I_CAL_RESOURCETYPE_NONE">
+	    <element name="ICAL_RESOURCETYPE_X"/>
+	    <element name="ICAL_RESOURCETYPE_ROOM"/>
+	    <element name="ICAL_RESOURCETYPE_PROJECTOR"/>
+	    <element name="ICAL_RESOURCETYPE_REMOTECONFERENCEAUDIO"/>
+	    <element name="ICAL_RESOURCETYPE_REMOTECONFERENCEVIDEO"/>
+	    <element name="ICAL_RESOURCETYPE_NONE"/>
 	</enum>
 	<enum name="ICalPropertyStatus" native_name="icalproperty_status" default_native="I_CAL_STATUS_NONE">
 	    <element name="ICAL_STATUS_X"/>
@@ -489,6 +498,21 @@
 		<parameter type="ICalValue *" name="val" comment="An #ICalValue"/>
 		<parameter type="ICalPropertyProximity" name="v" comment="The value of type #ICalPropertyProximity to be set"/>
 		<comment xml:space="preserve">Sets value @v to @val of kind %I_CAL_PROXIMITY_VALUE</comment>
+	</method>
+	<method name="i_cal_value_new_resourcetype" corresponds="icalvalue_new_resourcetype" kind="constructor" since="3.1">
+		<parameter type="ICalPropertyResourcetype" name="v" comment="An initial value for the new #ICalValue"/>
+		<returns type="ICalValue *" annotation="transfer full" comment="The newly created #ICalValue." />
+		<comment xml:space="preserve">Creates a new #ICalValue of kind %I_CAL_RESOURCETYPE_VALUE holding value @v of type #ICalPropertyResourcetype</comment>
+	</method>
+	<method name="i_cal_value_get_resourcetype" corresponds="icalvalue_get_resourcetype" kind="get" since="3.1">
+		<parameter type="const ICalValue *" name="val" comment="An #ICalValue to be queried"/>
+		<returns type="ICalPropertyResourcetype" comment="The value of the @val of type #ICalPropertyResourcetype"/>
+		<comment xml:space="preserve">Gets value of the @val of kind %I_CAL_RESOURCETYPE_VALUE</comment>
+	</method>
+	<method name="i_cal_value_set_resourcetype" corresponds="icalvalue_set_resourcetype" kind="set" since="3.1">
+		<parameter type="ICalValue *" name="val" comment="An #ICalValue"/>
+		<parameter type="ICalPropertyResourcetype" name="v" comment="The value of type #ICalPropertyResourcetype to be set"/>
+		<comment xml:space="preserve">Sets value @v to @val of kind %I_CAL_RESOURCETYPE_VALUE</comment>
 	</method>
 	<method name="i_cal_value_set_caladdress" corresponds="icalvalue_set_caladdress" kind="set" since="1.0">
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>

--- a/src/libical-glib/api/i-cal-derived-value.xml
+++ b/src/libical-glib/api/i-cal-derived-value.xml
@@ -26,6 +26,7 @@
 	    <element name="ICAL_GEO_VALUE"/>
 	    <element name="ICAL_INTEGER_VALUE"/>
 	    <element name="ICAL_METHOD_VALUE"/>
+	    <element name="ICAL_PARTICIPANTTYPE_VALUE"/>
 	    <element name="ICAL_PERIOD_VALUE"/>
 	    <element name="ICAL_POLLCOMPLETION_VALUE"/>
 	    <element name="ICAL_POLLMODE_VALUE"/>
@@ -108,6 +109,21 @@
 	    <element name="ICAL_METHOD_GENERATEUID"/>
 	    <element name="ICAL_METHOD_DELETE"/>
 	    <element name="ICAL_METHOD_NONE"/>
+	</enum>
+	<enum name="ICalPropertyParticipanttype" native_name="icalproperty_participanttype" default_native="I_CAL_PARTICIPANTTYPE_NONE">
+	    "/>
+	    <element name="ICAL_PARTICIPANTTYPE_X"/>
+	    <element name="ICAL_PARTICIPANTTYPE_ACTIVE"/>
+	    <element name="ICAL_PARTICIPANTTYPE_INACTIVE"/>
+	    <element name="ICAL_PARTICIPANTTYPE_SPONSOR"/>
+	    <element name="ICAL_PARTICIPANTTYPE_CONTACT"/>
+	    <element name="ICAL_PARTICIPANTTYPE_BOOKINGCONTACT"/>
+	    <element name="ICAL_PARTICIPANTTYPE_EMERGENCYCONTACT"/>
+	    <element name="ICAL_PARTICIPANTTYPE_PUBLICITYCONTACT"/>
+	    <element name="ICAL_PARTICIPANTTYPE_PLANNERCONTACT"/>
+	    <element name="ICAL_PARTICIPANTTYPE_PERFORMER"/>
+	    <element name="ICAL_PARTICIPANTTYPE_SPEAKER"/>
+	    <element name="ICAL_PARTICIPANTTYPE_NONE"/>
 	</enum>
 	<enum name="ICalPropertyPollcompletion" native_name="icalproperty_pollcompletion" default_native="I_CAL_POLLCOMPLETION_NONE">
 	    <element name="ICAL_POLLCOMPLETION_X"/>
@@ -433,6 +449,21 @@
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue to be queried"/>
 		<returns type="ICalPropertyMethod" comment="The method within #ICalValue"/>
 		<comment>Gets the method of #ICalValue.</comment>
+	</method>
+	<method name="i_cal_value_new_participanttype" corresponds="icalvalue_new_participanttype" kind="constructor" since="3.1">
+		<parameter type="ICalPropertyParticipanttype" name="v" comment="An initial value for the new #ICalValue"/>
+		<returns type="ICalValue *" annotation="transfer full" comment="The newly created #ICalValue." />
+		<comment xml:space="preserve">Creates a new #ICalValue of kind %I_CAL_PARTICIPANTTYPE_VALUE holding value @v of type #ICalPropertyParticipanttype</comment>
+	</method>
+	<method name="i_cal_value_get_participanttype" corresponds="icalvalue_get_participanttype" kind="get" since="3.1">
+		<parameter type="const ICalValue *" name="val" comment="An #ICalValue to be queried"/>
+		<returns type="ICalPropertyParticipanttype" comment="The value of the @val of type #ICalPropertyParticipanttype"/>
+		<comment xml:space="preserve">Gets value of the @val of kind %I_CAL_PARTICIPANTTYPE_VALUE</comment>
+	</method>
+	<method name="i_cal_value_set_participanttype" corresponds="icalvalue_set_participanttype" kind="set" since="3.1">
+		<parameter type="ICalValue *" name="val" comment="An #ICalValue"/>
+		<parameter type="ICalPropertyParticipanttype" name="v" comment="The value of type #ICalPropertyParticipanttype to be set"/>
+		<comment xml:space="preserve">Sets value @v to @val of kind %I_CAL_PARTICIPANTTYPE_VALUE</comment>
 	</method>
 	<method name="i_cal_value_set_caladdress" corresponds="icalvalue_set_caladdress" kind="set" since="1.0">
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>

--- a/src/libical-glib/api/i-cal-derived-value.xml
+++ b/src/libical-glib/api/i-cal-derived-value.xml
@@ -108,6 +108,7 @@
 	    <element name="ICAL_METHOD_MODIFY"/>
 	    <element name="ICAL_METHOD_GENERATEUID"/>
 	    <element name="ICAL_METHOD_DELETE"/>
+	    <element name="ICAL_METHOD_POLLSTATUS"/>
 	    <element name="ICAL_METHOD_NONE"/>
 	</enum>
 	<enum name="ICalPropertyParticipanttype" native_name="icalproperty_participanttype" default_native="I_CAL_PARTICIPANTTYPE_NONE">

--- a/src/libical-glib/api/i-cal-enums.xml
+++ b/src/libical-glib/api/i-cal-enums.xml
@@ -38,6 +38,12 @@
         <element name="ICAL_VPOLL_COMPONENT"/>
         <element name="ICAL_VVOTER_COMPONENT"/>
         <element name="ICAL_XVOTE_COMPONENT"/>
+        <element name="ICAL_VPATCH_COMPONENT"/>
+        <element name="ICAL_XPATCH_COMPONENT"/>
+        <element name="ICAL_PARTICIPANT_COMPONENT"/>
+        <element name="ICAL_VLOCATION_COMPONENT"/>
+        <element name="ICAL_VRESOURCE_COMPONENT"/>
+        <element name="ICAL_NUM_COMPONENT_TYPES"/>
     </enum>
     <enum name="ICalRequestStatus" native_name="icalrequeststatus" default_native="I_CAL_UNKNOWN_STATUS">
         <element name="ICAL_UNKNOWN_STATUS"/>

--- a/src/libical-glib/api/i-cal-parser.xml
+++ b/src/libical-glib/api/i-cal-parser.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="Parser" native="icalparser" destroy_func="icalparser_free">
-    <enum name="ICalParserState" native_name="icalparserstate" default_native="I_CAL_PARSER_ERROR">
+    <enum name="ICalParserState" native_name="icalparser_state" default_native="I_CAL_PARSER_ERROR">
         <element name="ICALPARSER_ERROR"/>
         <element name="ICALPARSER_SUCCESS"/>
         <element name="ICALPARSER_BEGIN_COMP"/>

--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -32,7 +32,9 @@
         <element name="ICAL_SKIP_OMIT"/>
         <element name="ICAL_SKIP_UNDEFINED"/>
 	</enum>
-    <enum name="ICalRecurrenceArrayMaxValues" native_name="enum icalrecurrence_array_max_values" default_native="I_CAL_RECURRENCE_ARRAY_MAX">
+    <!-- Mark "enum icalrecurrence_array_max_values" as "CUSTOM", to not have it checked
+         in build time due to the below reason. -->
+    <enum name="ICalRecurrenceArrayMaxValues" native_name="CUSTOM" default_native="I_CAL_RECURRENCE_ARRAY_MAX">
 	<element name="ICAL_RECURRENCE_ARRAY_MAX"/>
 	<!-- Skip this one, it confuses git generator (no name for the first,
 	     because it's all part of this one. Furthermore, this one is not


### PR DESCRIPTION
There had been added nice bunch of a new API into the libical, but the libical-glib has missing all of them. I split them into separate commits, thus it's easier to mimic the additions in the future.

There is also added a new generated build-only file, which verifies all enum values defined in libical are covered in the libical-glib in a way of a compiler warning. They could be turned into the errors for some developer builds to catch the missing API early, but I did not go that far yet.

This cannot be easily backported to the 3.0 branch, due to 43cb2e215a8ed10e03989f19db5457f89fc2412a