### PR TITLE
Fix building with glibc

### DIFF
--- a/src/libical/icaltz-util.c
+++ b/src/libical/icaltz-util.c
@@ -59,7 +59,9 @@
 #endif
 
 #if defined(HAVE_ENDIAN_H) || defined(HAVE_SYS_ENDIAN_H)
+#ifndef bswap_16
 #define bswap_16(x) (((x) << 8) & 0xff00) | (((x) >> 8) & 0xff)
+#endif
 #ifdef bswap32
 #define bswap_32 bswap32
 #define bswap_64 bswap64


### PR DESCRIPTION
Guard defining bswap_16 since it is provided by glibc.