### PR TITLE
icalvalue.c - remove setlocale() in icalvalue_geo_as_ical_string_r()

### DIFF
--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -1090,25 +1090,12 @@ static char *icalvalue_geo_as_ical_string_r(const icalvalue *value)
 {
     struct icalgeotype data;
     char *str;
-    char *old_locale;
 
     icalerror_check_arg_rz((value != 0), "value");
 
     data = icalvalue_get_geo(value);
-
-    /* bypass current locale in order to make
-     * sure snprintf uses a '.' as a separator
-     * set locate to 'C' and keep old locale */
-    old_locale = icalmemory_strdup(setlocale(LC_NUMERIC, NULL));
-    (void)setlocale(LC_NUMERIC, "C");
-
     str = (char *)icalmemory_new_buffer(80);
-
     snprintf(str, 80, "%s;%s", data.lat, data.lon);
-
-    /* restore saved locale */
-    (void)setlocale(LC_NUMERIC, old_locale);
-    icalmemory_free_buffer(old_locale);
 
     return str;
 }


### PR DESCRIPTION
Remove setlocale() calls in icalvalue_geo_as_ical_string_r() as it has no meaning as converting directly to strings.

fixes: #644