### PR TITLE
libical-glib/CMakeLists.txt - ical-glib-header target fix

### DIFF
--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -101,7 +101,6 @@ add_custom_target(
   DEPENDS ${ical-glib-src-generator_EXE} ${xml_files}
   BYPRODUCTS ${LIBICAL_GLIB_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/libical-glib-private.h
              ${CMAKE_CURRENT_BINARY_DIR}/i-cal-forward-declarations.h
-             ${CMAKE_CURRENT_BINARY_DIR}/ical-glib-build-check.c
   COMMENT "Generate the libical-glib sources"
 )
 


### PR DESCRIPTION
Remove ical-glib-build-check.c from the BYPRODUCTS list. The ical-glib-header does NOT create ical-glib-build-check.c

Mistakenly added in commit f54ee2f

fixes: #808