### PR TITLE
Allow `icalcomponent_foreach_recurrence` to receive `DATE`-only `start` and `end` params.

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -98,6 +98,8 @@ Version 3.0.19 (UNRELEASED):
  * Resolved known limitation: Negative values are now also supported for `BYMONTHDAY` and `BYYEARDAY`.
  * Add support for RDATE;VALUE=PERIOD
  * Fix time conversion to time_t for times before epoch
+ * Allow `icalcomponent_foreach_recurrence` to receive `DATE`-only `start` and `end` params.
+ * Fix the calculation of an event's duration if `DTSTART` is a `DATE`-only value.
 
 Version 3.0.18 (31 March 2024):
 -------------------------------

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -100,6 +100,7 @@ Version 3.0.19 (UNRELEASED):
  * Fix time conversion to time_t for times before epoch
  * Allow `icalcomponent_foreach_recurrence` to receive `DATE`-only `start` and `end` params.
  * Fix the calculation of an event's duration if `DTSTART` is a `DATE`-only value.
+ * Fix `icaltime_span_new()` - ignore the case where DTEND is unset and require it to be set by the caller instead.
 
 Version 3.0.18 (31 March 2024):
 -------------------------------

--- a/docs/KnownLimitations.md
+++ b/docs/KnownLimitations.md
@@ -17,3 +17,14 @@ Contributions to help us fix these limitations are welcome.
 * FREQ=YEARLY, BYWEEKNO can't be combined with BYYEARDAY, BYMONTH or BYMONTHDAY
 
      ref: <https://github.com/libical/libical/blob/cfd401b9d043214395888de1d9daf52263e3245b/src/libical/icalrecur.c#L2928>
+
+### Recurrence Rule sections 3.8.5.3, DURATION 3.3.6
+
+* The lib (e.g. `icalcomponent_foreach_recurrence()`, `icalcomponent_get_dtend()`) does not
+  differentiate between nominal and exact durations. According to the RFC, when a component's
+  duration is specified using the `DURATION` property rather than `DTEND`, the nominal duration
+  must be used to calculate each recurrence's duration. However, the current implementation always
+  uses the exact duration, which can cause discrepancies if a recurrence spans a daylight saving
+  time transition.
+
+     ref: <https://github.com/libical/libical/issues/630>

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -840,6 +840,21 @@ static bool icalcomponent_is_busy(icalcomponent *comp)
     return (ret);
 }
 
+static struct icaltimetype icaltime_with_time(const struct icaltimetype t, int hour, int minutes, int seconds)
+{
+    struct icaltimetype ret = t;
+    ret.hour = hour;
+    ret.minute = minutes;
+    ret.second = seconds;
+    ret.is_date = 0;
+    return ret;
+}
+
+static struct icaltimetype icaltime_at_midnight(const struct icaltimetype t)
+{
+    return icaltime_with_time(t, 0, 0, 0);
+}
+
 void icalcomponent_foreach_recurrence(icalcomponent *comp,
                                       struct icaltimetype start,
                                       struct icaltimetype end,
@@ -878,10 +893,22 @@ void icalcomponent_foreach_recurrence(icalcomponent *comp,
 
     basespan.is_busy = icalcomponent_is_busy(comp);
 
+    if (start.is_date) {
+        /* We always treat start as date-time, because we do arithmetic calculations later
+           on that wouldn't work on date-only. As date-only values shouldn't have a timezone set,
+           we shouldn't have any issues with potential DST changes. */
+        start = icaltime_at_midnight(start);
+    }
+
     /* Calculate the ceiling and floor values.. */
     limit_start = icaltime_as_timet_with_zone(start,
                                               icaltimezone_get_utc_timezone());
     if (!icaltime_is_null_time(end)) {
+        if (end.is_date) {
+            /* Same as with start, treat as date-time to allow for arithmetic operations. */
+            end = icaltime_at_midnight(end);
+        }
+
         limit_end = icaltime_as_timet_with_zone(end,
                                                 icaltimezone_get_utc_timezone());
     } else {
@@ -922,6 +949,7 @@ void icalcomponent_foreach_recurrence(icalcomponent *comp,
                 icaltimetype mystart = start;
 
                 /* make sure we include any recurrence that ends in timespan */
+                /* we ensured above that start is a date-time, so adding seconds is allowed. */
                 icaltime_adjust(&mystart, 0, 0, 0, -(int)(long)dtduration);
                 icalrecur_iterator_set_start(rrule_itr, mystart);
             }

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -462,6 +462,7 @@ LIBICAL_ICAL_EXPORT bool icalproperty_recurrence_is_excluded(icalcomponent *comp
  * It will filter out events that are specified as an EXDATE or an EXRULE.
  *
  * TODO: We do not filter out duplicate RRULES/RDATES
+ * TODO: We do not differentiate between nominal and exact durations.
  */
 LIBICAL_ICAL_EXPORT void icalcomponent_foreach_recurrence(icalcomponent *comp,
                                                           struct icaltimetype start,

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -462,7 +462,6 @@ LIBICAL_ICAL_EXPORT bool icalproperty_recurrence_is_excluded(icalcomponent *comp
  * It will filter out events that are specified as an EXDATE or an EXRULE.
  *
  * TODO: We do not filter out duplicate RRULES/RDATES
- * TODO: We do not handle RDATEs with explicit periods
  */
 LIBICAL_ICAL_EXPORT void icalcomponent_foreach_recurrence(icalcomponent *comp,
                                                           struct icaltimetype start,

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -902,17 +902,6 @@ icaltime_span icaltime_span_new(struct icaltimetype dtstart, struct icaltimetype
     span.start = icaltime_as_timet_with_zone(dtstart,
                                              dtstart.zone ? dtstart.zone : icaltimezone_get_utc_timezone());
 
-    if (icaltime_is_null_time(dtend)) {
-        if (!icaltime_is_date(dtstart)) {
-            /* If dtstart is a DATE-TIME and there is no DTEND nor DURATION
-               it takes no time */
-            span.end = span.start;
-            return span;
-        } else {
-            dtend = dtstart;
-        }
-    }
-
     span.end = icaltime_as_timet_with_zone(dtend,
                                            dtend.zone ? dtend.zone : icaltimezone_get_utc_timezone());
 

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -916,10 +916,6 @@ icaltime_span icaltime_span_new(struct icaltimetype dtstart, struct icaltimetype
     span.end = icaltime_as_timet_with_zone(dtend,
                                            dtend.zone ? dtend.zone : icaltimezone_get_utc_timezone());
 
-    if (icaltime_is_date(dtstart)) {
-        /* no time specified, go until the end of the day.. */
-        span.end += 60 * 60 * 24 - 1;
-    }
     return span;
 }
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -598,6 +598,66 @@ int test_component_foreach_parameterized(int startOffsSec, int endOffsSec, int e
     return 0;
 }
 
+void test_component_foreach_start_as_date_variant(const char *calStr, int expect_found)
+{
+    icalcomponent *calendar = icalparser_parse_string(calStr);
+    icalcomponent *event = icalcomponent_get_first_component(calendar, ICAL_VEVENT_COMPONENT);
+
+    // 2024-03-24 00:00 UTC to 2024-03-30 00:00 UTC
+    struct icaltimetype t_start = icaltime_from_string("20240324");
+    struct icaltimetype t_end = icaltime_from_string("20240330");
+
+    int found = 0;
+    icalcomponent_foreach_recurrence(event, t_start, t_end, test_component_foreach_callback, &found);
+    int_is("Occurs", found, expect_found);
+
+    icalcomponent_free(calendar);
+}
+
+// reproduces #833
+void test_component_foreach_start_as_date(void)
+{
+    test_component_foreach_start_as_date_variant(
+        "BEGIN:VCALENDAR\n"
+        "BEGIN:VEVENT\n"
+        "DTSTART:20240323T010000Z\n"
+        "DTEND:20240324T000100Z\n"
+        "RRULE:FREQ=WEEKLY\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n",
+        1);
+
+    test_component_foreach_start_as_date_variant(
+        "BEGIN:VCALENDAR\n"
+        "BEGIN:VEVENT\n"
+        "DTSTART:20240323T010000\n"
+        "DTEND:20240324T000100\n"
+        "RRULE:FREQ=WEEKLY\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n",
+        1);
+
+    test_component_foreach_start_as_date_variant(
+        "BEGIN:VCALENDAR\n"
+        "BEGIN:VEVENT\n"
+        "DTSTART:20240323\n"
+        "DTEND:20240324\n"
+        "RRULE:FREQ=WEEKLY\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n",
+        0);
+
+    test_component_foreach_start_as_date_variant(
+        "BEGIN:VCALENDAR\n"
+        "BEGIN:VEVENT\n"
+        "DTSTART:20240323\n"
+        "DTEND:20240325\n"
+        "RRULE:FREQ=WEEKLY\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n",
+        1);
+}
+
 void test_component_foreach(void)
 {
     const char *calStr =
@@ -5831,6 +5891,7 @@ int main(int argc, char *argv[])
     test_run("Test Properties", test_properties, do_test, do_header);
     test_run("Test Components", test_components, do_test, do_header);
     test_run("Test icalcomponent_foreach_recurrence", test_component_foreach, do_test, do_header);
+    test_run("Test icalcomponent_foreach_recurrence with start as date", test_component_foreach_start_as_date, do_test, do_header);
     test_run("Test icalrecur_iterator_set_start with date", test_recur_iterator_set_start, do_test, do_header);
     test_run("Test weekly icalrecur_iterator on January 1", test_recur_iterator_on_jan_1, do_test, do_header);
     test_run("Test Convenience", test_convenience, do_test, do_header);


### PR DESCRIPTION
Fixes #833.

* Allow `icalcomponent_foreach_recurrence` to receive `DATE`-only `start` and `end` params.
* Fix incorrect calculation of an event's duration in case `DTSTART`/`DTEND` are DATE-only.
* Mention limitation that the lib doesn't distinguish between nominal and exact event durations (related to #630).
