### PR TITLE
src/libical/CMakeLists.txt - set ICal_${LIB_VERSION}_gir_FILES non-empty

### DIFF
--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -152,6 +152,7 @@ if(HAVE_INTROSPECTION)
   set(_includes "-L${LIBRARY_OUTPUT_PATH}")
   set(ICal_${LIB_VERSION}_gir_CFLAGS ${_includes})
   set(ICal_${LIB_VERSION}_gir_LIBS ical)
+  set(ICal_${LIB_VERSION}_gir_FILES "") # quiet ERROR message in GObjectIntrospectionMacros.cmake
 
   list(APPEND GObjectIntrospection_GIRS ICal-${LIBICAL_GIR_VERSION_STRING}.gir)
 


### PR DESCRIPTION
The gir_add_introspections() macro in GObjectIntrospectionMacros prints ERROR message "Unspecified or empty ICal_3_0_gir_FILES variable" if the ICal_${LIB_VERSION}_gir_FILES is undefined or non-empty. So set that variable to an empty string.