### PR TITLE
vcardcomponent.c: set geo.lon to "" when converting empty geo: uri

### DIFF
--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -1148,6 +1148,9 @@ static void comp_to_v3(vcardcomponent *impl)
                         *lon++ = '\0';
                         geo.coords.lon = lon;
                     }
+                    else {
+                        geo.coords.lon = "";
+                    }
 
                     vcardvalue_set_geo(value, geo);
                 }

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -1147,8 +1147,7 @@ static void comp_to_v3(vcardcomponent *impl)
                     if (lon) {
                         *lon++ = '\0';
                         geo.coords.lon = lon;
-                    }
-                    else {
+                    } else {
                         geo.coords.lon = "";
                     }
 


### PR DESCRIPTION
Fixes a crash when trying to serialize a v3 GEO property when longitude is NULL