### PR TITLE
Fix Warnings in glib

### DIFF
--- a/src/libical-glib/api/i-cal-array.xml
+++ b/src/libical-glib/api/i-cal-array.xml
@@ -51,7 +51,7 @@
     </method>
     <method name="i_cal_array_sort" corresponds="CUSTOM" annotation="skip" kind="others" since="1.0">
         <parameter type="ICalArray *" name="array" comment="The #ICalArray to be sorted"/>
-        <parameter type="gint (*compare)" name="(const void *, const void *)" annotation="scope call" comment="FULL: @compare: (scope call): The compare function"/>
+        <parameter type="gint (*compare)" name="(const void *, const void *)" comment="FULL: @compare: The compare function"/>
         <comment xml:space="preserve">Does not work right now. Sorts the @array using the sort function @compare.</comment>
         <custom>	g_return_if_fail (I_CAL_IS_ARRAY (array));
 	g_return_if_fail (array != NULL);

--- a/src/libical-glib/api/i-cal-component.xml
+++ b/src/libical-glib/api/i-cal-component.xml
@@ -472,8 +472,8 @@ static void foreach_tzid_cb(icalparameter *in_param, void *user_data)
 }</declaration>
     <method name="i_cal_component_foreach_tzid" corresponds="CUSTOM" kind="other" since="3.0.5">
         <parameter type="ICalComponent *" name="comp" comment="The #ICalComponent to be queried"/>
-        <parameter type="ICalComponentForeachTZIDFunc" name="callback" annotation="scope call" comment="The callback function"/>
-        <parameter type="gpointer" name="user_data" annotation="nullable, closure callback" comment="The data for callback function"/>
+        <parameter type="ICalComponentForeachTZIDFunc" name="callback" annotation="scope call,closure user_data" comment="The callback function"/>
+        <parameter type="gpointer" name="user_data" annotation="nullable" comment="The user data for callback function"/>
         <comment>Applies the same manipulation on every tzid in #ICalComponent.</comment>
         <custom>    struct ForeachTZIDData data;
     icalcomponent *native_comp;
@@ -514,8 +514,8 @@ static void foreach_recurrence_cb(icalcomponent *in_comp, struct icaltime_span *
         <parameter type="ICalComponent *" name="comp" comment="The #ICalComponent to be queried"/>
         <parameter type="ICalTime *" name="start" comment="Ignore timespans before this"/>
         <parameter type="ICalTime *" name="end" comment="Ignore timespans after this"/>
-        <parameter type="ICalComponentForeachRecurrenceFunc" name="callback" annotation="scope call" comment="Function called for each timespan within the range"/>
-        <parameter type="gpointer" name="user_data" annotation="nullable, closure callback" comment="The user data for callback function"/>
+        <parameter type="ICalComponentForeachRecurrenceFunc" name="callback" annotation="scope call,closure user_data" comment="Function called for each timespan within the range"/>
+        <parameter type="gpointer" name="user_data" annotation="nullable" comment="The user data for callback function"/>
         <comment>Cycles through all recurrences of an event. This function will call the specified callback function for once for the base value of DTSTART, and foreach recurring date/time value. It will filter out events that are specified as an EXDATE or an EXRULE.</comment>
         <custom>    struct ForeachRecurrenceData data;
     icalcomponent *native_comp;

--- a/src/libical-glib/api/i-cal-mime.xml
+++ b/src/libical-glib/api/i-cal-mime.xml
@@ -16,8 +16,8 @@
  */
 typedef gchar *(*ICalMimeParseFunc)(gchar *bytes, size_t size, gpointer user_data);</declaration>
     <method name="i_cal_mime_parse" corresponds="CUSTOM" since="1.0">
-        <parameter type="ICalMimeParseFunc" name="func" annotation="scope call" comment="The parsing function"/>
-        <parameter type="gpointer" name="user_data" annotation="closure" comment="The date given to @func"/>
+        <parameter type="ICalMimeParseFunc" name="func" annotation="scope call,closure user_data" comment="The parsing function"/>
+        <parameter type="gpointer" name="user_data" comment="The date given to @func"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="The parsed #ICalComponent"/>
         <comment xml:space="preserve">Parses data to #ICalComponent using the given function.</comment>
         <custom>	g_return_val_if_fail (func != NULL, NULL);

--- a/src/libical-glib/api/i-cal-parser.xml
+++ b/src/libical-glib/api/i-cal-parser.xml
@@ -48,8 +48,8 @@ typedef gchar *(*ICalParserLineGenFunc)(gchar *bytes, size_t size, gpointer user
     </method>
     <method name="i_cal_parser_parse" corresponds="CUSTOM" since="1.0">
         <parameter type="ICalParser *" name="parser" comment="The parser used to parse the string and output the #ICalComponent"/>
-        <parameter type="ICalParserLineGenFunc" name="func" annotation="scope call" comment="The function used to parse"/>
-        <parameter type="gpointer" name="user_data" annotation="closure" comment="The data given to @func"/>
+        <parameter type="ICalParserLineGenFunc" name="func" annotation="scope call,closure user_data" comment="The function used to parse"/>
+        <parameter type="gpointer" name="user_data" comment="The data given to @func"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="The component output by the parser."/>
         <comment xml:space="preserve">icalparser_parse takes a string that holds the text ( in RFC 2445 format ) and returns a pointer to an #ICalComponent. The caller owns the memory. @func is a pointer to a function that returns one content line per invocation.</comment>
         <custom>	g_return_val_if_fail (parser != NULL &amp;&amp; func != NULL, NULL);
@@ -64,8 +64,8 @@ typedef gchar *(*ICalParserLineGenFunc)(gchar *bytes, size_t size, gpointer user
     </method>
     <method name="i_cal_parser_get_line" corresponds="CUSTOM" since="1.0">
         <parameter type="ICalParser *" name="parser" comment="The parser to be queried"/>
-        <parameter type="ICalParserLineGenFunc" name="func" annotation="scope call" comment="A line generator function"/>
-        <parameter type="gpointer" name="user_data" annotation="closure" comment="The data given to @func"/>
+        <parameter type="ICalParserLineGenFunc" name="func" annotation="scope call,closure user_data" comment="A line generator function"/>
+        <parameter type="gpointer" name="user_data" comment="The data given to @func"/>
         <returns type="gchar *" annotation="transfer full" comment="A single iCal content line."/>
         <comment xml:space="preserve">Given a line generator function, returns a single iCal content line.</comment>
         <custom>gchar *line, *linecopy;


### PR DESCRIPTION
```
i-cal-component.c:1602: Warning: ICalGLib: invalid "closure" annotation: only valid on callback parameters
i-cal-component.c:1635: Warning: ICalGLib: invalid "closure" annotation: only valid on callback parameters
i-cal-mime.c:20: Warning: ICalGLib: invalid "closure" annotation: only valid on callback parameters
i-cal-parser.c:155: Warning: ICalGLib: invalid "closure" annotation: only valid on callback parameters
i-cal-parser.c:200: Warning: ICalGLib: invalid "closure" annotation: only valid on callback parameters
```