### PR TITLE
.github/workflows/build.yml - move from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         configuration:
           - Debug
           - Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
github will no longer support the Ubuntu 20.04 runner after 1 Apr 2025