### PR TITLE
icaltime: Fails to convert time to time_t before epoch

### DIFF
--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -2121,6 +2121,27 @@ void do_test_time(const char *zone)
     int_is("icaltime_compare(): same UTC and NY",
            icaltime_compare(icttutc, icttny),
            0);
+
+    /* Conversion to time_t around the epoch */
+    ictt = icaltime_from_string("19700101T000000Z");
+    tt = icaltime_as_timet_with_zone(ictt, utczone);
+    int_is("convert to time_t EPOCH", tt, 0);
+
+    ictt = icaltime_from_string("19700101T000001Z");
+    tt = icaltime_as_timet_with_zone(ictt, utczone);
+    int_is("convert to time_t EPOCH+1", tt, 1);
+
+    ictt = icaltime_from_string("19700101T000002Z");
+    tt = icaltime_as_timet_with_zone(ictt, utczone);
+    int_is("convert to time_t EPOCH+2", tt, 2);
+
+    ictt = icaltime_from_string("19691231T235959Z");
+    tt = icaltime_as_timet_with_zone(ictt, utczone);
+    int_is("convert to time_t EPOCH-1", tt, -1);
+
+    ictt = icaltime_from_string("19691231T235958Z");
+    tt = icaltime_as_timet_with_zone(ictt, utczone);
+    int_is("convert to time_t EPOCH-2", tt, -2);
 }
 
 void test_iterators(void)


### PR DESCRIPTION
The time_t of a time before epoch is a negative number, but the code considered a negative number as an incorrectly entered time.