### PR TITLE
Remove stray vcardparameter_new_clone() and vcardproperty_new_clone()

### DIFF
--- a/src/libicalvcard/vcardparameter.c
+++ b/src/libicalvcard/vcardparameter.c
@@ -113,11 +113,6 @@ vcardparameter *vcardparameter_clone(const vcardparameter *old)
     return clone;
 }
 
-vcardparameter *vcardparameter_new_clone(vcardparameter *old)
-{
-    return vcardparameter_clone(old);
-}
-
 vcardparameter *vcardparameter_new_from_string(const char *str)
 {
     char *eq;

--- a/src/libicalvcard/vcardproperty.c
+++ b/src/libicalvcard/vcardproperty.c
@@ -118,11 +118,6 @@ vcardproperty *vcardproperty_clone(const vcardproperty *old)
     return clone;
 }
 
-vcardproperty *vcardproperty_new_clone(vcardproperty *old)
-{
-    return vcardproperty_clone(old);
-}
-
 vcardproperty *vcardproperty_new_from_string(const char *str)
 {
     size_t buf_size = 1024;


### PR DESCRIPTION
Remove stray vcardparameter_new_clone() and vcardproperty_new_clone() as they were never declared in a header and were there to be symmetric with (deprecated and now removed) equivalents in libical.

fixes: #863