### PR TITLE
icalrecur_test: Fix memory leak caused by not freeing rrule.rscale

### DIFF
--- a/src/test/icalrecur_test.c
+++ b/src/test/icalrecur_test.c
@@ -203,6 +203,7 @@ int main(int argc, char *argv[])
             }
 
             icalrecur_iterator_free(ritr);
+            free(rrule.rscale);
 
             if (test_error)
                 nof_failed_tests++;


### PR DESCRIPTION
Fixes #801

In #800 we back-ported a rework of icalrecur_test from master to 3.0. In contrast to master, we still need to explicitly free `icalrecurrencetype.rscale` on `3.0`, which was missing and is implemented in this PR.