### PR TITLE
src/libical/icalcomponent.c - fix a segfault on fuzz input

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -2502,7 +2502,7 @@ static int comp_compare(void *a, void *b)
     int r = k1 - k2;
 
     if (r == 0) {
-        if (k1 == ICAL_X_COMPONENT) {
+        if (k1 == ICAL_X_COMPONENT && (c1->x_name && c2->x_name)) {
             r = strcmp(c1->x_name, c2->x_name);
         }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -234,4 +234,5 @@ testme(parser_ctrl "${icalparser_ctrl_test_SRCS}")
 ############# fuzzer tests ############
 
 testme(icalcomponent_fuzz icalcomponent_fuzz.c)
+testme(icalcomponent_fuzz2 icalcomponent_fuzz2.c)
 testme(icaltime_fuzz icaltime_fuzz.c)

--- a/src/test/icalcomponent_fuzz2.c
+++ b/src/test/icalcomponent_fuzz2.c
@@ -1,0 +1,74 @@
+/*======================================================================
+ *
+ * SPDX-FileCopyrightText: 2024 Contributors to the libical project <git@github.com:libical/libical>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+ *
+ * Based on the original code by Gabe Sherman in
+ * https://github.com/libical/libical/issues/677
+ *
+ * ======================================================================*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if defined(NDEBUG)
+#undef NDEBUG
+#endif
+
+#include <stdlib.h>
+
+#include "libical/ical.h"
+
+int main(int argc, char *argv[])
+{
+    FILE *fp;
+    int fd, r;
+    const char *fname;
+#if defined(HAVE__FSTAT64)
+    struct _stat64 sbuf;
+#else
+    struct stat sbuf;
+#endif
+    size_t filesize;
+    void *data = NULL;
+    icalcomponent *comp1, *comp2;
+
+    if (argc != 2) {
+        fname = TEST_DATADIR "/poc-05";
+    } else {
+        fname = argv[1];
+    }
+
+    fp = fopen(fname, "rb");
+    if (fp == (FILE *)NULL) {
+        fprintf(stderr, "Error: unable to open %s\n", fname);
+        assert(0);
+    }
+
+    fd = fileno(fp);
+    fstat(fd, &sbuf);
+    filesize = sbuf.st_size; //to make fortify compile happy
+    data = malloc(filesize + 1);
+    memset(data, 0, filesize + 1);
+
+    r = read(fd, data, filesize);
+    fclose(fp);
+
+    if (r < 0) {
+        fprintf(stderr, "Failed to read data\n");
+        free(data);
+        assert(0);
+    }
+
+    comp1 = icalcomponent_new_from_string(data);
+    comp2 = icalcomponent_clone(comp1);
+    free(data);
+
+    icalcomponent_normalize(comp2);
+    icalcomponent_free(comp2);
+    icalcomponent_free(comp1);
+
+    return 0;
+}

--- a/test-data/poc-05
+++ b/test-data/poc-05
@@ -1,0 +1,10 @@
+BEGIN:VCALENDAR
+BEGIN:xEVENT
+SUMMARY:Bastille Daattemìt to breakﬂanyÈauthorty file lççççççççççççççççççindicateq that xauth should
+ attempt to breakKanyding.
+END:VEVENT
+EN authnrity fiNDNT
+BEGIN:xEVEAR
+EGIN:NTroceeding.
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
In comp_compare() for ICAL_X_COMPONENT don't call strcmp()
if either component x_name is NULL.

includes a regression test

fixes: #677
