### PR TITLE
icalrecur.c: icalrecurrencetype_clone() should initialize its refcount

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -683,6 +683,8 @@ struct icalrecurrencetype *icalrecurrencetype_clone(struct icalrecurrencetype *r
 
     memcpy(res, recur, sizeof(*res));
 
+    res->refcount = 1;
+
     if (res->rscale) {
         res->rscale = icalmemory_strdup(res->rscale);
         if (!res->rscale) {


### PR DESCRIPTION
Since this is a fresh copy of an existing icalrecurrencetype, we SHOULD NOT inherit the refcount.  This prevents us from leaking the icalrecurrentype inside an icaliterator