### PR TITLE
icaltypes.c: fix bug ignoring non-empty REQUEST-STATUS extdata

### DIFF
--- a/src/libical/icaltypes.c
+++ b/src/libical/icaltypes.c
@@ -140,7 +140,7 @@ struct icalreqstattype icalreqstattype_from_string(const char *str)
      */
 
     p2 = strchr(p1 + 1, ';');
-    if (p2 != 0 && *p2 != 0 && *p2 != ';') { // skipping empty debug strings
+    if (p2 != 0 && *(p2 + 1) != 0) { // skipping empty debug strings
         stat.debug = icalmemory_tmp_copy(p2 + 1);
     }
 

--- a/src/libical/icaltypes.h
+++ b/src/libical/icaltypes.h
@@ -45,9 +45,8 @@ LIBICAL_ICAL_EXPORT bool icaltriggertype_is_bad_trigger(struct icaltriggertype t
 /* struct icalreqstattype. This struct contains two string pointers,
 but don't try to free either of them. The "desc" string is a pointer
 to a static table inside the library.  Don't try to free it. The
-"debug" string is a pointer into the string that the called passed
-into to icalreqstattype_from_string. Don't try to free it either, and
-don't use it after the original string has been freed.
+"debug" string is allocated in the ring buffer. Don't try to free it
+either.
 
 BTW, you would get that original string from
 *icalproperty_get_requeststatus() or icalvalue_get_text(), when

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1778,11 +1778,9 @@ void test_requeststat(void)
     }
     p = icalcomponent_get_first_property(c, ICAL_REQUESTSTATUS_PROPERTY);
 
-#if ADD_TESTS_REQUIRING_INVESTIGATION
     str_is("icalproperty_new_from_string()",
            icalproperty_as_ical_string(p),
            "REQUEST-STATUS:2.1;Success but fallback taken  on one or more property  \r\n values.;booga\r\n");
-#endif
     icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, ICAL_ERROR_NONFATAL);
     st2 = icalreqstattype_from_string("16.4");
 


### PR DESCRIPTION
Due to an erroneous conditional, a non-empty 'extdata' part of a REQUEST-STATUS property value did not get parsed into the 'debug' field of the icalreqstattype struct type.

It also fixes the docstring in the header that mistakenly stated that the 'debug' field value points into the original input string. Instead, it points into the ring buffer memory.