### PR TITLE
CMakeLists.txt - prevent mixing introspection with MEMORY_CONSISTENCY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,11 +670,10 @@ endif()
 
 libical_option(LIBICAL_DEVMODE_MEMORY_CONSISTENCY "(Developer-only) Build with memory consistency functions." False)
 if(LIBICAL_DEVMODE_MEMORY_CONSISTENCY)
-  if(ENABLE_GTK_DOC)
+  if(GOBJECT_INTROSPECTION)
     message(
-      FATAL_ERROR
-        "Memory consistency combined with libical-glib documentation generation is incompatible at this time.\n"
-        "Please disable either the LIBICAL_DEVMODE_MEMORY_CONSISTENCY or ENABLE_GTK_DOC CMake options."
+      FATAL_ERROR "Memory consistency combined with GObject Introspection is incompatible at this time.\n"
+                  "Please disable either the LIBICAL_DEVMODE_MEMORY_CONSISTENCY or GOBJECT_INTROSPECTION CMake options."
     )
   endif()
   set(CMAKE_BUILD_TYPE "Debug")


### PR DESCRIPTION
In commit 906d398c48183ae011ee0ef7787ff0db04acb7e0 the buildsystem was changed to prevent building GOBJECT_INTROSPECTION with the MEMORY_CONSISTENCY check. That was wrong: it should have been preventing GOBJECT_INSPECTION.