### PR TITLE
icalrecur.c: Some performance improvements.

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -2692,17 +2692,18 @@ static void filter_bysetpos(icalrecur_iterator *impl, int pos_total,
 
     impl->days_index = ICAL_YEARDAYS_MASK_SIZE;
 
-    for (doy = start_doy; doy <= end_doy; doy++) {
-        if (daysmask_getbit(impl->days, doy)) {
-            daysmask_setbit(impl->days, doy,
-                            (check_set_position(impl, pos_count + 1) ||
-                             check_set_position(impl, pos_count - pos_total)));
+    for (doy = daymask_find_next_bit(impl->days, start_doy);
+         (doy != ICAL_YEARDAYS_MASK_SIZE) && (doy <= end_doy);
+         doy = daymask_find_next_bit(impl->days, doy + 1)) {
+        int valid = (check_set_position(impl, pos_count + 1) ||
+                     check_set_position(impl, pos_count - pos_total));
 
-            if (daysmask_getbit(impl->days, doy) && doy < impl->days_index) {
-                impl->days_index = doy;
-            }
-            pos_count++;
+        daysmask_setbit(impl->days, doy, valid);
+
+        if (valid && doy < impl->days_index) {
+            impl->days_index = doy;
         }
+        pos_count++;
     }
 }
 

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -3086,10 +3086,9 @@ static int prev_year(icalrecur_iterator *impl)
     return prev_yearday(impl, &__next_year);
 }
 
-static short daymask_find_next_bit(icalrecur_iterator *impl)
+static short daymask_find_next_bit(unsigned long *days, short start_index)
 {
-    unsigned long *days = impl->days;
-    short days_index = impl->days_index + 1;
+    short days_index = start_index;
     unsigned long v;
     short startBitIndex;
     unsigned short wordIdx, maxWordIdx;
@@ -3141,10 +3140,9 @@ static short daymask_find_next_bit(icalrecur_iterator *impl)
     return days_index;
 }
 
-static short daymask_find_prev_bit(icalrecur_iterator *impl)
+static short daymask_find_prev_bit(unsigned long *days, short start_index)
 {
-    unsigned long *days = impl->days;
-    short days_index = impl->days_index - 1;
+    short days_index = start_index;
     unsigned long v;
     short startBitIndex;
     int wordIdx;
@@ -3207,7 +3205,7 @@ static int next_yearday(icalrecur_iterator *impl,
     reset_period_start(impl);
 
     /* Find next year day that is set */
-    impl->days_index = daymask_find_next_bit(impl);
+    impl->days_index = daymask_find_next_bit(impl->days, impl->days_index + 1);
 
     if (impl->days_index >= ICAL_YEARDAYS_MASK_SIZE) {
         for (;;) {
@@ -3242,14 +3240,14 @@ static int prev_yearday(icalrecur_iterator *impl,
     reset_period_start(impl);
 
     /* Find previous year day that is set */
-    impl->days_index = daymask_find_prev_bit(impl);
+    impl->days_index = daymask_find_prev_bit(impl->days, impl->days_index - 1);
 
     while (impl->days_index <= -ICAL_YEARDAYS_MASK_OFFSET) {
         /* Decrement to and expand the previous period */
         next_period(impl, -impl->rule->interval);
 
         impl->days_index = ICAL_YEARDAYS_MASK_SIZE;
-        impl->days_index = daymask_find_prev_bit(impl);
+        impl->days_index = daymask_find_prev_bit(impl->days, impl->days_index - 1);
     }
 
     if (impl->days_index < 1) {


### PR DESCRIPTION
Implement a number of performance improvements.

Most notable changes:
* Avoid evaluating limiting expressions in `check_contracting_rules()` if not needed. I.e. we don't need to calculate day of week, day of month and week no if no according restriction is applied.
* Avoid extra iterations over all days in the 'days' bit field in `expand_by_day()` and `filter_bysetpos()`.

## Benchmark
I benchmarked the change by running the test cases from icalrecur_test 1000 times each. The time in icalrecur.c is as follows:

With ICU
|     | w/o ICU | with ICU |
| --- | ---: | ---: |
| before | 1.300 ms | 7.070 ms |
| after | 700 ms | 4.850 ms |

Tested on a 64bit Ubuntu Docker container hosted on a Windows Laptop (Intel Core i7-10750H).