### PR TITLE
src/libical/icaltime.c - fix a segfault on fuzz input

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -273,8 +273,8 @@ icaltime_t icaltime_as_timet_with_zone(const struct icaltimetype tt, const icalt
 
     utc_zone = icaltimezone_get_utc_timezone();
 
-    /* If the time is the special null time, return 0. */
-    if (icaltime_is_null_time(tt)) {
+    /* Return 0 if the time is the special null time or a bad time */
+    if (icaltime_is_null_time(tt) || !icaltime_is_valid_time(tt)) {
         return 0;
     }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -234,3 +234,4 @@ testme(parser_ctrl "${icalparser_ctrl_test_SRCS}")
 ############# fuzzer tests ############
 
 testme(icalcomponent_fuzz icalcomponent_fuzz.c)
+testme(icaltime_fuzz icaltime_fuzz.c)

--- a/src/test/icaltime_fuzz.c
+++ b/src/test/icaltime_fuzz.c
@@ -1,0 +1,70 @@
+/*======================================================================
+ *
+ * SPDX-FileCopyrightText: 2024 Contributors to the libical project <git@github.com:libical/libical>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+ *
+ * Based on the original code by Gabe Sherman in
+ * https://github.com/libical/libical/issues/678
+ *
+ * ======================================================================*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdint.h>
+
+#include "libical/ical.h"
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+typedef unsigned int usize;
+typedef int8_t i8;
+typedef int16_t i16;
+typedef int32_t i32;
+typedef int64_t i64;
+typedef int isize;
+typedef float f32;
+typedef double f64;
+
+int main(void)
+{
+    struct _icaltimezone *v1;
+
+    icaltimetype v0 = {
+        5,
+        -2147483639,
+        -1,
+        1,
+        60,
+        14,
+        7,
+        118,
+        NULL,
+    }; // dtstart
+
+    v1 = icaltimezone_new(); // zone
+    if (v1 == NULL)
+        return 0;
+
+    icaltimetype v3 = {
+        3,
+        -11,
+        3,
+        4,
+        -4,
+        -3,
+        6,
+        -1,
+        v1,
+    }; // dtend
+
+    i32 v4 = 40;                         // is_busy
+    (void)icaltime_span_new(v0, v3, v4); // $target
+
+    icaltimezone_free(v1, 1);
+    return 0;
+}


### PR DESCRIPTION
In icaltime_as_timet_with_zone() return early with a failure
code if the specified icaltimetype is invalid.

includes a regression test

fixes: #680
