### PR TITLE
Buildsystem - remove support for using GetNumberFormat

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -67,16 +67,6 @@ endif()
 if(NOT DEFINED CMAKE_REQUIRED_LIBRARIES)
   set(CMAKE_REQUIRED_LIBRARIES "")
 endif()
-#GetNumberFormat is not implemented on wine correctly
-#(see https://forum.winehq.org/viewtopic.php?t=27809) which results in
-#error when building. That means if linux user has installed wine,
-#the build of libical will fail.
-if(WIN32)
-  set(_SAVE_RQL ${CMAKE_REQUIRED_LIBRARIES})
-  set(CMAKE_REQUIRED_LIBRARIES kernel32.lib)
-  check_function_exists(GetNumberFormat HAVE_GETNUMBERFORMAT) #Windows <windows.h>
-  set(CMAKE_REQUIRED_LIBRARIES ${_SAVE_RQL})
-endif()
 
 include(CheckTypeSize)
 check_type_size(intptr_t SIZEOF_INTPTR_T)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -20,9 +20,6 @@ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 /* Define to 1 if you have the <endian.h> header file. */
 #cmakedefine HAVE_ENDIAN_H 1
 
-/* Define to 1 if you have the `GetNumberFormat' function. */
-#cmakedefine HAVE_GETNUMBERFORMAT 1
-
 /* Define to 1 if you have the `gmtime_r' function. */
 #cmakedefine HAVE_GMTIME_R 1
 

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -368,9 +368,7 @@ static int simple_str_to_doublestr(const char *from, char *result, int result_le
 {
     char *start = NULL, *end = NULL, *cur = (char *)from;
 
-#if !defined(HAVE_GETNUMBERFORMAT)
     struct lconv *loc_data = localeconv();
-#endif
     int i = 0, len;
     double dtest;
 
@@ -402,7 +400,6 @@ static int simple_str_to_doublestr(const char *from, char *result, int result_le
      * care to have the (optional) decimal separator be the one
      * of the current locale.
      */
-#if !defined(HAVE_GETNUMBERFORMAT)
     for (i = 0; i < len; ++i) {
         if (start[i] == '.' && loc_data && loc_data->decimal_point && loc_data->decimal_point[0]
             && loc_data->decimal_point[0] != '.') {
@@ -412,9 +409,6 @@ static int simple_str_to_doublestr(const char *from, char *result, int result_le
             result[i] = start[i];
         }
     }
-#else
-    GetNumberFormat(LOCALE_SYSTEM_DEFAULT, 0, start, NULL, result, result_len);
-#endif
     if (to) {
         *to = end;
     }


### PR DESCRIPTION
GetNumberFormat was introduced over a dozen years ago for WinCE support. This is no longer needed as we can rely on our own code for doing the same thing portably
across all platforms.