### PR TITLE
Increase minimum CMake version to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@
 #  is available, it will be used; otherwise, no synchronization is applied.
 #  Default: false.
 
-cmake_minimum_required(VERSION 3.11.0) #first line, to shutup a cygwin warning
+cmake_minimum_required(VERSION 3.19.0)
 project(libical C) #CXX is optional for the bindings
 
 cmake_policy(SET CMP0003 NEW)

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -5,7 +5,7 @@ Version 3.1.0 (NOT RELEASED YET):
 --------------------------------
  * REUSE compliant licensing
  * Requires MSVC 2013 or higher (when building on Windows with MSVC)
- * Requires CMake v3.11.0 or higher
+ * Requires CMake v3.19.0 or higher
  * For the C++ bindings, requires a C++11 compliant compiler
  * The old src/python code is removed in favor of the glib-introspection generated
    Python bindings. Requires building with -DGOBJECT_INTROSPECTION=ON


### PR DESCRIPTION
Among other good things, this also fixes the issue with msvc:
"Command line warning D9025: overriding '/W3' with '/W4'"

fixes: #597
