### PR TITLE
gitignore: ignore build/ directory rather than /build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *~
 *.rej
 *.orig
-/build
+build/


### PR DESCRIPTION
The `.gitignore` file ignores the `/build` directory, outside the source controlled file tree. This fixes it to actually ignore the `build/` directory local to the source directory.