### PR TITLE
icalrecurrencetype: Replace static 'by' arrays with dynamically allocated ones.

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -21,6 +21,9 @@ Version 3.1.0 (NOT RELEASED YET):
  * libical-glib API is considered stable; no longer need to define LIBICAL_GLIB_UNSTABLE_API=1
    before including <libical-glib/libical-glib.h>
  * icalrecurrencetype now handled by reference rather than by value throughout the library.
+ * icalrecur_iterator_new() now keeps a reference to the passed rule, so that mustn't be modified as long as the iterator is in use.
+ * icalrecurrencetype.by_xxx static arrays replaced by dynamically allocated ones.
+ * GLib/Python bindings: `i_cal_recurrence_*_by_xxx*` methods have been replaced by more generic versions that take the 'by' type (day, month, ...) as a parameter.
  * Allow previous recurrence iteration
  * Improved performance of recurrence iterators
  * GEO property has arbitrary precision (values are internally stored as strings, not doubles)
@@ -38,6 +41,7 @@ Version 3.1.0 (NOT RELEASED YET):
     + icalvalue_clone
     + icalcluster_clone
     + icalrecur_iterator_prev
+    + icalrecur_resize_by
     + icalrecurrencetype_new
     + icalrecurrencetype_ref
     + icalrecurrencetype_unref

--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -32,6 +32,19 @@
         <element name="ICAL_SKIP_OMIT"/>
         <element name="ICAL_SKIP_UNDEFINED"/>
 	</enum>
+    <enum name="ICalRecurrenceByRule" native_name="icalrecurrencetype_byrule" default_native="ICAL_BYRULE_NO_CONTRACTION">
+        <element name="ICAL_BYRULE_NO_CONTRACTION"/>
+        <element name="ICAL_BY_MONTH"/>
+        <element name="ICAL_BY_WEEK_NO"/>
+        <element name="ICAL_BY_YEAR_DAY"/>
+        <element name="ICAL_BY_MONTH_DAY"/>
+        <element name="ICAL_BY_DAY"/>
+        <element name="ICAL_BY_HOUR"/>
+        <element name="ICAL_BY_MINUTE"/>
+        <element name="ICAL_BY_SECOND"/>
+        <element name="ICAL_BY_SET_POS"/>
+        <element name="ICAL_BY_NUM_PARTS"/>
+	</enum>
     <!-- Not a real enum, those are defines in libical -->
     <enum name="ICalRecurrenceArraySizes" native_name="CUSTOM" default_native="I_CAL_BY_SECOND_SIZE">
         <element name="ICAL_BY_SECOND_SIZE"/>
@@ -174,427 +187,72 @@
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->week_start = (icalrecurrencetype_weekday) week_start;</custom>
     </method>
-    <method name="i_cal_recurrence_get_by_second_array" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_recurrence_get_by_array" corresponds="CUSTOM" kind="get" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_SECOND] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_SECOND] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SECOND_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_SECOND]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_second_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_SECOND] array in @recur at once. The array size can be less than I_CAL_BY_SECOND_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_SECOND], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_second_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_SECOND] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_SECOND], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_second" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SECOND] of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_SECOND] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_SECOND] value at index @index. The index should be less than %I_CAL_BY_SECOND_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SECOND], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_second" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SECOND] of #ICalRecurrence, less than I_CAL_BY_SECOND_SIZE"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_SECOND] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_SECOND] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SECOND_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_SECOND_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SECOND], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_minute_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_MINUTE] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_MINUTE] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MINUTE_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_MINUTE]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_minute_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_MINUTE] array in @recur at once. The array size can be less than I_CAL_BY_MINUTE_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_MINUTE], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_minute_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_MINUTE] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_MINUTE], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_minute" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MINUTE] of #ICalRecurrence, less than %I_CAL_BY_MINUTE_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_MINUTE] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_MINUTE] value at index @index. The index should be less than %I_CAL_BY_MINUTE_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MINUTE], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_minute" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MINUTE] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_MINUTE] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_MINUTE] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MINUTE_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_MINUTE_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MINUTE], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_hour_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_HOUR] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_HOUR] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_HOUR_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_HOUR]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_hour_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_HOUR] array in @recur at once. The array size can be less than I_CAL_BY_HOUR_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_HOUR], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_hour_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_HOUR] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_HOUR], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_hour" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_HOUR] of #ICalRecurrence, less than %I_CAL_BY_HOUR_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_HOUR] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_HOUR] value at index @index. The index should be less than %I_CAL_BY_HOUR_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_HOUR], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_hour" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_HOUR] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_HOUR] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_HOUR] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_HOUR_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_HOUR_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_HOUR], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_day_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_DAY] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_DAY] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_DAY_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_DAY]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_day_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_DAY] array in @recur at once. The array size can be less than I_CAL_BY_DAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_DAY], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_day_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_DAY] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_DAY], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_day" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_DAY] of #ICalRecurrence, less than %I_CAL_BY_DAY_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_DAY] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_DAY] value at index @index. The index should be less than %I_CAL_BY_DAY_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_DAY], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_day" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_DAY] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_DAY] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_DAY] array from #ICalRecurrence at the given index. The array size if I_CAL_BY_DAY_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_DAY_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_DAY], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_month_day_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_MONTH_DAY] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_MONTH_DAY] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTHDAY_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_MONTH_DAY]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_month_day_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_MONTH_DAY] array in @recur at once. The array size can be less than I_CAL_BY_MONTHDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_MONTH_DAY], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_month_day_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_MONTH_DAY] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_MONTH_DAY], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_month_day" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH_DAY] of #ICalRecurrence, less than %I_CAL_BY_MONTHDAY_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_MONTH_DAY] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_MONTH_DAY] value at index @index. The index should be less than %I_CAL_BY_MONTHDAY_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH_DAY], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_month_day" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH_DAY] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_MONTH_DAY] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_MONTH_DAY] array from #ICalRecurrence at the given index. The array size if I_CAL_BY_MONTHDAY_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_MONTHDAY_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH_DAY], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_year_day_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_YEAR_DAY] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_YEAR_DAY] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_YEARDAY_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_YEAR_DAY]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_year_day_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_YEAR_DAY] array in @recur at once. The array size can be less than I_CAL_BY_YEARDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_YEAR_DAY], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_year_day_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_YEAR_DAY] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_YEAR_DAY], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_year_day" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_YEAR_DAY] of #ICalRecurrence, less than %I_CAL_BY_YEARDAY_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_YEAR_DAY] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_YEAR_DAY] value at index @index. The index should be less than %I_CAL_BY_YEARDAY_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_YEAR_DAY], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_year_day" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_YEAR_DAY] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_YEAR_DAY] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_YEAR_DAY] array from #ICalRecurrence at the given index. The array size if I_CAL_BY_YEARDAY_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_YEARDAY_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_YEAR_DAY], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_week_no_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_WEEK_NO] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_WEEK_NO] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_WEEKNO_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_WEEK_NO]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_week_no_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_WEEK_NO] array in @recur at once. The array size can be less than I_CAL_BY_WEEKNO_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_WEEK_NO], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_week_no_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_WEEK_NO] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_WEEK_NO], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_week_no" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_WEEK_NO] of #ICalRecurrence, less than %I_CAL_BY_WEEKNO_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_WEEK_NO] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_WEEK_NO] value at index @index. The index should be less than %I_CAL_BY_WEEKNO_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_WEEK_NO], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_week_no" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_WEEK_NO] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_WEEK_NO] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_WEEK_NO] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_WEEKNO_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_WEEKNO_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_WEEK_NO], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_month_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_MONTH] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_MONTH] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTH_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_MONTH]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_month_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_MONTH] array in @recur at once. The array size can be less than I_CAL_BY_MONTH_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_MONTH], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_month_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_MONTH] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_MONTH], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_month" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH] of #ICalRecurrence, less than %I_CAL_BY_MONTH_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_MONTH] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_MONTH] value at index @index. The index should be less than %I_CAL_BY_MONTH_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_month" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_MONTH] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_MONTH] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MONTH_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_MONTH_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_set_pos_array" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_SET_POS] of #ICalRecurrence."/>
-        <comment>Gets the by[ICAL_BY_SET_POS] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SETPOS_SIZE.</comment>
-        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_SET_POS]);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_set_pos_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by[ICAL_BY_SET_POS] array in @recur at once. The array size can be less than I_CAL_BY_SETPOS_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-    g_return_if_fail(values != NULL);
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_SET_POS], values);</custom>
-    </method>
-    <method name="i_cal_recurrence_resize_by_set_pos_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by[ICAL_BY_SET_POS] array in @recur to the given size.</comment>
-        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_SET_POS], size);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_set_pos" corresponds="CUSTOM" kind="get" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SET_POS] of #ICalRecurrence, less than %I_CAL_BY_SETPOS_SIZE"/>
-        <returns type="gshort" comment="The by[ICAL_BY_WEEK_NO] of #ICalRecurrence at index @index."/>
-        <comment>Gets the by[ICAL_BY_SET_POS] value at index @index. The index should be less than %I_CAL_BY_SETPOS_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SET_POS], index);</custom>
-    </method>
-    <method name="i_cal_recurrence_set_by_set_pos" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SET_POS] of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_SET_POS] of #ICalRecurrence"/>
-        <comment>Sets the by[ICAL_BY_SET_POS] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SETPOS_SIZE.</comment>
-        <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
-	g_return_if_fail (index &lt; I_CAL_BY_SETPOS_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SET_POS], index, value);</custom>
-    </method>
-    <method name="i_cal_recurrence_get_by_array" corresponds="CUSTOM" annotation="skip" kind="private">
-        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data to return as GArray."/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="A 'by' part of #ICalRecurrence."/>
-        <comment>Copies the specified 'by' data from #ICalRecurrence into a new GArray and returns it.</comment>
-        <custom>	GArray *array;
-	g_return_val_if_fail (by != NULL, NULL);
-	array = g_array_sized_new(FALSE, TRUE, sizeof (gshort), by->size);
+        <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[byrule] of #ICalRecurrence."/>
+        <comment>Gets the by[byrule] array from #ICalRecurrence.</comment>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+    g_return_val_if_fail ((byrule &gt;= 0) &amp;&amp; ((int)byrule &lt; (int)ICAL_BY_NUM_PARTS), NULL);
+    icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
+    GArray *array = g_array_sized_new(FALSE, TRUE, sizeof (gshort), by->size);
     if (by->size) g_array_append_vals (array, by->data, by->size);
 	return array;</custom>
     </method>
-    <method name="i_cal_recurrence_set_by_array" corresponds="CUSTOM" annotation="skip" kind="private">
-        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data to return as GArray."/>
+    <method name="i_cal_recurrence_get_by_array_size" corresponds="CUSTOM" kind="get" since="4.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
+        <returns type="guint" comment="The current size of the given 'by' array."/>
+        <comment>Returns the size of given 'by' array from #ICalRecurrence.</comment>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0);
+    g_return_val_if_fail ((byrule &gt;= 0) &amp;&amp; ((int)byrule &lt; (int)ICAL_BY_NUM_PARTS), 0);
+    icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
+	return by->size;</custom>
+    </method>
+    <method name="i_cal_recurrence_set_by_array" corresponds="CUSTOM" kind="set" since="4.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
         <comment>Sets the given 'by' array.</comment>
-        <custom>g_return_if_fail(by != NULL);
+        <custom>    g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+    g_return_if_fail ((byrule &gt;= 0) &amp;&amp; ((int)byrule &lt; (int)ICAL_BY_NUM_PARTS));
     g_return_if_fail(values != NULL);
-
+    icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
     g_return_if_fail(icalrecur_resize_by(by, values->len));
     memcpy(by->data, values->data, values->len * sizeof(by->data[0]));</custom>
     </method>
-    <method name="i_cal_recurrence_get_by" corresponds="CUSTOM" annotation="skip" kind="private">
-        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
-        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SECOND] of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
+    <method name="i_cal_recurrence_get_by" corresponds="CUSTOM" kind="get" since="4.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
+        <parameter type="guint" name="index" comment="The index in the by[byrule] array of #ICalRecurrence."/>
         <returns type="gshort" comment="The 'by' part at the given position."/>
-        <comment>Returns the element at the specified index of the 'by' array if it exists, 0x7FFF otherwise.</comment>
-        <custom>	g_return_val_if_fail (by != NULL, 0x7FFF);
-    if (index >= (guint)by->size) return 0x7FFF;
+        <comment>Returns the element at the specified index of the 'by' array if it exists, 0 otherwise.</comment>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0);
+    g_return_val_if_fail ((byrule &gt;= 0) &amp;&amp; ((int)byrule &lt; (int)ICAL_BY_NUM_PARTS), 0);
+    icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
+    g_return_val_if_fail (index &lt; (guint)by->size, 0);
 	return by->data[index];</custom>
     </method>
-    <method name="i_cal_recurrence_set_by" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
+    <method name="i_cal_recurrence_set_by" corresponds="CUSTOM" kind="set" since="4.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="guint" name="index" comment="The index in the 'by' array"/>
         <parameter type="gshort" name="value" comment="The value to be set"/>
-        <comment>Sets the by array at the given index. Resizes the array to have a size of at least index+1 elements.</comment>
-        <custom>	g_return_if_fail (by != NULL);
+        <comment>Sets the by array at the given index. Resizes the array to have a size of at least index+1 elements if necessary.</comment>
+        <custom>    g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+    g_return_if_fail ((byrule &gt;= 0) &amp;&amp; ((int)byrule &lt; (int)ICAL_BY_NUM_PARTS));
+    icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
     if (((guint)by->size) &lt; (index + 1)) g_return_if_fail (icalrecur_resize_by(by, index + 1));
 	by->data[index] = value;</custom>
     </method>
-    <method name="i_cal_recurrence_resize_by_array" corresponds="CUSTOM" kind="set" since="1.0">
-        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
+    <method name="i_cal_recurrence_resize_by_array" corresponds="CUSTOM" kind="others" since="4.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="guint" name="size" comment="The new size of the 'by' array"/>
         <comment>Resizes the 'by' array to the given size.</comment>
-        <custom>	g_return_if_fail (by != NULL);
+        <custom>    g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+    g_return_if_fail ((byrule &gt;= 0) &amp;&amp; ((int)byrule &lt; (int)ICAL_BY_NUM_PARTS));
+    icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
     g_return_if_fail (icalrecur_resize_by(by, size));</custom>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -176,381 +176,381 @@
     </method>
     <method name="i_cal_recurrence_get_by_second_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_second of #ICalRecurrence."/>
-        <comment>Gets the by_second array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SECOND_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_SECOND] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_SECOND] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SECOND_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_second);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_SECOND]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_second_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_second array in @recur at once. The array size can be less than I_CAL_BY_SECOND_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_SECOND] array in @recur at once. The array size can be less than I_CAL_BY_SECOND_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_second, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_SECOND], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_second_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_second array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_SECOND] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_second, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_SECOND], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_second" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_second of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
-        <returns type="gshort" comment="The by_second of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_second value at index @index. The index should be less than %I_CAL_BY_SECOND_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SECOND] of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_SECOND] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_SECOND] value at index @index. The index should be less than %I_CAL_BY_SECOND_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_second, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SECOND], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_second" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_second of #ICalRecurrence, less than I_CAL_BY_SECOND_SIZE"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_second of #ICalRecurrence"/>
-        <comment>Sets the by_second array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SECOND_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SECOND] of #ICalRecurrence, less than I_CAL_BY_SECOND_SIZE"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_SECOND] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_SECOND] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SECOND_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_SECOND_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_second, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SECOND], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_minute_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_minute of #ICalRecurrence."/>
-        <comment>Gets the by_minute array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MINUTE_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_MINUTE] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_MINUTE] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MINUTE_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_minute);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_MINUTE]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_minute_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_minute array in @recur at once. The array size can be less than I_CAL_BY_MINUTE_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_MINUTE] array in @recur at once. The array size can be less than I_CAL_BY_MINUTE_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_minute, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_MINUTE], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_minute_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_minute array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_MINUTE] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_minute, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_MINUTE], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_minute" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_minute of #ICalRecurrence, less than %I_CAL_BY_MINUTE_SIZE"/>
-        <returns type="gshort" comment="The by_minute of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_minute value at index @index. The index should be less than %I_CAL_BY_MINUTE_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MINUTE] of #ICalRecurrence, less than %I_CAL_BY_MINUTE_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_MINUTE] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_MINUTE] value at index @index. The index should be less than %I_CAL_BY_MINUTE_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_minute, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MINUTE], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_minute" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_minute of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_minute of #ICalRecurrence"/>
-        <comment>Sets the by_minute array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MINUTE_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MINUTE] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_MINUTE] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_MINUTE] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MINUTE_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_MINUTE_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_minute, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MINUTE], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_hour_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_hour of #ICalRecurrence."/>
-        <comment>Gets the by_hour array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_HOUR_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_HOUR] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_HOUR] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_HOUR_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_hour);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_HOUR]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_hour_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_hour array in @recur at once. The array size can be less than I_CAL_BY_HOUR_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_HOUR] array in @recur at once. The array size can be less than I_CAL_BY_HOUR_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_hour, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_HOUR], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_hour_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_hour array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_HOUR] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_hour, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_HOUR], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_hour" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_hour of #ICalRecurrence, less than %I_CAL_BY_HOUR_SIZE"/>
-        <returns type="gshort" comment="The by_hour of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_hour value at index @index. The index should be less than %I_CAL_BY_HOUR_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_HOUR] of #ICalRecurrence, less than %I_CAL_BY_HOUR_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_HOUR] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_HOUR] value at index @index. The index should be less than %I_CAL_BY_HOUR_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_hour, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_HOUR], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_hour" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_hour of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_hour of #ICalRecurrence"/>
-        <comment>Sets the by_hour array from #ICalRecurrence at the given index. The array size is I_CAL_BY_HOUR_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_HOUR] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_HOUR] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_HOUR] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_HOUR_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_HOUR_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_hour, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_HOUR], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_day_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_day of #ICalRecurrence."/>
-        <comment>Gets the by_day array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_DAY_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_DAY] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_DAY] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_DAY_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_day);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_DAY]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_day array in @recur at once. The array size can be less than I_CAL_BY_DAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_DAY] array in @recur at once. The array size can be less than I_CAL_BY_DAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_day, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_DAY], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_day array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_DAY] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_day, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_DAY], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_day of #ICalRecurrence, less than %I_CAL_BY_DAY_SIZE"/>
-        <returns type="gshort" comment="The by_day of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_day value at index @index. The index should be less than %I_CAL_BY_DAY_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_DAY] of #ICalRecurrence, less than %I_CAL_BY_DAY_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_DAY] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_DAY] value at index @index. The index should be less than %I_CAL_BY_DAY_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_day, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_DAY], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_day of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_day of #ICalRecurrence"/>
-        <comment>Sets the by_day array from #ICalRecurrence at the given index. The array size if I_CAL_BY_DAY_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_DAY] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_DAY] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_DAY] array from #ICalRecurrence at the given index. The array size if I_CAL_BY_DAY_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_DAY_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_day, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_DAY], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month_day_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_month_day of #ICalRecurrence."/>
-        <comment>Gets the by_month_day array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTHDAY_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_MONTH_DAY] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_MONTH_DAY] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTHDAY_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_month_day);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_MONTH_DAY]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_month_day array in @recur at once. The array size can be less than I_CAL_BY_MONTHDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_MONTH_DAY] array in @recur at once. The array size can be less than I_CAL_BY_MONTHDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_month_day, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_MONTH_DAY], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_month_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_month_day array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_MONTH_DAY] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_month_day, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_MONTH_DAY], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_month_day of #ICalRecurrence, less than %I_CAL_BY_MONTHDAY_SIZE"/>
-        <returns type="gshort" comment="The by_month_day of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_month_day value at index @index. The index should be less than %I_CAL_BY_MONTHDAY_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH_DAY] of #ICalRecurrence, less than %I_CAL_BY_MONTHDAY_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_MONTH_DAY] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_MONTH_DAY] value at index @index. The index should be less than %I_CAL_BY_MONTHDAY_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month_day, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH_DAY], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_month_day of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_month_day of #ICalRecurrence"/>
-        <comment>Sets the by_month_day array from #ICalRecurrence at the given index. The array size if I_CAL_BY_MONTHDAY_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH_DAY] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_MONTH_DAY] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_MONTH_DAY] array from #ICalRecurrence at the given index. The array size if I_CAL_BY_MONTHDAY_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_MONTHDAY_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month_day, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH_DAY], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_year_day_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_year_day of #ICalRecurrence."/>
-        <comment>Gets the by_year_day array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_YEARDAY_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_YEAR_DAY] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_YEAR_DAY] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_YEARDAY_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_year_day);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_YEAR_DAY]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_year_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_year_day array in @recur at once. The array size can be less than I_CAL_BY_YEARDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_YEAR_DAY] array in @recur at once. The array size can be less than I_CAL_BY_YEARDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_year_day, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_YEAR_DAY], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_year_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_year_day array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_YEAR_DAY] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_year_day, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_YEAR_DAY], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_year_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_year_day of #ICalRecurrence, less than %I_CAL_BY_YEARDAY_SIZE"/>
-        <returns type="gshort" comment="The by_year_day of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_year_day value at index @index. The index should be less than %I_CAL_BY_YEARDAY_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_YEAR_DAY] of #ICalRecurrence, less than %I_CAL_BY_YEARDAY_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_YEAR_DAY] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_YEAR_DAY] value at index @index. The index should be less than %I_CAL_BY_YEARDAY_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_year_day, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_YEAR_DAY], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_year_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_year_day of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_year_day of #ICalRecurrence"/>
-        <comment>Sets the by_year_day array from #ICalRecurrence at the given index. The array size if I_CAL_BY_YEARDAY_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_YEAR_DAY] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_YEAR_DAY] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_YEAR_DAY] array from #ICalRecurrence at the given index. The array size if I_CAL_BY_YEARDAY_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_YEARDAY_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_year_day, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_YEAR_DAY], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_week_no_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_week_no of #ICalRecurrence."/>
-        <comment>Gets the by_week_no array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_WEEKNO_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_WEEK_NO] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_WEEK_NO] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_WEEKNO_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_week_no);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_WEEK_NO]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_week_no_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_week_no array in @recur at once. The array size can be less than I_CAL_BY_WEEKNO_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_WEEK_NO] array in @recur at once. The array size can be less than I_CAL_BY_WEEKNO_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_week_no, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_WEEK_NO], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_week_no_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_week_no array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_WEEK_NO] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_week_no, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_WEEK_NO], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_week_no" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_week_no of #ICalRecurrence, less than %I_CAL_BY_WEEKNO_SIZE"/>
-        <returns type="gshort" comment="The by_week_no of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_week_no value at index @index. The index should be less than %I_CAL_BY_WEEKNO_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_WEEK_NO] of #ICalRecurrence, less than %I_CAL_BY_WEEKNO_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_WEEK_NO] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_WEEK_NO] value at index @index. The index should be less than %I_CAL_BY_WEEKNO_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_week_no, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_WEEK_NO], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_week_no" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_week_no of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_week_no of #ICalRecurrence"/>
-        <comment>Sets the by_week_no array from #ICalRecurrence at the given index. The array size is I_CAL_BY_WEEKNO_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_WEEK_NO] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_WEEK_NO] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_WEEK_NO] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_WEEKNO_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_WEEKNO_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_week_no, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_WEEK_NO], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_month of #ICalRecurrence."/>
-        <comment>Gets the by_month array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTH_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_MONTH] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_MONTH] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTH_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_month);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_MONTH]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_month array in @recur at once. The array size can be less than I_CAL_BY_MONTH_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_MONTH] array in @recur at once. The array size can be less than I_CAL_BY_MONTH_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_month, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_MONTH], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_month_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_month array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_MONTH] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_month, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_MONTH], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_month of #ICalRecurrence, less than %I_CAL_BY_MONTH_SIZE"/>
-        <returns type="gshort" comment="The by_month of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_month value at index @index. The index should be less than %I_CAL_BY_MONTH_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH] of #ICalRecurrence, less than %I_CAL_BY_MONTH_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_MONTH] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_MONTH] value at index @index. The index should be less than %I_CAL_BY_MONTH_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_month of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_month of #ICalRecurrence"/>
-        <comment>Sets the by_month array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MONTH_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_MONTH] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_MONTH] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_MONTH] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MONTH_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_MONTH_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_MONTH], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_set_pos_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_set_pos of #ICalRecurrence."/>
-        <comment>Gets the by_set_pos array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SETPOS_SIZE.</comment>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[ICAL_BY_SET_POS] of #ICalRecurrence."/>
+        <comment>Gets the by[ICAL_BY_SET_POS] array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SETPOS_SIZE.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_set_pos);</custom>
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by[ICAL_BY_SET_POS]);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_set_pos_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_set_pos array in @recur at once. The array size can be less than I_CAL_BY_SETPOS_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <comment>Sets the by[ICAL_BY_SET_POS] array in @recur at once. The array size can be less than I_CAL_BY_SETPOS_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_set_by_array(&amp;rt->by_set_pos, values);</custom>
+    i_cal_recurrence_set_by_array(&amp;rt->by[ICAL_BY_SET_POS], values);</custom>
     </method>
     <method name="i_cal_recurrence_resize_by_set_pos_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
-        <comment>Resizes the by_set_pos array in @recur to the given size.</comment>
+        <comment>Resizes the by[ICAL_BY_SET_POS] array in @recur to the given size.</comment>
         <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-    i_cal_recurrence_resize_by_array(&amp;rt->by_set_pos, size);</custom>
+    i_cal_recurrence_resize_by_array(&amp;rt->by[ICAL_BY_SET_POS], size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_set_pos" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_set_pos of #ICalRecurrence, less than %I_CAL_BY_SETPOS_SIZE"/>
-        <returns type="gshort" comment="The by_week_no of #ICalRecurrence at index @index."/>
-        <comment>Gets the by_set_pos value at index @index. The index should be less than %I_CAL_BY_SETPOS_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SET_POS] of #ICalRecurrence, less than %I_CAL_BY_SETPOS_SIZE"/>
+        <returns type="gshort" comment="The by[ICAL_BY_WEEK_NO] of #ICalRecurrence at index @index."/>
+        <comment>Gets the by[ICAL_BY_SET_POS] value at index @index. The index should be less than %I_CAL_BY_SETPOS_SIZE.</comment>
         <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
-    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_set_pos, index);</custom>
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SET_POS], index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_set_pos" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
-        <parameter type="guint" name="index" comment="The index in by_set_pos of #ICalRecurrence"/>
-        <parameter type="gshort" name="value" comment="The value to be set into by_set_pos of #ICalRecurrence"/>
-        <comment>Sets the by_set_pos array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SETPOS_SIZE.</comment>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SET_POS] of #ICalRecurrence"/>
+        <parameter type="gshort" name="value" comment="The value to be set into by[ICAL_BY_SET_POS] of #ICalRecurrence"/>
+        <comment>Sets the by[ICAL_BY_SET_POS] array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SETPOS_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_SETPOS_SIZE);
-    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_set_pos, index, value);</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[ICAL_BY_SET_POS], index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_array" corresponds="CUSTOM" annotation="skip" kind="private">
         <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data to return as GArray."/>
@@ -574,7 +574,7 @@
     </method>
     <method name="i_cal_recurrence_get_by" corresponds="CUSTOM" annotation="skip" kind="private">
         <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
-        <parameter type="guint" name="index" comment="The index in by_second of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
+        <parameter type="guint" name="index" comment="The index in by[ICAL_BY_SECOND] of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
         <returns type="gshort" comment="The 'by' part at the given position."/>
         <comment>Returns the element at the specified index of the 'by' array if it exists, 0x7FFF otherwise.</comment>
         <custom>	g_return_val_if_fail (by != NULL, 0x7FFF);

--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -32,16 +32,6 @@
         <element name="ICAL_SKIP_OMIT"/>
         <element name="ICAL_SKIP_UNDEFINED"/>
 	</enum>
-    <!-- Mark "enum icalrecurrence_array_max_values" as "CUSTOM", to not have it checked
-         in build time due to the below reason. -->
-    <enum name="ICalRecurrenceArrayMaxValues" native_name="CUSTOM" default_native="I_CAL_RECURRENCE_ARRAY_MAX">
-	<element name="ICAL_RECURRENCE_ARRAY_MAX"/>
-	<!-- Skip this one, it confuses git generator (no name for the first,
-	     because it's all part of this one. Furthermore, this one is not
-	     used in public.
-	<element name="ICAL_RECURRENCE_ARRAY_MAX_BYTE"/>
-	-->
-    </enum>
     <!-- Not a real enum, those are defines in libical -->
     <enum name="ICalRecurrenceArraySizes" native_name="CUSTOM" default_native="I_CAL_BY_SECOND_SIZE">
         <element name="ICAL_BY_SECOND_SIZE"/>
@@ -188,46 +178,34 @@
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_second of #ICalRecurrence."/>
         <comment>Gets the by_second array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SECOND_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	array = g_array_new (FALSE, TRUE, sizeof (gshort));
-	for (size = 0; size &lt; I_CAL_BY_SECOND_SIZE; size++) {
-		if (native_recurrence->by_second[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_second, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_second);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_second_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_second array in @recur at once. The array size can be less than I_CAL_BY_SECOND_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_second array in @recur at once. The array size can be less than I_CAL_BY_SECOND_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_SECOND_SIZE; ii++) {
-        rt->by_second[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_SECOND_SIZE)
-        rt->by_second[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_second, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_second_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_second array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_second, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_second" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_second of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
         <returns type="gshort" comment="The by_second of #ICalRecurrence at index @index."/>
         <comment>Gets the by_second value at index @index. The index should be less than %I_CAL_BY_SECOND_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_SECOND_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_second[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_second, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_second" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -236,52 +214,40 @@
         <comment>Sets the by_second array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SECOND_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_SECOND_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_second[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_second, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_minute_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_minute of #ICalRecurrence."/>
         <comment>Gets the by_minute array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MINUTE_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	for (size = 0; size &lt; I_CAL_BY_MINUTE_SIZE; size++) {
-		if (native_recurrence->by_minute[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_minute, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_minute);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_minute_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_minute array in @recur at once. The array size can be less than I_CAL_BY_MINUTE_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_minute array in @recur at once. The array size can be less than I_CAL_BY_MINUTE_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_MINUTE_SIZE; ii++) {
-        rt->by_minute[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_MINUTE_SIZE)
-        rt->by_minute[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_minute, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_minute_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_minute array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_minute, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_minute" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_minute of #ICalRecurrence, less than %I_CAL_BY_MINUTE_SIZE"/>
         <returns type="gshort" comment="The by_minute of #ICalRecurrence at index @index."/>
         <comment>Gets the by_minute value at index @index. The index should be less than %I_CAL_BY_MINUTE_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_MINUTE_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_minute[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_minute, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_minute" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -290,52 +256,40 @@
         <comment>Sets the by_minute array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MINUTE_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_MINUTE_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_minute[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_minute, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_hour_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_hour of #ICalRecurrence."/>
         <comment>Gets the by_hour array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_HOUR_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_HOUR_SIZE; size++) {
-		if (native_recurrence->by_hour[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_hour, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_hour);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_hour_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_hour array in @recur at once. The array size can be less than I_CAL_BY_HOUR_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_hour array in @recur at once. The array size can be less than I_CAL_BY_HOUR_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_HOUR_SIZE; ii++) {
-        rt->by_hour[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_HOUR_SIZE)
-        rt->by_hour[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_hour, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_hour_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_hour array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_hour, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_hour" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_hour of #ICalRecurrence, less than %I_CAL_BY_HOUR_SIZE"/>
         <returns type="gshort" comment="The by_hour of #ICalRecurrence at index @index."/>
         <comment>Gets the by_hour value at index @index. The index should be less than %I_CAL_BY_HOUR_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_HOUR_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_hour[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_hour, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_hour" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -344,52 +298,40 @@
         <comment>Sets the by_hour array from #ICalRecurrence at the given index. The array size is I_CAL_BY_HOUR_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_HOUR_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_hour[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_hour, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_day_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_day of #ICalRecurrence."/>
         <comment>Gets the by_day array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_DAY_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_DAY_SIZE; size++) {
-		if (native_recurrence->by_day[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_day, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_day);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_day array in @recur at once. The array size can be less than I_CAL_BY_DAY_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_day array in @recur at once. The array size can be less than I_CAL_BY_DAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_DAY_SIZE; ii++) {
-        rt->by_day[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_DAY_SIZE)
-        rt->by_day[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_day, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_day_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_day array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_day, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_day of #ICalRecurrence, less than %I_CAL_BY_DAY_SIZE"/>
         <returns type="gshort" comment="The by_day of #ICalRecurrence at index @index."/>
         <comment>Gets the by_day value at index @index. The index should be less than %I_CAL_BY_DAY_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_DAY_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_day[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_day, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -398,52 +340,40 @@
         <comment>Sets the by_day array from #ICalRecurrence at the given index. The array size if I_CAL_BY_DAY_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_DAY_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_day[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_day, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month_day_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_month_day of #ICalRecurrence."/>
         <comment>Gets the by_month_day array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTHDAY_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_MONTHDAY_SIZE; size++) {
-		if (native_recurrence->by_month_day[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_month_day, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_month_day);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_month_day array in @recur at once. The array size can be less than I_CAL_BY_MONTHDAY_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_month_day array in @recur at once. The array size can be less than I_CAL_BY_MONTHDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_MONTHDAY_SIZE; ii++) {
-        rt->by_month_day[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_MONTHDAY_SIZE)
-        rt->by_month_day[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_month_day, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_month_day_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_month_day array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_month_day, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_month_day of #ICalRecurrence, less than %I_CAL_BY_MONTHDAY_SIZE"/>
         <returns type="gshort" comment="The by_month_day of #ICalRecurrence at index @index."/>
         <comment>Gets the by_month_day value at index @index. The index should be less than %I_CAL_BY_MONTHDAY_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_MONTHDAY_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month_day[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month_day, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -452,52 +382,40 @@
         <comment>Sets the by_month_day array from #ICalRecurrence at the given index. The array size if I_CAL_BY_MONTHDAY_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_MONTHDAY_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month_day[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month_day, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_year_day_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_year_day of #ICalRecurrence."/>
         <comment>Gets the by_year_day array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_YEARDAY_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_YEARDAY_SIZE; size++) {
-		if (native_recurrence->by_year_day[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_year_day, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_year_day);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_year_day_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_year_day array in @recur at once. The array size can be less than I_CAL_BY_YEARDAY_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_year_day array in @recur at once. The array size can be less than I_CAL_BY_YEARDAY_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_YEARDAY_SIZE; ii++) {
-        rt->by_year_day[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_YEARDAY_SIZE)
-        rt->by_year_day[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_year_day, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_year_day_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_year_day array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_year_day, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_year_day" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_year_day of #ICalRecurrence, less than %I_CAL_BY_YEARDAY_SIZE"/>
         <returns type="gshort" comment="The by_year_day of #ICalRecurrence at index @index."/>
         <comment>Gets the by_year_day value at index @index. The index should be less than %I_CAL_BY_YEARDAY_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_YEARDAY_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_year_day[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_year_day, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_year_day" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -506,52 +424,40 @@
         <comment>Sets the by_year_day array from #ICalRecurrence at the given index. The array size if I_CAL_BY_YEARDAY_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_YEARDAY_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_year_day[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_year_day, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_week_no_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_week_no of #ICalRecurrence."/>
         <comment>Gets the by_week_no array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_WEEKNO_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_WEEKNO_SIZE; size++) {
-		if (native_recurrence->by_week_no[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_week_no, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_week_no);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_week_no_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_week_no array in @recur at once. The array size can be less than I_CAL_BY_WEEKNO_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_week_no array in @recur at once. The array size can be less than I_CAL_BY_WEEKNO_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_WEEKNO_SIZE; ii++) {
-        rt->by_week_no[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_WEEKNO_SIZE)
-        rt->by_week_no[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_week_no, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_week_no_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_week_no array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_week_no, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_week_no" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_week_no of #ICalRecurrence, less than %I_CAL_BY_WEEKNO_SIZE"/>
         <returns type="gshort" comment="The by_week_no of #ICalRecurrence at index @index."/>
         <comment>Gets the by_week_no value at index @index. The index should be less than %I_CAL_BY_WEEKNO_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_WEEKNO_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_week_no[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_week_no, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_week_no" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -560,52 +466,40 @@
         <comment>Sets the by_week_no array from #ICalRecurrence at the given index. The array size is I_CAL_BY_WEEKNO_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_WEEKNO_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_week_no[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_week_no, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_month of #ICalRecurrence."/>
         <comment>Gets the by_month array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_MONTH_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_MONTH_SIZE; size++) {
-		if (native_recurrence->by_month[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_month, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_month);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_month array in @recur at once. The array size can be less than I_CAL_BY_MONTH_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_month array in @recur at once. The array size can be less than I_CAL_BY_MONTH_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_MONTH_SIZE; ii++) {
-        rt->by_month[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_MONTH_SIZE)
-        rt->by_month[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_month, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_month_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_month array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_month, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_month" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_month of #ICalRecurrence, less than %I_CAL_BY_MONTH_SIZE"/>
         <returns type="gshort" comment="The by_month of #ICalRecurrence at index @index."/>
         <comment>Gets the by_month value at index @index. The index should be less than %I_CAL_BY_MONTH_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_MONTH_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_month" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -614,52 +508,40 @@
         <comment>Sets the by_month array from #ICalRecurrence at the given index. The array size is I_CAL_BY_MONTH_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_MONTH_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_month, index, value);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_set_pos_array" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by_set_pos of #ICalRecurrence."/>
         <comment>Gets the by_set_pos array from #ICalRecurrence. The array has a maximum size of I_CAL_BY_SETPOS_SIZE.</comment>
-        <custom>	GArray *array;
-	struct icalrecurrencetype *native_recurrence;
-	guint size;
-	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
-	array = g_array_new (FALSE, FALSE, sizeof (gshort));
-	native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
-	for (size = 0; size &lt; I_CAL_BY_SETPOS_SIZE; size++) {
-		if (native_recurrence->by_set_pos[size] == I_CAL_RECURRENCE_ARRAY_MAX)
-			break;
-	}
-	g_array_append_vals (array, native_recurrence->by_set_pos, size);
-	return array;</custom>
+        <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
+	struct icalrecurrencetype *native_recurrence = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+	return i_cal_recurrence_get_by_array(&amp;native_recurrence->by_set_pos);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_set_pos_array" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
-        <comment>Sets the by_set_pos array in @recur at once. The array size can be less than I_CAL_BY_SETPOS_SIZE. Shorter arrays are terminated with I_CAL_RECURRENCE_ARRAY_MAX value, longer arrays are truncated.</comment>
-        <custom>    struct icalrecurrencetype *rt;
-    guint ii;
-
-    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+        <comment>Sets the by_set_pos array in @recur at once. The array size can be less than I_CAL_BY_SETPOS_SIZE. Shorter arrays are terminated with 0x7FFF value, longer arrays are truncated.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
     g_return_if_fail(values != NULL);
-
-    rt = (struct icalrecurrencetype *)i_cal_object_get_native((ICalObject *)recur);
-    g_return_if_fail(rt != NULL);
-
-    for(ii = 0; ii &lt; values-&gt;len &amp;&amp; ii &lt; I_CAL_BY_SETPOS_SIZE; ii++) {
-        rt->by_set_pos[ii] = g_array_index(values, gshort, ii);
-    }
-    if(ii &lt; I_CAL_BY_SETPOS_SIZE)
-        rt->by_set_pos[ii] = I_CAL_RECURRENCE_ARRAY_MAX;</custom>
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_set_by_array(&amp;rt->by_set_pos, values);</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_set_pos_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
+        <parameter type="guint" name="size" comment="The new size of the array in number of elements."/>
+        <comment>Resizes the by_set_pos array in @recur to the given size.</comment>
+        <custom>    g_return_if_fail(recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
+	struct icalrecurrencetype *rt = (struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur);
+    i_cal_recurrence_resize_by_array(&amp;rt->by_set_pos, size);</custom>
     </method>
     <method name="i_cal_recurrence_get_by_set_pos" corresponds="CUSTOM" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="guint" name="index" comment="The index in by_set_pos of #ICalRecurrence, less than %I_CAL_BY_SETPOS_SIZE"/>
         <returns type="gshort" comment="The by_week_no of #ICalRecurrence at index @index."/>
         <comment>Gets the by_set_pos value at index @index. The index should be less than %I_CAL_BY_SETPOS_SIZE.</comment>
-        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_RECURRENCE_ARRAY_MAX);
-    g_return_val_if_fail (index &lt; I_CAL_BY_SETPOS_SIZE, I_CAL_RECURRENCE_ARRAY_MAX);
-    return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_set_pos[index];</custom>
+        <custom>    g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0x7FFF);
+    return i_cal_recurrence_get_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_set_pos, index);</custom>
     </method>
     <method name="i_cal_recurrence_set_by_set_pos" corresponds="CUSTOM" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
@@ -668,6 +550,51 @@
         <comment>Sets the by_set_pos array from #ICalRecurrence at the given index. The array size is I_CAL_BY_SETPOS_SIZE.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	g_return_if_fail (index &lt; I_CAL_BY_SETPOS_SIZE);
-	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_set_pos[index] = value;</custom>
+    i_cal_recurrence_set_by(&amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by_set_pos, index, value);</custom>
+    </method>
+    <method name="i_cal_recurrence_get_by_array" corresponds="CUSTOM" annotation="skip" kind="private">
+        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data to return as GArray."/>
+        <returns type="GArray *" annotation="transfer full, element-type gshort" comment="A 'by' part of #ICalRecurrence."/>
+        <comment>Copies the specified 'by' data from #ICalRecurrence into a new GArray and returns it.</comment>
+        <custom>	GArray *array;
+	g_return_val_if_fail (by != NULL, NULL);
+	array = g_array_sized_new(FALSE, TRUE, sizeof (gshort), by->size);
+    if (by->size) g_array_append_vals (array, by->data, by->size);
+	return array;</custom>
+    </method>
+    <method name="i_cal_recurrence_set_by_array" corresponds="CUSTOM" annotation="skip" kind="private">
+        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data to return as GArray."/>
+        <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
+        <comment>Sets the given 'by' array.</comment>
+        <custom>g_return_if_fail(by != NULL);
+    g_return_if_fail(values != NULL);
+
+    g_return_if_fail(icalrecur_resize_by(by, values->len));
+    memcpy(by->data, values->data, values->len * sizeof(by->data[0]));</custom>
+    </method>
+    <method name="i_cal_recurrence_get_by" corresponds="CUSTOM" annotation="skip" kind="private">
+        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
+        <parameter type="guint" name="index" comment="The index in by_second of #ICalRecurrence, less than %I_CAL_BY_SECOND_SIZE"/>
+        <returns type="gshort" comment="The 'by' part at the given position."/>
+        <comment>Returns the element at the specified index of the 'by' array if it exists, 0x7FFF otherwise.</comment>
+        <custom>	g_return_val_if_fail (by != NULL, 0x7FFF);
+    if (index >= (guint)by->size) return 0x7FFF;
+	return by->data[index];</custom>
+    </method>
+    <method name="i_cal_recurrence_set_by" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
+        <parameter type="guint" name="index" comment="The index in the 'by' array"/>
+        <parameter type="gshort" name="value" comment="The value to be set"/>
+        <comment>Sets the by array at the given index. Resizes the array to have a size of at least index+1 elements.</comment>
+        <custom>	g_return_if_fail (by != NULL);
+    if (((guint)by->size) &lt; (index + 1)) g_return_if_fail (icalrecur_resize_by(by, index + 1));
+	by->data[index] = value;</custom>
+    </method>
+    <method name="i_cal_recurrence_resize_by_array" corresponds="CUSTOM" kind="set" since="1.0">
+        <parameter type="icalrecurrence_by_data *" annotation="" name="by" comment="The 'by' data."/>
+        <parameter type="guint" name="size" comment="The new size of the 'by' array"/>
+        <comment>Resizes the 'by' array to the given size.</comment>
+        <custom>	g_return_if_fail (by != NULL);
+    g_return_if_fail (icalrecur_resize_by(by, size));</custom>
     </method>
 </structure>

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -407,28 +407,18 @@ static const struct expand_split_map_struct expand_map[] = {
 
 static const struct recur_map {
     const char *str;
-    size_t by_offset;
     int size;
     int min;
 } recur_map[] = {
-    {"BYMONTH", offsetof(struct icalrecurrencetype, by_month),
-     ICAL_BY_MONTH_SIZE, 1},
-    {"BYWEEKNO", offsetof(struct icalrecurrencetype, by_week_no),
-     ICAL_BY_WEEKNO_SIZE, -1},
-    {"BYYEARDAY", offsetof(struct icalrecurrencetype, by_year_day),
-     ICAL_BY_YEARDAY_SIZE, -1},
-    {"BYMONTHDAY", offsetof(struct icalrecurrencetype, by_month_day),
-     ICAL_BY_MONTHDAY_SIZE, -1},
-    {"BYDAY", offsetof(struct icalrecurrencetype, by_day),
-     ICAL_BY_DAY_SIZE, 0},
-    {"BYHOUR", offsetof(struct icalrecurrencetype, by_hour),
-     ICAL_BY_HOUR_SIZE, 0},
-    {"BYMINUTE", offsetof(struct icalrecurrencetype, by_minute),
-     ICAL_BY_MINUTE_SIZE, 0},
-    {"BYSECOND", offsetof(struct icalrecurrencetype, by_second),
-     ICAL_BY_SECOND_SIZE, 0},
-    {"BYSETPOS", offsetof(struct icalrecurrencetype, by_set_pos),
-     ICAL_BY_SETPOS_SIZE, -1},
+    {"BYMONTH", ICAL_BY_MONTH_SIZE, 1},
+    {"BYWEEKNO", ICAL_BY_WEEKNO_SIZE, -1},
+    {"BYYEARDAY", ICAL_BY_YEARDAY_SIZE, -1},
+    {"BYMONTHDAY", ICAL_BY_MONTHDAY_SIZE, -1},
+    {"BYDAY", ICAL_BY_DAY_SIZE, 0},
+    {"BYHOUR", ICAL_BY_HOUR_SIZE, 0},
+    {"BYMINUTE", ICAL_BY_MINUTE_SIZE, 0},
+    {"BYSECOND", ICAL_BY_SECOND_SIZE, 0},
+    {"BYSETPOS", ICAL_BY_SETPOS_SIZE, -1},
 };
 
 static const char *icalrecur_first_clause(struct icalrecur_parser *parser)
@@ -543,7 +533,7 @@ static int icalrecur_add_byrules(struct icalrecur_parser *parser, icalrecurrence
 
         if (*t) {
             /* Check for leap month suffix (RSCALE only) */
-            if (by == &parser->rt->by_month && strcmp(t, "L") == 0) {
+            if (by == &parser->rt->by[ICAL_BY_MONTH] && strcmp(t, "L") == 0) {
                 if (icalrecurrencetype_rscale_is_supported()) {
                     /* The "L" suffix in a BYMONTH recur-rule-part
                        is encoded by setting a high-order bit */
@@ -573,9 +563,9 @@ static int icalrecur_add_byrules(struct icalrecur_parser *parser, icalrecurrence
  */
 static void sort_bydayrules(struct icalrecur_parser *parser)
 {
-    icalrecurrence_by_data *by = &parser->rt->by_day;
+    icalrecurrence_by_data *by = &parser->rt->by[ICAL_BY_DAY];
     short *array = by->data;
-    
+
     int week_start, one, two, i, j;
 
     week_start = parser->rt->week_start;
@@ -605,7 +595,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
                                     const char *vals)
 {
     char *t, *n;
-    icalrecurrence_by_data *by = &parser->rt->by_day;
+    icalrecurrence_by_data *by = &parser->rt->by[ICAL_BY_DAY];
 
     char *vals_copy;
     int idx = 0;
@@ -683,13 +673,14 @@ struct icalrecurrencetype *icalrecurrencetype_new(void)
         return NULL;
     }
 
+    memset(rule, 0, sizeof(*rule));
     rule->refcount = 1;
     icalrecurrencetype_clear(rule);
 
     return rule;
 }
 
-static void icalrecurrencetype_free(struct icalrecurrencetype *recur)
+static void icalrecurrencetype_free(struct icalrecurrencetype *recur, int free_self)
 {
 #define SAFEFREE(p)                \
     if (p) {                       \
@@ -698,19 +689,15 @@ static void icalrecurrencetype_free(struct icalrecurrencetype *recur)
     }
 
     SAFEFREE(recur->rscale);
-    SAFEFREE(recur->by_second.data);
-    SAFEFREE(recur->by_minute.data);
-    SAFEFREE(recur->by_hour.data);
-    SAFEFREE(recur->by_day.data);
-    SAFEFREE(recur->by_month_day.data);
-    SAFEFREE(recur->by_year_day.data);
-    SAFEFREE(recur->by_week_no.data);
-    SAFEFREE(recur->by_month.data);
-    SAFEFREE(recur->by_set_pos.data);
+    for (int i = 0; i < ICAL_BY_NUM_PARTS; i++) {
+        SAFEFREE(recur->by[i].data);
+    }
 
 #undef SAFEFREE
 
-    icalmemory_free_buffer(recur);
+    if (free_self) {
+        icalmemory_free_buffer(recur);
+    }
 }
 
 void icalrecurrencetype_ref(struct icalrecurrencetype *recur)
@@ -731,7 +718,7 @@ void icalrecurrencetype_unref(struct icalrecurrencetype *recur)
     if (recur->refcount != 0)
         return;
 
-    icalrecurrencetype_free(recur);
+    icalrecurrencetype_free(recur, 1);
 }
 
 static void* icalrecur_memdup(void *p, size_t size, int* error)
@@ -783,16 +770,14 @@ struct icalrecurrencetype *icalrecurrencetype_clone(struct icalrecurrencetype *r
         }
     }
 
-
     for (int i = 0; i < ICAL_BY_NUM_PARTS; i++) {
-        size_t offset = recur_map[i].by_offset;
-        icalrecurrence_by_data *src_by = (icalrecurrence_by_data *)(offset + (size_t)recur);
-        icalrecurrence_by_data *dst_by = (icalrecurrence_by_data *)(offset + (size_t)res);
+        icalrecurrence_by_data *src_by = &recur->by[i];
+        icalrecurrence_by_data *dst_by = &res->by[i];
         *dst_by = icalrecur_by_dup(src_by, &error);
     }
 
     if (error) {
-        icalrecurrencetype_free(res);
+        icalrecurrencetype_free(res, 1);
         return NULL;
     }
 
@@ -919,7 +904,7 @@ struct icalrecurrencetype *icalrecurrencetype_new_from_string(const char *str)
                     if (byrule == ICAL_BY_DAY) {
                         r = icalrecur_add_bydayrules(&parser, value);
                     } else {
-                        icalrecurrence_by_data *by = (icalrecurrence_by_data *)(recur_map[byrule].by_offset + (size_t)parser.rt);
+                        icalrecurrence_by_data *by = &parser.rt->by[byrule];
                         r = icalrecur_add_byrules(&parser, by,
                                                   recur_map[byrule].min,
                                                   recur_map[byrule].size,
@@ -939,16 +924,13 @@ struct icalrecurrencetype *icalrecurrencetype_new_from_string(const char *str)
             if (r != -2) {
                 icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
             }
-            if (parser.rt->rscale) {
-                icalmemory_free_buffer(parser.rt->rscale);
-            }
             icalrecurrencetype_clear(parser.rt);
             break;
         }
     }
 
     for (byrule = 0; byrule < ICAL_BY_NUM_PARTS; ++byrule) {
-        icalrecurrence_by_data *by = (icalrecurrence_by_data *)(recur_map[byrule].by_offset + (size_t)parser.rt);
+        icalrecurrence_by_data *by = &parser.rt->by[byrule];
 
         if (by->size > 0 &&
             expand_map[parser.rt->freq].map[byrule] == ILLEGAL) {
@@ -957,9 +939,6 @@ struct icalrecurrencetype *icalrecurrencetype_new_from_string(const char *str)
 
             if (rruleHandlingSetting == ICAL_RRULE_TREAT_AS_ERROR) {
                 icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-                if (parser.rt->rscale) {
-                    icalmemory_free_buffer(parser.rt->rscale);
-                }
                 icalrecurrencetype_clear(parser.rt);
                 break;
             } else {
@@ -1036,7 +1015,7 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
     }
 
     for (j = 0; j < ICAL_BY_NUM_PARTS; j++) {
-        icalrecurrence_by_data *by = (icalrecurrence_by_data *)(recur_map[j].by_offset + (size_t)recur);
+        icalrecurrence_by_data *by = &recur->by[j];
         int limit = recur_map[j].size - 1;
 
         /* Skip unused arrays */
@@ -2145,15 +2124,15 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype *rule,
     /* Set up convenience pointers to make the code simpler. Allows
        us to iterate through all of the BY* arrays in the rule. */
 
-    impl->by_ptrs[ICAL_BY_MONTH] = &impl->rule->by_month;
-    impl->by_ptrs[ICAL_BY_WEEK_NO] = &impl->rule->by_week_no;
-    impl->by_ptrs[ICAL_BY_YEAR_DAY] = &impl->rule->by_year_day;
-    impl->by_ptrs[ICAL_BY_MONTH_DAY] = &impl->rule->by_month_day;
-    impl->by_ptrs[ICAL_BY_DAY] = &impl->rule->by_day;
-    impl->by_ptrs[ICAL_BY_HOUR] = &impl->rule->by_hour;
-    impl->by_ptrs[ICAL_BY_MINUTE] = &impl->rule->by_minute;
-    impl->by_ptrs[ICAL_BY_SECOND] = &impl->rule->by_second;
-    impl->by_ptrs[ICAL_BY_SET_POS] = &impl->rule->by_set_pos;
+    impl->by_ptrs[ICAL_BY_MONTH] = &impl->rule->by[ICAL_BY_MONTH];
+    impl->by_ptrs[ICAL_BY_WEEK_NO] = &impl->rule->by[ICAL_BY_WEEK_NO];
+    impl->by_ptrs[ICAL_BY_YEAR_DAY] = &impl->rule->by[ICAL_BY_YEAR_DAY];
+    impl->by_ptrs[ICAL_BY_MONTH_DAY] = &impl->rule->by[ICAL_BY_MONTH_DAY];
+    impl->by_ptrs[ICAL_BY_DAY] = &impl->rule->by[ICAL_BY_DAY];
+    impl->by_ptrs[ICAL_BY_HOUR] = &impl->rule->by[ICAL_BY_HOUR];
+    impl->by_ptrs[ICAL_BY_MINUTE] = &impl->rule->by[ICAL_BY_MINUTE];
+    impl->by_ptrs[ICAL_BY_SECOND] = &impl->rule->by[ICAL_BY_SECOND];
+    impl->by_ptrs[ICAL_BY_SET_POS] = &impl->rule->by[ICAL_BY_SET_POS];
 
     memset(impl->orig_data, 0, ICAL_BY_NUM_PARTS * sizeof(short));
 
@@ -2163,31 +2142,27 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype *rule,
        routine. The orig_data array will be used later in has_by_data */
 
     impl->orig_data[ICAL_BY_MONTH] =
-        (short)(impl->rule->by_month.size > 0);
+        (short)(impl->rule->by[ICAL_BY_MONTH].size > 0);
     impl->orig_data[ICAL_BY_WEEK_NO] =
-        (short)(impl->rule->by_week_no.size > 0);
+        (short)(impl->rule->by[ICAL_BY_WEEK_NO].size > 0);
     impl->orig_data[ICAL_BY_YEAR_DAY] =
-        (short)(impl->rule->by_year_day.size > 0);
+        (short)(impl->rule->by[ICAL_BY_YEAR_DAY].size > 0);
     impl->orig_data[ICAL_BY_MONTH_DAY] =
-        (short)(impl->rule->by_month_day.size > 0);
+        (short)(impl->rule->by[ICAL_BY_MONTH_DAY].size > 0);
     impl->orig_data[ICAL_BY_DAY] =
-        (short)(impl->rule->by_day.size > 0);
+        (short)(impl->rule->by[ICAL_BY_DAY].size > 0);
     impl->orig_data[ICAL_BY_HOUR] =
-        (short)(impl->rule->by_hour.size > 0);
+        (short)(impl->rule->by[ICAL_BY_HOUR].size > 0);
     impl->orig_data[ICAL_BY_MINUTE] =
-        (short)(impl->rule->by_minute.size > 0);
+        (short)(impl->rule->by[ICAL_BY_MINUTE].size > 0);
     impl->orig_data[ICAL_BY_SECOND] =
-        (short)(impl->rule->by_second.size > 0);
+        (short)(impl->rule->by[ICAL_BY_SECOND].size > 0);
     impl->orig_data[ICAL_BY_SET_POS] =
-        (short)(impl->rule->by_set_pos.size > 0);
+        (short)(impl->rule->by[ICAL_BY_SET_POS].size > 0);
 
     /* Check if the recurrence rule is legal */
 
-<<<<<<< HEAD
-    for (byrule = 0; byrule < NUM_BY_PARTS; ++byrule) {
-=======
-    for (byrule = 0; byrule < ICAL_BY_NUM_PARTS; byrule++) {
->>>>>>> e3f6e5f0 (icalrecur: Refactor `enum icalrecurrencetype_byrule` et al into a public type for future use.)
+    for (byrule = 0; byrule < ICAL_BY_NUM_PARTS; ++byrule) {
         if (expand_map[freq].map[byrule] == ILLEGAL &&
             has_by_data(impl, byrule)) {
             ical_invalid_rrule_handling rruleHandlingSetting =
@@ -2423,7 +2398,7 @@ static int prev_unit(icalrecur_iterator *impl,
                      void (*increment_super_unit)(icalrecur_iterator *, int))
 {
     int has_by_unit = (by_unit > ICAL_BYRULE_NO_CONTRACTION) &&
-                      (impl->by_ptrs[by_unit]->size > 0);
+                      (impl->bydata[by_unit].by.size > 0);
     int this_frequency = (impl->rule->freq == frequency);
 
     int end_of_data = 0;
@@ -2435,6 +2410,8 @@ static int prev_unit(icalrecur_iterator *impl,
     }
 
     if (has_by_unit) {
+        icalrecurrence_iterator_by_data *bydata = &impl->bydata[by_unit];
+
         /* Ignore the frequency and use the byrule data */
 
         impl->by_indices[by_unit]--;
@@ -2492,8 +2469,8 @@ static int check_set_position(icalrecur_iterator *impl, int set_pos)
     int i;
     int found = 0;
 
-    for (i = 0; i < impl->rule->by_set_pos.size; i++) {
-        if (impl->rule->by_set_pos.data[i] == set_pos) {
+    for (i = 0; i < impl->rule->by[ICAL_BY_SET_POS].size; i++) {
+        if (impl->rule->by[ICAL_BY_SET_POS].data[i] == set_pos) {
             found = 1;
             break;
         }
@@ -3736,10 +3713,9 @@ static void icalrecurrencetype_clear(struct icalrecurrencetype *recur)
 {
     int refcount = recur->refcount;
 
-    for (int byrule = 0; byrule < ICAL_BY_NUM_PARTS; byrule++) {
-        icalrecurrence_by_data *by = (icalrecurrence_by_data *)(recur_map[byrule].by_offset + (size_t)recur);
-        icalrecur_free_by(by);
-    }
+    icalrecurrencetype_free(recur, 0);
+
+    memset(recur, 0, sizeof(*recur));
 
     recur->refcount = refcount;
 

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -109,6 +109,22 @@ typedef enum icalrecurrencetype_skip
     ICAL_SKIP_UNDEFINED
 } icalrecurrencetype_skip;
 
+typedef enum icalrecurrencetype_byrule
+{
+    ICAL_BYRULE_NO_CONTRACTION = -1,
+    ICAL_BY_MONTH = 0,
+    ICAL_BY_WEEK_NO = 1,
+    ICAL_BY_YEAR_DAY = 2,
+    ICAL_BY_MONTH_DAY = 3,
+    ICAL_BY_DAY = 4,
+    ICAL_BY_HOUR = 5,
+    ICAL_BY_MINUTE = 6,
+    ICAL_BY_SECOND = 7,
+    ICAL_BY_SET_POS = 8,
+
+    ICAL_BY_NUM_PARTS = 9
+} icalrecurrencetype_byrule;
+
 /*
  * Recurrence enumerations conversion routines.
  */

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -178,38 +178,23 @@ struct icalrecurrencetype {
 
     icalrecurrencetype_weekday week_start;
 
-    /* The BY* parameters can each take a list of values. Here I
-     * assume that the list of values will not be larger than the
-     * range of the value -- that is, the client will not name a
-     * value more than once.
-     */
-
-
-    icalrecurrence_by_data by_second;
-    icalrecurrence_by_data by_minute;
-    icalrecurrence_by_data by_hour;
-    icalrecurrence_by_data by_day; /**< @brief Encoded value
-        *
-        * The 'day' element of the by_day array is encoded to allow
-        * representation of both the day of the week ( Monday, Tuesday), but
-        * also the Nth day of the week (first Tuesday of the month, last
-        * Thursday of the year).
-        *
-        * These values are decoded by icalrecurrencetype_day_day_of_week() and
-        * icalrecurrencetype_day_position().
-        */
-    icalrecurrence_by_data by_month_day;
-    icalrecurrence_by_data by_year_day;
-    icalrecurrence_by_data by_week_no;
-    icalrecurrence_by_data by_month; /**< @brief Encoded value
-        *
-        * The 'month' element of the by_month array is encoded to allow
-        * representation of the "L" leap suffix (RFC 7529).
-        *
-        * These values are decoded by icalrecurrencetype_month_is_leap()
-        * and icalrecurrencetype_month_month().
-        */
-    icalrecurrence_by_data by_set_pos;
+    /**< @brief Encoded value
+    *
+    * The 'day' element of the ICAL_BY_DAY array is encoded to allow
+    * representation of both the day of the week ( Monday, Tuesday), but
+    * also the Nth day of the week (first Tuesday of the month, last
+    * Thursday of the year).
+    *
+    * These values are decoded by icalrecurrencetype_day_day_of_week() and
+    * icalrecurrencetype_day_position().
+    *
+    * The 'month' element of the ICAL_BY_MONTH array is encoded to allow
+    * representation of the "L" leap suffix (RFC 7529).
+    *
+    * These values are decoded by icalrecurrencetype_month_is_leap()
+    * and icalrecurrencetype_month_month().
+    */
+    icalrecurrence_by_data by[ICAL_BY_NUM_PARTS];
 
     /* For RSCALE extension (RFC 7529) */
     char *rscale;
@@ -217,7 +202,7 @@ struct icalrecurrencetype {
 };
 
 /**
- * @brief Allocates and initalizes a new instance of icalrecurrencetype. The new instance
+ * @brief Allocates and initializes a new instance of icalrecurrencetype. The new instance
  * is returned with a refcount of 1.
  * @return A pointer to the new instance, of NULL if allocation failed.
  */
@@ -252,7 +237,7 @@ LIBICAL_ICAL_EXPORT struct icalrecurrencetype *icalrecurrencetype_clone(struct i
 LIBICAL_ICAL_EXPORT int icalrecur_resize_by(icalrecurrence_by_data *by, short size);
 
 /*
- * Routines to decode the day values of the by_day array
+ * Routines to decode the day values of the by[ICAL_BY_DAY] array
  */
 
 /** @brief Decodes a day to a weekday.
@@ -281,7 +266,7 @@ LIBICAL_ICAL_EXPORT enum icalrecurrencetype_weekday icalrecurrencetype_day_day_o
 LIBICAL_ICAL_EXPORT int icalrecurrencetype_day_position(short day);
 
 /** Encodes the @p weekday and @p position into a form, which can be stored
- *  to icalrecurrencetype::by_day array. Use icalrecurrencetype_day_day_of_week()
+ *  to icalrecurrencetype::by[ICAL_BY_DAY] array. Use icalrecurrencetype_day_day_of_week()
  *  and icalrecurrencetype_day_position() to split the encoded value back into the parts.
  * @since 3.1
  */
@@ -289,11 +274,11 @@ LIBICAL_ICAL_EXPORT short icalrecurrencetype_encode_day(enum icalrecurrencetype_
                                                         int position);
 
 /*
- * Routines to decode the 'month' element of the by_month array
+ * Routines to decode the 'month' element of the by[ICAL_BY_MONTH] array
  */
 
 /**
- * The @p month element of the by_month array is encoded to allow
+ * The @p month element of the by[ICAL_BY_MONTH] array is encoded to allow
  * representation of the "L" leap suffix (RFC 7529).
  * These routines decode the month values.
  *
@@ -304,7 +289,7 @@ LIBICAL_ICAL_EXPORT int icalrecurrencetype_month_is_leap(short month);
 LIBICAL_ICAL_EXPORT int icalrecurrencetype_month_month(short month);
 
 /** Encodes the @p month and the @p is_leap into a form, which can be stored
- *  to icalrecurrencetype::by_month array. Use icalrecurrencetype_month_is_leap()
+ *  to icalrecurrencetype::by[ICAL_BY_MONTH] array. Use icalrecurrencetype_month_is_leap()
  *  and icalrecurrencetype_month_month() to split the encoded value back into the parts
  *  @since 3.1
  */

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -312,7 +312,11 @@ LIBICAL_ICAL_EXPORT char *icalrecurrencetype_as_string_r(struct icalrecurrencety
 
 typedef struct icalrecur_iterator_impl icalrecur_iterator;
 
-/** Creates a new recurrence rule iterator, starting at DTSTART. */
+/** Creates a new recurrence rule iterator, starting at DTSTART.
+ *
+ * NOTE: The new iterator may keep a reference to the passed rule. It must not be modified as long as
+ * the iterator is in use.
+ */
 LIBICAL_ICAL_EXPORT icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype *rule,
                                                                struct icaltimetype dtstart);
 

--- a/src/libicalvcal/icalvcal.c
+++ b/src/libicalvcal/icalvcal.c
@@ -873,7 +873,7 @@ static const char *rrule_parse_weekly_days(const char *s,
     if (*error_message)
         return NULL;
 
-    if (!icalrecur_resize_by(&recur->by_day, ICAL_BY_DAY_SIZE)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_DAY], ICAL_BY_DAY_SIZE)) {
         return NULL;
     }
 
@@ -897,7 +897,7 @@ static const char *rrule_parse_weekly_days(const char *s,
             break;
 
         /* cppcheck-suppress arrayIndexOutOfBounds; since 'day' can't be >6 */
-        recur->by_day.data[i] = weekday_codes[day];
+        recur->by[ICAL_BY_DAY].data[i] = weekday_codes[day];
 
         s = e;
         /* Skip any whitespace. */
@@ -905,7 +905,7 @@ static const char *rrule_parse_weekly_days(const char *s,
             s++;
     }
 
-    if (!icalrecur_resize_by(&recur->by_day, i)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_DAY], i)) {
         return NULL;
     }
 
@@ -922,7 +922,7 @@ static const char *rrule_parse_monthly_days(const char *s,
     if (*error_message)
         return NULL;
 
-    if (!icalrecur_resize_by(&recur->by_month_day, ICAL_BY_MONTHDAY_SIZE)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_MONTH_DAY], ICAL_BY_MONTHDAY_SIZE)) {
         return NULL;
     }
 
@@ -953,7 +953,7 @@ static const char *rrule_parse_monthly_days(const char *s,
         if (*e != ' ' && *e != '\t' && *e != '\0')
             break;
 
-        recur->by_month_day.data[i] = month_day;
+        recur->by[ICAL_BY_MONTH_DAY].data[i] = month_day;
 
         s = e;
         /* Skip any whitespace. */
@@ -961,15 +961,15 @@ static const char *rrule_parse_monthly_days(const char *s,
             s++;
     }
 
-    if (!icalrecur_resize_by(&recur->by_month_day, i)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_MONTH_DAY], i)) {
         return NULL;
     }
 
     return s;
 }
 
-static int icalrecur_set_single_by(icalrecurrence_by_data *by, short value) {
-
+static int icalrecur_set_single_by(icalrecurrence_by_data *by, short value)
+{
     if (!icalrecur_resize_by(by, 1)) {
         return 0;
     }
@@ -1053,7 +1053,7 @@ static const char *rrule_parse_monthly_positions(const char *s,
             s++;
     }
 
-    /* Now merge them together into the recur->by_day array. If there is a
+    /* Now merge them together into the recur->by[ICAL_BY_DAY] array. If there is a
        single position & weekday we output something like
        'BYDAY=TU;BYSETPOS=2', so Outlook will understand it. */
     num_weekdays = 0;
@@ -1064,11 +1064,11 @@ static const char *rrule_parse_monthly_positions(const char *s,
         }
     }
     if (num_positions == 1 && num_weekdays == 1) {
-        if (!icalrecur_set_single_by(&recur->by_day, weekday_codes[only_weekday])) {
+        if (!icalrecur_set_single_by(&recur->by[ICAL_BY_DAY], weekday_codes[only_weekday])) {
             return NULL;
         }
 
-        if (!icalrecur_set_single_by(&recur->by_set_pos, occurrences[0])) {
+        if (!icalrecur_set_single_by(&recur->by[ICAL_BY_SET_POS], occurrences[0])) {
             return NULL;
         }
     } else {
@@ -1078,12 +1078,11 @@ static const char *rrule_parse_monthly_positions(const char *s,
 
             for (day = 0; day < 7; day++) {
                 if (found_weekdays[day]) {
-
-                    if (!icalrecur_resize_by(&recur->by_day, elems + 1)) {
+                    if (!icalrecur_resize_by(&recur->by[ICAL_BY_DAY], elems + 1)) {
                         return NULL;
                     }
 
-                    recur->by_day.data[elems] =
+                    recur->by[ICAL_BY_DAY].data[elems] =
                         (abs(month_position) * 8 +
                          weekday_codes[day]) *
                         ((month_position < 0) ? -1 : 1);
@@ -1111,7 +1110,7 @@ static const char *rrule_parse_yearly_months(const char *s,
     if (*error_message)
         return NULL;
 
-    if (!icalrecur_resize_by(&recur->by_month, ICAL_BY_MONTH_SIZE)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_MONTH], ICAL_BY_MONTH_SIZE)) {
         return NULL;
     }
 
@@ -1129,7 +1128,7 @@ static const char *rrule_parse_yearly_months(const char *s,
         if (*e != ' ' && *e != '\t' && *e != '\0')
             break;
 
-        recur->by_month.data[i] = month;
+        recur->by[ICAL_BY_MONTH].data[i] = month;
 
         s = e;
         /* Skip any whitespace. */
@@ -1137,7 +1136,7 @@ static const char *rrule_parse_yearly_months(const char *s,
             s++;
     }
 
-    if (!icalrecur_resize_by(&recur->by_month, i)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_MONTH], i)) {
         return NULL;
     }
 
@@ -1154,7 +1153,7 @@ static const char *rrule_parse_yearly_days(const char *s,
     if (*error_message)
         return NULL;
 
-    if (!icalrecur_resize_by(&recur->by_year_day, ICAL_BY_YEARDAY_SIZE)) {
+    if (!icalrecur_resize_by(&recur->by[ICAL_BY_YEAR_DAY], ICAL_BY_YEARDAY_SIZE)) {
         return NULL;
     }
 
@@ -1172,7 +1171,7 @@ static const char *rrule_parse_yearly_days(const char *s,
         if (*e != ' ' && *e != '\t' && *e != '\0')
             break;
 
-        recur->by_year_day.data[i] = year_day;
+        recur->by[ICAL_BY_YEAR_DAY].data[i] = year_day;
 
         s = e;
         /* Skip any whitespace. */

--- a/src/test/libical-glib/recurrence.py
+++ b/src/test/libical-glib/recurrence.py
@@ -49,9 +49,8 @@ recurrence = ICalGLib.Recurrence.new_from_string(string)
 assert recurrence.to_string() == "FREQ=DAILY;COUNT=10"
 
 recurrence.set_by_second(0, 1)
-recurrence.set_by_second(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
 assert recurrence.get_by_second(0) == 1
-assert recurrence.get_by_second(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_second(1) == 0x7FFF
 array = recurrence.get_by_second_array()
 assert array[0] == 1
 assert len(array) == 1
@@ -60,16 +59,16 @@ assert len(array) == 2
 recurrence.set_by_second_array(array)
 assert recurrence.get_by_second(0) == 100
 assert recurrence.get_by_second(1) == 101
-assert recurrence.get_by_second(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_second(2) == 0x7FFF
 array = recurrence.get_by_second_array()
 assert array[0] == 100
 assert array[1] == 101
 assert len(array) == 2
 
 recurrence.set_by_minute(0, 2)
-recurrence.set_by_minute(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_minute_array(1)
 assert recurrence.get_by_minute(0) == 2
-assert recurrence.get_by_minute(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_minute(1) == 0x7FFF
 array = recurrence.get_by_minute_array()
 assert array[0] == 2
 assert len(array) == 1
@@ -78,16 +77,16 @@ assert len(array) == 2
 recurrence.set_by_minute_array(array)
 assert recurrence.get_by_minute(0) == 200
 assert recurrence.get_by_minute(1) == 201
-assert recurrence.get_by_minute(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_minute(2) == 0x7FFF
 array = recurrence.get_by_minute_array()
 assert array[0] == 200
 assert array[1] == 201
 assert len(array) == 2
 
 recurrence.set_by_hour(0, 3)
-recurrence.set_by_hour(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_hour_array(1)
 assert recurrence.get_by_hour(0) == 3
-assert recurrence.get_by_hour(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_hour(1) == 0x7FFF
 array = recurrence.get_by_hour_array()
 assert array[0] == 3
 assert len(array) == 1
@@ -96,16 +95,16 @@ assert len(array) == 2
 recurrence.set_by_hour_array(array)
 assert recurrence.get_by_hour(0) == 300
 assert recurrence.get_by_hour(1) == 301
-assert recurrence.get_by_hour(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_hour(2) == 0x7FFF
 array = recurrence.get_by_hour_array()
 assert array[0] == 300
 assert array[1] == 301
 assert len(array) == 2
 
 recurrence.set_by_day(0, 4)
-recurrence.set_by_day(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_day_array(1)
 assert recurrence.get_by_day(0) == 4
-assert recurrence.get_by_day(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_day(1) == 0x7FFF
 array = recurrence.get_by_day_array()
 assert array[0] == 4
 assert len(array) == 1
@@ -114,16 +113,16 @@ assert len(array) == 2
 recurrence.set_by_day_array(array)
 assert recurrence.get_by_day(0) == 400
 assert recurrence.get_by_day(1) == 401
-assert recurrence.get_by_day(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_day(2) == 0x7FFF
 array = recurrence.get_by_day_array()
 assert array[0] == 400
 assert array[1] == 401
 assert len(array) == 2
 
 recurrence.set_by_month_day(0, 5)
-recurrence.set_by_month_day(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_month_day_array(1)
 assert recurrence.get_by_month_day(0) == 5
-assert recurrence.get_by_month_day(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_month_day(1) == 0x7FFF
 array = recurrence.get_by_month_day_array()
 assert array[0] == 5
 assert len(array) == 1
@@ -132,16 +131,16 @@ assert len(array) == 2
 recurrence.set_by_month_day_array(array)
 assert recurrence.get_by_month_day(0) == 500
 assert recurrence.get_by_month_day(1) == 501
-assert recurrence.get_by_month_day(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_month_day(2) == 0x7FFF
 array = recurrence.get_by_month_day_array()
 assert array[0] == 500
 assert array[1] == 501
 assert len(array) == 2
 
 recurrence.set_by_year_day(0, 6)
-recurrence.set_by_year_day(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_year_day_array(1)
 assert recurrence.get_by_year_day(0) == 6
-assert recurrence.get_by_year_day(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_year_day(1) == 0x7FFF
 array = recurrence.get_by_year_day_array()
 assert array[0] == 6
 assert len(array) == 1
@@ -150,16 +149,16 @@ assert len(array) == 2
 recurrence.set_by_year_day_array(array)
 assert recurrence.get_by_year_day(0) == 600
 assert recurrence.get_by_year_day(1) == 601
-assert recurrence.get_by_year_day(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_year_day(2) == 0x7FFF
 array = recurrence.get_by_year_day_array()
 assert array[0] == 600
 assert array[1] == 601
 assert len(array) == 2
 
 recurrence.set_by_week_no(0, 7)
-recurrence.set_by_week_no(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_week_no_array(1)
 assert recurrence.get_by_week_no(0) == 7
-assert recurrence.get_by_week_no(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_week_no(1) == 0x7FFF
 array = recurrence.get_by_week_no_array()
 assert array[0] == 7
 assert len(array) == 1
@@ -168,16 +167,16 @@ assert len(array) == 2
 recurrence.set_by_week_no_array(array)
 assert recurrence.get_by_week_no(0) == 700
 assert recurrence.get_by_week_no(1) == 701
-assert recurrence.get_by_week_no(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_week_no(2) == 0x7FFF
 array = recurrence.get_by_week_no_array()
 assert array[0] == 700
 assert array[1] == 701
 assert len(array) == 2
 
 recurrence.set_by_month(0, 8)
-recurrence.set_by_month(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_month_array(1)
 assert recurrence.get_by_month(0) == 8
-assert recurrence.get_by_month(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_month(1) == 0x7FFF
 array = recurrence.get_by_month_array()
 assert array[0] == 8
 assert len(array) == 1
@@ -186,16 +185,16 @@ assert len(array) == 2
 recurrence.set_by_month_array(array)
 assert recurrence.get_by_month(0) == 800
 assert recurrence.get_by_month(1) == 801
-assert recurrence.get_by_month(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_month(2) == 0x7FFF
 array = recurrence.get_by_month_array()
 assert array[0] == 800
 assert array[1] == 801
 assert len(array) == 2
 
 recurrence.set_by_set_pos(0, 9)
-recurrence.set_by_set_pos(1, ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX)
+recurrence.resize_by_set_pos_array(1)
 assert recurrence.get_by_set_pos(0) == 9
-assert recurrence.get_by_set_pos(1) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_set_pos(1) == 0x7FFF
 array = recurrence.get_by_set_pos_array()
 assert array[0] == 9
 assert len(array) == 1
@@ -204,7 +203,7 @@ assert len(array) == 2
 recurrence.set_by_set_pos_array(array)
 assert recurrence.get_by_set_pos(0) == 900
 assert recurrence.get_by_set_pos(1) == 901
-assert recurrence.get_by_set_pos(2) == ICalGLib.RecurrenceArrayMaxValues.RECURRENCE_ARRAY_MAX
+assert recurrence.get_by_set_pos(2) == 0x7FFF
 array = recurrence.get_by_set_pos_array()
 assert array[0] == 900
 assert array[1] == 901

--- a/src/test/libical-glib/recurrence.py
+++ b/src/test/libical-glib/recurrence.py
@@ -48,169 +48,170 @@ string = "COUNT=10;FREQ=DAILY"
 recurrence = ICalGLib.Recurrence.new_from_string(string)
 assert recurrence.to_string() == "FREQ=DAILY;COUNT=10"
 
-recurrence.set_by_second(0, 1)
-assert recurrence.get_by_second(0) == 1
-assert recurrence.get_by_second(1) == 0x7FFF
-array = recurrence.get_by_second_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_SECOND, 0, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SECOND, 0) == 1
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SECOND, 1) == 0
+assert recurrence.get_by_array_size(ICalGLib.RecurrenceByRule.BY_SECOND) == 1
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_SECOND)
 assert array[0] == 1
 assert len(array) == 1
 array = [100, 101]
 assert len(array) == 2
-recurrence.set_by_second_array(array)
-assert recurrence.get_by_second(0) == 100
-assert recurrence.get_by_second(1) == 101
-assert recurrence.get_by_second(2) == 0x7FFF
-array = recurrence.get_by_second_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_SECOND, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SECOND, 0) == 100
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SECOND, 1) == 101
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SECOND, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_SECOND)
 assert array[0] == 100
 assert array[1] == 101
 assert len(array) == 2
 
-recurrence.set_by_minute(0, 2)
-recurrence.resize_by_minute_array(1)
-assert recurrence.get_by_minute(0) == 2
-assert recurrence.get_by_minute(1) == 0x7FFF
-array = recurrence.get_by_minute_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_MINUTE, 0, 2)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_MINUTE, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MINUTE, 0) == 2
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MINUTE, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_MINUTE, )
 assert array[0] == 2
 assert len(array) == 1
 array = [200, 201]
 assert len(array) == 2
-recurrence.set_by_minute_array(array)
-assert recurrence.get_by_minute(0) == 200
-assert recurrence.get_by_minute(1) == 201
-assert recurrence.get_by_minute(2) == 0x7FFF
-array = recurrence.get_by_minute_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_MINUTE, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MINUTE, 0) == 200
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MINUTE, 1) == 201
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MINUTE, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_MINUTE, )
 assert array[0] == 200
 assert array[1] == 201
 assert len(array) == 2
 
-recurrence.set_by_hour(0, 3)
-recurrence.resize_by_hour_array(1)
-assert recurrence.get_by_hour(0) == 3
-assert recurrence.get_by_hour(1) == 0x7FFF
-array = recurrence.get_by_hour_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_HOUR, 0, 3)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_HOUR, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_HOUR, 0) == 3
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_HOUR, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_HOUR, )
 assert array[0] == 3
 assert len(array) == 1
 array = [300, 301]
 assert len(array) == 2
-recurrence.set_by_hour_array(array)
-assert recurrence.get_by_hour(0) == 300
-assert recurrence.get_by_hour(1) == 301
-assert recurrence.get_by_hour(2) == 0x7FFF
-array = recurrence.get_by_hour_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_HOUR, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_HOUR, 0) == 300
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_HOUR, 1) == 301
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_HOUR, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_HOUR, )
 assert array[0] == 300
 assert array[1] == 301
 assert len(array) == 2
 
-recurrence.set_by_day(0, 4)
-recurrence.resize_by_day_array(1)
-assert recurrence.get_by_day(0) == 4
-assert recurrence.get_by_day(1) == 0x7FFF
-array = recurrence.get_by_day_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_DAY, 0, 4)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_DAY, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_DAY, 0) == 4
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_DAY, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_DAY, )
 assert array[0] == 4
 assert len(array) == 1
 array = [400, 401]
 assert len(array) == 2
-recurrence.set_by_day_array(array)
-assert recurrence.get_by_day(0) == 400
-assert recurrence.get_by_day(1) == 401
-assert recurrence.get_by_day(2) == 0x7FFF
-array = recurrence.get_by_day_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_DAY, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_DAY, 0) == 400
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_DAY, 1) == 401
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_DAY, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_DAY, )
 assert array[0] == 400
 assert array[1] == 401
 assert len(array) == 2
 
-recurrence.set_by_month_day(0, 5)
-recurrence.resize_by_month_day_array(1)
-assert recurrence.get_by_month_day(0) == 5
-assert recurrence.get_by_month_day(1) == 0x7FFF
-array = recurrence.get_by_month_day_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 0, 5)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 0) == 5
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, )
 assert array[0] == 5
 assert len(array) == 1
 array = [500, 501]
 assert len(array) == 2
-recurrence.set_by_month_day_array(array)
-assert recurrence.get_by_month_day(0) == 500
-assert recurrence.get_by_month_day(1) == 501
-assert recurrence.get_by_month_day(2) == 0x7FFF
-array = recurrence.get_by_month_day_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 0) == 500
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 1) == 501
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_MONTH_DAY, )
 assert array[0] == 500
 assert array[1] == 501
 assert len(array) == 2
 
-recurrence.set_by_year_day(0, 6)
-recurrence.resize_by_year_day_array(1)
-assert recurrence.get_by_year_day(0) == 6
-assert recurrence.get_by_year_day(1) == 0x7FFF
-array = recurrence.get_by_year_day_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 0, 6)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 0) == 6
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, )
 assert array[0] == 6
 assert len(array) == 1
 array = [600, 601]
 assert len(array) == 2
-recurrence.set_by_year_day_array(array)
-assert recurrence.get_by_year_day(0) == 600
-assert recurrence.get_by_year_day(1) == 601
-assert recurrence.get_by_year_day(2) == 0x7FFF
-array = recurrence.get_by_year_day_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 0) == 600
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 1) == 601
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_YEAR_DAY, )
 assert array[0] == 600
 assert array[1] == 601
 assert len(array) == 2
 
-recurrence.set_by_week_no(0, 7)
-recurrence.resize_by_week_no_array(1)
-assert recurrence.get_by_week_no(0) == 7
-assert recurrence.get_by_week_no(1) == 0x7FFF
-array = recurrence.get_by_week_no_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 0, 7)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 0) == 7
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_WEEK_NO, )
 assert array[0] == 7
 assert len(array) == 1
 array = [700, 701]
 assert len(array) == 2
-recurrence.set_by_week_no_array(array)
-assert recurrence.get_by_week_no(0) == 700
-assert recurrence.get_by_week_no(1) == 701
-assert recurrence.get_by_week_no(2) == 0x7FFF
-array = recurrence.get_by_week_no_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_WEEK_NO, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 0) == 700
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 1) == 701
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_WEEK_NO, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_WEEK_NO, )
 assert array[0] == 700
 assert array[1] == 701
 assert len(array) == 2
 
-recurrence.set_by_month(0, 8)
-recurrence.resize_by_month_array(1)
-assert recurrence.get_by_month(0) == 8
-assert recurrence.get_by_month(1) == 0x7FFF
-array = recurrence.get_by_month_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_MONTH, 0, 8)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_MONTH, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH, 0) == 8
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_MONTH, )
 assert array[0] == 8
 assert len(array) == 1
 array = [800, 801]
 assert len(array) == 2
-recurrence.set_by_month_array(array)
-assert recurrence.get_by_month(0) == 800
-assert recurrence.get_by_month(1) == 801
-assert recurrence.get_by_month(2) == 0x7FFF
-array = recurrence.get_by_month_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_MONTH, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH, 0) == 800
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH, 1) == 801
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_MONTH, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_MONTH, )
 assert array[0] == 800
 assert array[1] == 801
 assert len(array) == 2
 
-recurrence.set_by_set_pos(0, 9)
-recurrence.resize_by_set_pos_array(1)
-assert recurrence.get_by_set_pos(0) == 9
-assert recurrence.get_by_set_pos(1) == 0x7FFF
-array = recurrence.get_by_set_pos_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_SET_POS, 0, 9)
+recurrence.resize_by_array(ICalGLib.RecurrenceByRule.BY_SET_POS, 1)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SET_POS, 0) == 9
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SET_POS, 1) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_SET_POS, )
 assert array[0] == 9
 assert len(array) == 1
 array = [900, 901]
 assert len(array) == 2
-recurrence.set_by_set_pos_array(array)
-assert recurrence.get_by_set_pos(0) == 900
-assert recurrence.get_by_set_pos(1) == 901
-assert recurrence.get_by_set_pos(2) == 0x7FFF
-array = recurrence.get_by_set_pos_array()
+recurrence.set_by_array(ICalGLib.RecurrenceByRule.BY_SET_POS, array)
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SET_POS, 0) == 900
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SET_POS, 1) == 901
+assert recurrence.get_by(ICalGLib.RecurrenceByRule.BY_SET_POS, 2) == 0
+array = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_SET_POS, )
 assert array[0] == 900
 assert array[1] == 901
 assert len(array) == 2
 
-recurrence.set_by_second(0, 13)
-by_second = recurrence.get_by_second_array()
+recurrence.set_by(ICalGLib.RecurrenceByRule.BY_SECOND, 0, 13)
+by_second = recurrence.get_by_array(ICalGLib.RecurrenceByRule.BY_SECOND)
 assert by_second[0] == 13
 
 recurrence = ICalGLib.Recurrence.new_from_string(string)

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1292,29 +1292,26 @@ void test_recur_encode_by_day(void)
 
     rt = icalrecurrencetype_new_from_string("FREQ=WEEKLY;BYDAY=WE");
     ok("Is weekly recurrence", (rt->freq == ICAL_WEEKLY_RECURRENCE));
-    ok("The by_day[0] is set", (rt->by_day[0] != ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The by_day[1] is not set", (rt->by_day[1] == ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The day of week is Wednesday", (icalrecurrencetype_day_day_of_week(rt->by_day[0]) == ICAL_WEDNESDAY_WEEKDAY));
-    ok("The position is 0", (icalrecurrencetype_day_position(rt->by_day[0]) == 0));
-    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_WEDNESDAY_WEEKDAY, 0) == rt->by_day[0]));
+    ok("The by_day size equals 1", (rt->by_day.size == 1));
+    ok("The day of week is Wednesday", (icalrecurrencetype_day_day_of_week(rt->by_day.data[0]) == ICAL_WEDNESDAY_WEEKDAY));
+    ok("The position is 0", (icalrecurrencetype_day_position(rt->by_day.data[0]) == 0));
+    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_WEDNESDAY_WEEKDAY, 0) == rt->by_day.data[0]));
     icalrecurrencetype_unref(rt);
 
     rt = icalrecurrencetype_new_from_string("FREQ=MONTHLY;BYDAY=2FR");
     ok("Is monthly recurrence", (rt->freq == ICAL_MONTHLY_RECURRENCE));
-    ok("The by_day[0] is set", (rt->by_day[0] != ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The by_day[1] is not set", (rt->by_day[1] == ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The day of week is Friday", (icalrecurrencetype_day_day_of_week(rt->by_day[0]) == ICAL_FRIDAY_WEEKDAY));
-    ok("The position is 2", (icalrecurrencetype_day_position(rt->by_day[0]) == 2));
-    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_FRIDAY_WEEKDAY, 2) == rt->by_day[0]));
+    ok("The by_day size equals 1", (rt->by_day.size == 1));
+    ok("The day of week is Friday", (icalrecurrencetype_day_day_of_week(rt->by_day.data[0]) == ICAL_FRIDAY_WEEKDAY));
+    ok("The position is 2", (icalrecurrencetype_day_position(rt->by_day.data[0]) == 2));
+    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_FRIDAY_WEEKDAY, 2) == rt->by_day.data[0]));
     icalrecurrencetype_unref(rt);
 
     rt = icalrecurrencetype_new_from_string("FREQ=YEARLY;BYDAY=-3MO");
     ok("Is yearly recurrence", (rt->freq == ICAL_YEARLY_RECURRENCE));
-    ok("The by_day[0] is set", (rt->by_day[0] != ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The by_day[1] is not set", (rt->by_day[1] == ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The day of week is Monday", (icalrecurrencetype_day_day_of_week(rt->by_day[0]) == ICAL_MONDAY_WEEKDAY));
-    ok("The position is -3", (icalrecurrencetype_day_position(rt->by_day[0]) == -3));
-    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_MONDAY_WEEKDAY, -3) == rt->by_day[0]));
+    ok("The by_day size equals 1", (rt->by_day.size == 1));
+    ok("The day of week is Monday", (icalrecurrencetype_day_day_of_week(rt->by_day.data[0]) == ICAL_MONDAY_WEEKDAY));
+    ok("The position is -3", (icalrecurrencetype_day_position(rt->by_day.data[0]) == -3));
+    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_MONDAY_WEEKDAY, -3) == rt->by_day.data[0]));
     icalrecurrencetype_unref(rt);
 
     for (ii = -5; ii <= 5; ii++) {
@@ -1341,21 +1338,19 @@ void test_recur_encode_by_month(void)
 
     rt = icalrecurrencetype_new_from_string("FREQ=WEEKLY;BYMONTH=2");
     ok("Is weekly recurrence", (rt->freq == ICAL_WEEKLY_RECURRENCE));
-    ok("The by_month[0] is set", (rt->by_month[0] != ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The by_month[1] is not set", (rt->by_month[1] == ICAL_RECURRENCE_ARRAY_MAX));
-    ok("The month is 2", (icalrecurrencetype_month_month(rt->by_month[0]) == 2));
-    ok("Is not leap month", (icalrecurrencetype_month_is_leap(rt->by_month[0]) == 0));
-    ok("Encoded value matches", (icalrecurrencetype_encode_month(2, 0) == rt->by_month[0]));
+    ok("The by_month size equals 1", (rt->by_month.size == 1));
+    ok("The month is 2", (icalrecurrencetype_month_month(rt->by_month.data[0]) == 2));
+    ok("Is not leap month", (icalrecurrencetype_month_is_leap(rt->by_month.data[0]) == 0));
+    ok("Encoded value matches", (icalrecurrencetype_encode_month(2, 0) == rt->by_month.data[0]));
     icalrecurrencetype_unref(rt);
 
     rt = icalrecurrencetype_new_from_string("FREQ=MONTHLY;BYMONTH=3L");
     if (rt != NULL) {
         ok("Is monthly recurrence", (rt->freq == ICAL_MONTHLY_RECURRENCE));
-        ok("The by_month[0] is set", (rt->by_month[0] != ICAL_RECURRENCE_ARRAY_MAX));
-        ok("The by_month[1] is not set", (rt->by_month[1] == ICAL_RECURRENCE_ARRAY_MAX));
-        ok("The month is 3", (icalrecurrencetype_month_month(rt->by_month[0]) == 3));
-        ok("Is leap month", (icalrecurrencetype_month_is_leap(rt->by_month[0]) != 0));
-        ok("Encoded value matches", (icalrecurrencetype_encode_month(3, 1) == rt->by_month[0]));
+        ok("The by_month size equals 1", (rt->by_month.size == 1));
+        ok("The month is 3", (icalrecurrencetype_month_month(rt->by_month.data[0]) == 3));
+        ok("Is leap month", (icalrecurrencetype_month_is_leap(rt->by_month.data[0]) != 0));
+        ok("Encoded value matches", (icalrecurrencetype_encode_month(3, 1) == rt->by_month.data[0]));
         icalrecurrencetype_unref(rt);
     }
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1292,26 +1292,26 @@ void test_recur_encode_by_day(void)
 
     rt = icalrecurrencetype_new_from_string("FREQ=WEEKLY;BYDAY=WE");
     ok("Is weekly recurrence", (rt->freq == ICAL_WEEKLY_RECURRENCE));
-    ok("The by_day size equals 1", (rt->by_day.size == 1));
-    ok("The day of week is Wednesday", (icalrecurrencetype_day_day_of_week(rt->by_day.data[0]) == ICAL_WEDNESDAY_WEEKDAY));
-    ok("The position is 0", (icalrecurrencetype_day_position(rt->by_day.data[0]) == 0));
-    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_WEDNESDAY_WEEKDAY, 0) == rt->by_day.data[0]));
+    ok("The by[ICAL_BY_DAY] size equals 1", (rt->by[ICAL_BY_DAY].size == 1));
+    ok("The day of week is Wednesday", (icalrecurrencetype_day_day_of_week(rt->by[ICAL_BY_DAY].data[0]) == ICAL_WEDNESDAY_WEEKDAY));
+    ok("The position is 0", (icalrecurrencetype_day_position(rt->by[ICAL_BY_DAY].data[0]) == 0));
+    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_WEDNESDAY_WEEKDAY, 0) == rt->by[ICAL_BY_DAY].data[0]));
     icalrecurrencetype_unref(rt);
 
     rt = icalrecurrencetype_new_from_string("FREQ=MONTHLY;BYDAY=2FR");
     ok("Is monthly recurrence", (rt->freq == ICAL_MONTHLY_RECURRENCE));
-    ok("The by_day size equals 1", (rt->by_day.size == 1));
-    ok("The day of week is Friday", (icalrecurrencetype_day_day_of_week(rt->by_day.data[0]) == ICAL_FRIDAY_WEEKDAY));
-    ok("The position is 2", (icalrecurrencetype_day_position(rt->by_day.data[0]) == 2));
-    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_FRIDAY_WEEKDAY, 2) == rt->by_day.data[0]));
+    ok("The by[ICAL_BY_DAY] size equals 1", (rt->by[ICAL_BY_DAY].size == 1));
+    ok("The day of week is Friday", (icalrecurrencetype_day_day_of_week(rt->by[ICAL_BY_DAY].data[0]) == ICAL_FRIDAY_WEEKDAY));
+    ok("The position is 2", (icalrecurrencetype_day_position(rt->by[ICAL_BY_DAY].data[0]) == 2));
+    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_FRIDAY_WEEKDAY, 2) == rt->by[ICAL_BY_DAY].data[0]));
     icalrecurrencetype_unref(rt);
 
     rt = icalrecurrencetype_new_from_string("FREQ=YEARLY;BYDAY=-3MO");
     ok("Is yearly recurrence", (rt->freq == ICAL_YEARLY_RECURRENCE));
-    ok("The by_day size equals 1", (rt->by_day.size == 1));
-    ok("The day of week is Monday", (icalrecurrencetype_day_day_of_week(rt->by_day.data[0]) == ICAL_MONDAY_WEEKDAY));
-    ok("The position is -3", (icalrecurrencetype_day_position(rt->by_day.data[0]) == -3));
-    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_MONDAY_WEEKDAY, -3) == rt->by_day.data[0]));
+    ok("The by[ICAL_BY_DAY] size equals 1", (rt->by[ICAL_BY_DAY].size == 1));
+    ok("The day of week is Monday", (icalrecurrencetype_day_day_of_week(rt->by[ICAL_BY_DAY].data[0]) == ICAL_MONDAY_WEEKDAY));
+    ok("The position is -3", (icalrecurrencetype_day_position(rt->by[ICAL_BY_DAY].data[0]) == -3));
+    ok("Encoded value matches", (icalrecurrencetype_encode_day(ICAL_MONDAY_WEEKDAY, -3) == rt->by[ICAL_BY_DAY].data[0]));
     icalrecurrencetype_unref(rt);
 
     for (ii = -5; ii <= 5; ii++) {
@@ -1338,19 +1338,19 @@ void test_recur_encode_by_month(void)
 
     rt = icalrecurrencetype_new_from_string("FREQ=WEEKLY;BYMONTH=2");
     ok("Is weekly recurrence", (rt->freq == ICAL_WEEKLY_RECURRENCE));
-    ok("The by_month size equals 1", (rt->by_month.size == 1));
-    ok("The month is 2", (icalrecurrencetype_month_month(rt->by_month.data[0]) == 2));
-    ok("Is not leap month", (icalrecurrencetype_month_is_leap(rt->by_month.data[0]) == 0));
-    ok("Encoded value matches", (icalrecurrencetype_encode_month(2, 0) == rt->by_month.data[0]));
+    ok("The by[ICAL_BY_MONTH] size equals 1", (rt->by[ICAL_BY_MONTH].size == 1));
+    ok("The month is 2", (icalrecurrencetype_month_month(rt->by[ICAL_BY_MONTH].data[0]) == 2));
+    ok("Is not leap month", (icalrecurrencetype_month_is_leap(rt->by[ICAL_BY_MONTH].data[0]) == 0));
+    ok("Encoded value matches", (icalrecurrencetype_encode_month(2, 0) == rt->by[ICAL_BY_MONTH].data[0]));
     icalrecurrencetype_unref(rt);
 
     rt = icalrecurrencetype_new_from_string("FREQ=MONTHLY;BYMONTH=3L");
     if (rt != NULL) {
         ok("Is monthly recurrence", (rt->freq == ICAL_MONTHLY_RECURRENCE));
-        ok("The by_month size equals 1", (rt->by_month.size == 1));
-        ok("The month is 3", (icalrecurrencetype_month_month(rt->by_month.data[0]) == 3));
-        ok("Is leap month", (icalrecurrencetype_month_is_leap(rt->by_month.data[0]) != 0));
-        ok("Encoded value matches", (icalrecurrencetype_encode_month(3, 1) == rt->by_month.data[0]));
+        ok("The by[ICAL_BY_MONTH] size equals 1", (rt->by[ICAL_BY_MONTH].size == 1));
+        ok("The month is 3", (icalrecurrencetype_month_month(rt->by[ICAL_BY_MONTH].data[0]) == 3));
+        ok("Is leap month", (icalrecurrencetype_month_is_leap(rt->by[ICAL_BY_MONTH].data[0]) != 0));
+        ok("Encoded value matches", (icalrecurrencetype_encode_month(3, 1) == rt->by[ICAL_BY_MONTH].data[0]));
         icalrecurrencetype_unref(rt);
     }
 
@@ -5774,8 +5774,8 @@ int main(int argc, char *argv[])
     test_run("Test day of year of week start", test_start_of_week, do_test, do_header);
     test_run("Test recur parser", test_recur_parser, do_test, do_header);
     test_run("Test recur", test_recur, do_test, do_header);
-    test_run("Test recur encode by_day", test_recur_encode_by_day, do_test, do_header);
-    test_run("Test recur encode by_month", test_recur_encode_by_month, do_test, do_header);
+    test_run("Test recur encode by[ICAL_BY_DAY]", test_recur_encode_by_day, do_test, do_header);
+    test_run("Test recur encode by[ICAL_BY_MONTH]", test_recur_encode_by_month, do_test, do_header);
     test_run("Test Recurring Events File", test_recur_file, do_test, do_header);
     test_run("Test parameter bug", test_recur_parameter_bug, do_test, do_header);
     test_run("Test Array Expansion", test_expand_recurrence, do_test, do_header);


### PR DESCRIPTION
Now that `icalrecurrencetype` is [passed by ref rather than by value](https://github.com/libical/libical/pull/751), we can continue by making the type more dynamic. This PR replaces the 'by_xxx' arrays that have previously been allocated as statically sized arrays as part of `icalrecurrencetype`, with dynamically allocated ones. This allows to significantly reduce the type's memory footprint (in all real use cases), which used to be > 2k. As a consequence of the dynamic arrays, we can also improve the code in many places by making it more generic.

The PR does:
- Replace statically allocated 'by_xxx' arrays with dynamically allocated ones.
- Replace 'by_xxx' fields with a single, more generic `by[ICAL_BY_XXX]` array
- Simplify the GLib/Python bindings by replacing the individual '*_by_xxx' methods with generic ones that take the 'by' component as an enum parameter.
- Avoid cloning the rule in `icalrecurrencetype_iterator_new()` if not necessary (i.e. in all cases except if rscale is used).

Todos
- [x] Discuss modified GLib API (i.e. replace individual 'by_xxx' methods with more generic, parameterized ones)
- [x] Documentation & Release notes