### PR TITLE
.github/workflows/build.yml - test GTK_DOC, GLIB, GOBJECT on Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: brew install pkg-config ninja gtk-doc glib libxml2 icu4c berkeley-db docbook docbook-xsl
+        run: brew install pkg-config ninja gtk-doc glib libxml2 icu4c berkeley-db docbook docbook-xsl gobject-introspection
       - name: Configure project
         run: |
           export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
           export XML_CATALOG_FILES=/usr/local/etc/xml/catalog
           mkdir build
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DLIBICAL_BUILD_TESTING=True -DENABLE_GTK_DOC=False -DICAL_GLIB=False -DGOBJECT_INTROSPECTION=False -DICAL_GLIB_VAPI=False
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DLIBICAL_BUILD_TESTING=True -DENABLE_GTK_DOC=True -DICAL_GLIB=True -DGOBJECT_INTROSPECTION=False -DICAL_GLIB_VAPI=False
       - name: Build project
         run: cmake --build build
       - name: Test project


### PR DESCRIPTION
Try setting these cmake options to True for Mac builds: ENABLE_GTK_DOC=True ICAL_GLIB=True GOBJECT_INTROSPECTION=True