### PR TITLE
src/test/icalrecur_test.c - fix structure init

### DIFF
--- a/src/test/icalrecur_test.c
+++ b/src/test/icalrecur_test.c
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
             const char *sep = "";
             char actual_instances[2048];
             int actual_instances_len = 0;
-            struct icaltimetype start = {};
+            struct icaltimetype start = icaltime_null_time();
             int test_error = 0;
 
             nof_tests++;


### PR DESCRIPTION
init struct icaltimetype in a way that makes MSVC happy.