### PR TITLE
Add external iterators for properties and parameters

### DIFF
--- a/src/libical/ical_file.cmake
+++ b/src/libical/ical_file.cmake
@@ -19,8 +19,8 @@ set(
   ${TOPS}/src/libical/icalvalue.h
   ${TOPS}/src/libical/icalparameter.h
   ${TOPB}/src/libical/icalderivedproperty.h
-  ${TOPS}/src/libical/icalproperty.h
   ${TOPS}/src/libical/pvl.h
+  ${TOPS}/src/libical/icalproperty.h
   ${TOPS}/src/libical/icalcomponent.h
   ${TOPS}/src/libical/icaltimezone.h
   ${TOPS}/src/libical/icaltz-util.h

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1298,11 +1298,11 @@ icalcompiter icalcomponent_end_component(icalcomponent *component, icalcomponent
 
 icalcomponent *icalcompiter_next(icalcompiter *i)
 {
+    icalerror_check_arg_rz((i != 0), "i");
+
     if (i->iter == 0) {
         return 0;
     }
-
-    icalerror_check_arg_rz((i != 0), "i");
 
     for (i->iter = pvl_next(i->iter); i->iter != 0; i->iter = pvl_next(i->iter)) {
         icalcomponent *c = (icalcomponent *)pvl_data(i->iter);
@@ -1317,6 +1317,8 @@ icalcomponent *icalcompiter_next(icalcompiter *i)
 
 icalcomponent *icalcompiter_prior(icalcompiter *i)
 {
+    icalerror_check_arg_rz((i != 0), "i");
+
     if (i->iter == 0) {
         return 0;
     }
@@ -1334,6 +1336,8 @@ icalcomponent *icalcompiter_prior(icalcompiter *i)
 
 icalcomponent *icalcompiter_deref(icalcompiter *i)
 {
+    icalerror_check_arg_rz((i != 0), "i");
+
     if (i->iter == 0) {
         return 0;
     }

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1355,7 +1355,7 @@ icalpropiter icalcomponent_begin_property(icalcomponent *component, icalproperty
         icalproperty *p = (icalproperty *)pvl_data(i);
 
         if (icalproperty_isa(p) == kind || kind == ICAL_ANY_PROPERTY) {
-            icalpropiter itr = { kind, i };
+            icalpropiter itr = {kind, i};
             return itr;
         }
     }

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1153,6 +1153,8 @@ void icalcomponent_set_parent(icalcomponent *component, icalcomponent *parent)
 
 static const icalcompiter icalcompiter_null = {ICAL_NO_COMPONENT, 0};
 
+static const icalpropiter icalpropiter_null = {ICAL_NO_PROPERTY, 0};
+
 struct icalcomponent_kind_map {
     icalcomponent_kind kind;
     char name[20];
@@ -1332,6 +1334,54 @@ icalcomponent *icalcompiter_prior(icalcompiter *i)
 
 icalcomponent *icalcompiter_deref(icalcompiter *i)
 {
+    if (i->iter == 0) {
+        return 0;
+    }
+
+    return pvl_data(i->iter);
+}
+
+icalpropiter icalcomponent_begin_property(icalcomponent *component, icalproperty_kind kind)
+{
+    icalerror_check_arg_re(component != 0, "component", icalpropiter_null);
+
+    pvl_elem i;
+
+    for (i = pvl_head(component->properties); i != 0; i = pvl_next(i)) {
+        icalproperty *p = (icalproperty *)pvl_data(i);
+
+        if (icalproperty_isa(p) == kind || kind == ICAL_ANY_PROPERTY) {
+            icalpropiter itr = { kind, i };
+            return itr;
+        }
+    }
+
+    return icalpropiter_null;
+}
+
+icalproperty *icalpropiter_next(icalpropiter *i)
+{
+    icalerror_check_arg_rz((i != 0), "i");
+
+    if (i->iter == 0) {
+        return 0;
+    }
+
+    for (i->iter = pvl_next(i->iter); i->iter != 0; i->iter = pvl_next(i->iter)) {
+        icalproperty *p = (icalproperty *)pvl_data(i->iter);
+
+        if (icalproperty_isa(p) == i->kind || i->kind == ICAL_ANY_PROPERTY) {
+            return icalpropiter_deref(i);
+        }
+    }
+
+    return 0;
+}
+
+icalproperty *icalpropiter_deref(icalpropiter *i)
+{
+    icalerror_check_arg_rz((i != 0), "i");
+
     if (i->iter == 0) {
         return 0;
     }

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -28,8 +28,12 @@ typedef struct icalcomponent_impl icalcomponent;
 typedef struct icalcompiter {
     icalcomponent_kind kind;
     pvl_elem iter;
-
 } icalcompiter;
+
+typedef struct icalpropiter {
+    icalproperty_kind kind;
+    pvl_elem iter;
+} icalpropiter;
 
 /** @brief Constructor
  */
@@ -159,6 +163,13 @@ LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_next(icalcompiter *i);
 LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_prior(icalcompiter *i);
 
 LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_deref(icalcompiter *i);
+
+LIBICAL_ICAL_EXPORT icalpropiter icalcomponent_begin_property(icalcomponent *component,
+                                                             icalproperty_kind kind);
+
+LIBICAL_ICAL_EXPORT icalproperty *icalpropiter_next(icalpropiter *i);
+
+LIBICAL_ICAL_EXPORT icalproperty *icalpropiter_deref(icalpropiter *i);
 
 /***** Working with embedded error properties *****/
 

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -165,7 +165,7 @@ LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_prior(icalcompiter *i);
 LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_deref(icalcompiter *i);
 
 LIBICAL_ICAL_EXPORT icalpropiter icalcomponent_begin_property(icalcomponent *component,
-                                                             icalproperty_kind kind);
+                                                              icalproperty_kind kind);
 
 LIBICAL_ICAL_EXPORT icalproperty *icalpropiter_next(icalpropiter *i);
 

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -1089,7 +1089,7 @@ icalparamiter icalproperty_begin_parameter(icalproperty *property, icalparameter
         icalparameter *p = (icalparameter *)pvl_data(i);
 
         if (icalparameter_isa(p) == kind || kind == ICAL_ANY_PARAMETER) {
-            icalparamiter itr = { kind, i };
+            icalparamiter itr = {kind, i};
             return itr;
         }
     }

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -1076,3 +1076,51 @@ struct icaltimetype icalproperty_get_datetime_with_component(icalproperty *prop,
 
     return ret;
 }
+
+static const icalparamiter icalparamiter_null = {ICAL_NO_PARAMETER, 0};
+
+icalparamiter icalproperty_begin_parameter(icalproperty *property, icalparameter_kind kind)
+{
+    icalerror_check_arg_re(property != 0, "property", icalparamiter_null);
+
+    pvl_elem i;
+
+    for (i = pvl_head(property->parameters); i != 0; i = pvl_next(i)) {
+        icalparameter *p = (icalparameter *)pvl_data(i);
+
+        if (icalparameter_isa(p) == kind || kind == ICAL_ANY_PARAMETER) {
+            icalparamiter itr = { kind, i };
+            return itr;
+        }
+    }
+
+    return icalparamiter_null;
+}
+
+icalparameter *icalparamiter_next(icalparamiter *i)
+{
+    icalerror_check_arg_rz((i != 0), "i");
+
+    if (i->iter == 0) {
+        return 0;
+    }
+
+    for (i->iter = pvl_next(i->iter); i->iter != 0; i->iter = pvl_next(i->iter)) {
+        icalparameter *p = (icalparameter *)pvl_data(i->iter);
+
+        if (icalparameter_isa(p) == i->kind || i->kind == ICAL_ANY_PARAMETER) {
+            return icalparamiter_deref(i);
+        }
+    }
+
+    return 0;
+}
+
+icalparameter *icalparamiter_deref(icalparamiter *i)
+{
+    if (i->iter == 0) {
+        return 0;
+    }
+
+    return pvl_data(i->iter);
+}

--- a/src/libical/icalproperty.h
+++ b/src/libical/icalproperty.h
@@ -13,6 +13,7 @@
 
 #include "libical_ical_export.h"
 #include "icalderivedproperty.h" /* To get icalproperty_kind enumerations */
+#include "pvl.h"
 
 #include <stdarg.h> /* for va_... */
 
@@ -174,5 +175,18 @@ LIBICAL_ICAL_EXPORT bool icalproperty_enum_belongs_to_property(icalproperty_kind
  * @since 3.0
  */
 LIBICAL_ICAL_EXPORT void icalproperty_normalize(icalproperty *prop);
+
+/* This is exposed so that callers will not have to allocate and
+   deallocate iterators. Pretend that you can't see it. */
+typedef struct icalparamiter {
+    icalparameter_kind kind;
+    pvl_elem iter;
+} icalparamiter;
+
+LIBICAL_ICAL_EXPORT icalparamiter icalproperty_begin_parameter(icalproperty *property, icalparameter_kind kind);
+
+LIBICAL_ICAL_EXPORT icalparameter *icalparamiter_next(icalparamiter *i);
+
+LIBICAL_ICAL_EXPORT icalparameter *icalparamiter_deref(icalparamiter *i);
 
 #endif /*ICALPROPERTY_H */

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -5846,33 +5846,33 @@ static void test_icalpropiter(void)
     // Iterate all properties.
     icalpropiter iter = icalcomponent_begin_property(comp, ICAL_ANY_PROPERTY);
     ok("iter at DTSTAMP",
-        dtstamp == icalpropiter_deref(&iter));
+       dtstamp == icalpropiter_deref(&iter));
     ok("iter at COMMENT (comment1)",
-        comment1 == icalpropiter_next(&iter) &&
-        comment1 == icalpropiter_deref(&iter));
+       comment1 == icalpropiter_next(&iter) &&
+           comment1 == icalpropiter_deref(&iter));
     ok("iter at UID",
-        uid == icalpropiter_next(&iter) &&
-        uid == icalpropiter_deref(&iter));
+       uid == icalpropiter_next(&iter) &&
+           uid == icalpropiter_deref(&iter));
     ok("iter at DTSTART",
-        dtstart == icalpropiter_next(&iter) &&
-        dtstart == icalpropiter_deref(&iter));
+       dtstart == icalpropiter_next(&iter) &&
+           dtstart == icalpropiter_deref(&iter));
     ok("iter at COMMENT (comment2)",
-        comment2 == icalpropiter_next(&iter) &&
-        comment2 == icalpropiter_deref(&iter));
+       comment2 == icalpropiter_next(&iter) &&
+           comment2 == icalpropiter_deref(&iter));
     ok("iter at end",
-        NULL == icalpropiter_next(&iter) &&
-        NULL == icalpropiter_deref(&iter));
+       NULL == icalpropiter_next(&iter) &&
+           NULL == icalpropiter_deref(&iter));
 
     // Iterate COMMENT property.
     iter = icalcomponent_begin_property(comp, ICAL_COMMENT_PROPERTY);
     ok("iter at COMMENT (comment1)",
-        comment1 == icalpropiter_deref(&iter));
+       comment1 == icalpropiter_deref(&iter));
     ok("iter at COMMENT (comment2)",
-        comment2 == icalpropiter_next(&iter) &&
-        comment2 == icalpropiter_deref(&iter));
+       comment2 == icalpropiter_next(&iter) &&
+           comment2 == icalpropiter_deref(&iter));
     ok("iter at end",
-        NULL == icalpropiter_next(&iter) &&
-        NULL == icalpropiter_deref(&iter));
+       NULL == icalpropiter_next(&iter) &&
+           NULL == icalpropiter_deref(&iter));
 
     // Iterate in-existent property.
     iter = icalcomponent_begin_property(comp, ICAL_DESCRIPTION_PROPERTY);
@@ -5911,21 +5911,21 @@ static void test_icalparamiter(void)
     // Iterate all parameters.
     icalparamiter iter = icalproperty_begin_parameter(prop, ICAL_ANY_PARAMETER);
     ok("iter at RSVP",
-        rsvp == icalparamiter_deref(&iter));
+       rsvp == icalparamiter_deref(&iter));
     ok("iter at PARTSTAT",
-        partstat == icalparamiter_next(&iter) &&
-        partstat == icalparamiter_deref(&iter));
+       partstat == icalparamiter_next(&iter) &&
+           partstat == icalparamiter_deref(&iter));
     ok("iter at end",
-        NULL == icalparamiter_next(&iter) &&
-        NULL == icalparamiter_deref(&iter));
+       NULL == icalparamiter_next(&iter) &&
+           NULL == icalparamiter_deref(&iter));
 
     // Iterate PARTSTAT parameter.
     iter = icalproperty_begin_parameter(prop, ICAL_PARTSTAT_PARAMETER);
     ok("iter at PARTSTAT",
-        partstat == icalparamiter_deref(&iter));
+       partstat == icalparamiter_deref(&iter));
     ok("iter at end",
-        NULL == icalparamiter_next(&iter) &&
-        NULL == icalparamiter_deref(&iter));
+       NULL == icalparamiter_next(&iter) &&
+           NULL == icalparamiter_deref(&iter));
 
     // Iterate in-existent parameter.
     iter = icalproperty_begin_parameter(prop, ICAL_CN_PARAMETER);
@@ -5933,8 +5933,6 @@ static void test_icalparamiter(void)
 
     icalcomponent_free(comp);
 }
-
-
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
In addition to the already existing compiter iterator, this adds external iterators for properties and parameters.

In a separate a drive-by commit, this also adds error checking for some of the compiter functions, which were at risk at dereferencing a NULL pointer.