### PR TITLE
icalparser.c - restore using icalerror_warn() if END is before BEGIN

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -834,8 +834,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
 
         if (parser->level < 0) {
             // Encountered an END before any BEGIN, this must be invalid data
-            icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR,
-                                      icalerror_get_error_state(ICAL_MALFORMEDDATA_ERROR));
+            icalerror_warn("Encountered END before BEGIN");
             parser->state = ICALPARSER_ERROR;
             parser->level = 0;
             return 0;


### PR DESCRIPTION
Put back the icalerror_warn() if the parser detects that the END preceeds any BEGIN datetime. Looks like an "ooops" I mistakenly committed when working the fuzzer fixes.

fixes: #886