### PR TITLE
icalparameter.c: fix RFC 6868 encoding of ^ (U+005E) character

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,7 +3,7 @@ Release Highlights
 
 Version 3.0.18 (UNRELEASED):
 ----------------------------
-*
+* Escape ^ (U+005E) character in parameter values according to RFC 6868
 
 Version 3.0.17 (14 October 2023):
 ---------------------------------

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -227,11 +227,8 @@ static void icalparameter_append_encoded_value(char **buf, char **buf_ptr,
 
     /* Copy the parameter value */
     for (p = value; *p; p++) {
-        if (icalparameter_is_safe_char((unsigned char)*p, qm)) {
-            icalmemory_append_char(buf, buf_ptr, buf_size, *p);
-        } else {
-            /* Encode unsafe characters per RFC6868, otherwise replace with SP */
-            switch (*p) {
+        /* Encode unsafe characters per RFC6868, otherwise replace with SP */
+        switch (*p) {
             case '\n':
                 icalmemory_append_string(buf, buf_ptr, buf_size, "^n");
                 break;
@@ -245,9 +242,12 @@ static void icalparameter_append_encoded_value(char **buf, char **buf_ptr,
                 break;
 
             default:
-                icalmemory_append_char(buf, buf_ptr, buf_size, ' ');
+                if (icalparameter_is_safe_char((unsigned char)*p, qm)) {
+                    icalmemory_append_char(buf, buf_ptr, buf_size, *p);
+                } else {
+                    icalmemory_append_char(buf, buf_ptr, buf_size, ' ');
+                }
                 break;
-            }
         }
     }
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1500,7 +1500,7 @@ void test_tzid_escape(void)
     icalparameter *tzid;
     icalproperty *prop;
 
-    tzid = icalparameter_new_tzid("Timezone\nwith a newline");
+    tzid = icalparameter_new_tzid("Timezone\nwith a newline and\"mo^re");
     prop = icalproperty_new_dtstart(icaltime_from_day_of_year(26, 2009));
     icalproperty_add_parameter(prop, tzid);
 
@@ -1509,7 +1509,7 @@ void test_tzid_escape(void)
 
     str_is("test encoding of 'Timezone\\nwith a newline'",
            icalproperty_as_ical_string(prop),
-           "DTSTART;VALUE=DATE;TZID=Timezone^nwith a newline:20090126\r\n");
+           "DTSTART;VALUE=DATE;TZID=Timezone^nwith a newline and^'mo^^re:20090126\r\n");
 
     icalproperty_free(prop);
 }


### PR DESCRIPTION
This fixes a bug with RFC 6868 parameter value encoding: the `^` must encoded as `^^` but was added without encoding to the parameter value instead