### PR TITLE
vcardderivedvalue.c.in: don't try to access nonexistent array item

### DIFF
--- a/src/libicalvcard/vcardderivedvalue.c.in
+++ b/src/libicalvcard/vcardderivedvalue.c.in
@@ -23,6 +23,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined __GNUC__ && __GNUC__ > 6
+#define GCC_FALLTHROUGH __attribute__((fallthrough));
+#else
+#define GCC_FALLTHROUGH /* fall through */
+#endif
+
 struct vcardvalue_impl *vcardvalue_new_impl(vcardvalue_kind kind);
 
 /* This map associates each of the value types with its string
@@ -127,10 +133,19 @@ struct vcardgeotype vcardvalue_get_geo(const vcardvalue *impl)
     if (impl->kind == VCARD_URI_VALUE) {
         geo.uri = impl->data.v_string;
     } else if (impl->kind == VCARD_STRUCTURED_VALUE) {
-        geo.coords.lat =
-            vcardstrarray_element_at(impl->data.v_structured.field[0], 0);
-        geo.coords.lon =
-            vcardstrarray_element_at(impl->data.v_structured.field[1], 0);
+        geo.coords.lat = geo.coords.lon = "0.0";
+        switch (impl->data.v_structured.num_fields) {
+        default:
+            geo.coords.lon =
+                vcardstrarray_element_at(impl->data.v_structured.field[1], 0);
+            GCC_FALLTHROUGH
+        case 1:
+            geo.coords.lat =
+                vcardstrarray_element_at(impl->data.v_structured.field[0], 0);
+            GCC_FALLTHROUGH
+        case 0:
+            break;
+        }
     } else {
         icalerror_set_errno(ICAL_BADARG_ERROR);
     }


### PR DESCRIPTION
Fixes a crasher