### PR TITLE
icaltimezone.c - fix crash calling icalrecur_iterator_set_start

### DIFF
--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -2376,7 +2376,7 @@ void icaltimezone_truncate_vtimezone(icalcomponent *vtz,
 
                     ritr = icalrecur_iterator_new(rrule, dtstart);
 
-                    if (trunc_dtstart) {
+                    if (ritr && trunc_dtstart) {
                         /* Bump RRULE start to 1 year prior to our window open */
                         icaltimetype newstart = dtstart;
                         newstart.year = start.year - 1;
@@ -2494,7 +2494,6 @@ void icaltimezone_truncate_vtimezone(icalcomponent *vtz,
                                 newstart.year = end.year - 1;
                                 newstart.month = end.month;
                                 newstart.day = end.day;
-                                (void)icaltime_normalize(newstart);
                                 icalrecur_iterator_set_start(ritr, newstart);
                             }
                         }


### PR DESCRIPTION
In icaltimezone_truncate_vtimezone(), fix a crash when calling icalrecur_iterator_set_start() with a null iterator.