### PR TITLE
CMakeLists.txt - don't allow mixing GTK_DOC with MEMORY_CONSISTENCY

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
           export XML_CATALOG_FILES=/usr/local/etc/xml/catalog
           mkdir build
-          cmake -B build --warn-uninitialized -Werror=dev -G Ninja -DLIBICAL_DEVMODE_MEMORY_CONSISTENCY=True -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DLIBICAL_BUILD_TESTING=True -DENABLE_GTK_DOC=True -DICAL_GLIB=True -DGOBJECT_INTROSPECTION=False -DICAL_GLIB_VAPI=False -DLIBICAL_BUILD_TESTING_BIGFUZZ=True
+          cmake -B build --warn-uninitialized -Werror=dev -G Ninja -DLIBICAL_DEVMODE_MEMORY_CONSISTENCY=False -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DLIBICAL_BUILD_TESTING=True -DENABLE_GTK_DOC=True -DICAL_GLIB=True -DGOBJECT_INTROSPECTION=False -DICAL_GLIB_VAPI=False -DLIBICAL_BUILD_TESTING_BIGFUZZ=True
       - name: Build project
         run: cmake --build build
       - name: Test project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,6 +670,13 @@ endif()
 
 libical_option(LIBICAL_DEVMODE_MEMORY_CONSISTENCY "(Developer-only) Build with memory consistency functions." False)
 if(LIBICAL_DEVMODE_MEMORY_CONSISTENCY)
+  if(ENABLE_GTK_DOC)
+    message(
+      FATAL_ERROR
+        "Memory consistency combined with libical-glib documentation generation is incompatible at this time.\n"
+        "Please disable either the LIBICAL_DEVMODE_MEMORY_CONSISTENCY or ENABLE_GTK_DOC CMake options."
+    )
+  endif()
   set(CMAKE_BUILD_TYPE "Debug")
   add_definitions(-DMEMORY_CONSISTENCY)
 endif()


### PR DESCRIPTION
Causes string memory access issues on Mac, at least. see https://github.com/libical/libical/issues/738