### PR TITLE
tolower and toupper cast to int

### DIFF
--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -933,7 +933,7 @@ static void comp_to_v4(vcardcomponent *impl)
                         icalmemory_append_string(&mediatype, &buf_ptr,
                                                  &size, type->xvalue);
                         for (c = mediatype; *c; c++) {
-                            *c = (char)tolower(*c);
+                            *c = (char)tolower((int)*c);
                         }
 
                         /* Remove this TYPE */
@@ -1067,7 +1067,7 @@ static void comp_to_v3(vcardcomponent *impl)
 
                 subtype = icalmemory_strdup(subtype + 1);
                 for (c = subtype; *c; c++) {
-                    *c = (char)toupper(*c);
+                    *c = (char)toupper((int)*c);
                 }
 
                 /* Add TYPE parameter */
@@ -1140,7 +1140,7 @@ static void comp_to_v3(vcardcomponent *impl)
                     char *c;
 
                     for (c = ++subtype; *c; c++) {
-                        *c = (char)toupper(*c);
+                        *c = (char)toupper((int)*c);
                     }
 
                     /* Add TYPE parameter */


### PR DESCRIPTION
encountered when building with clang in msys
