### PR TITLE
Remove calls to '(void)icaltime_normalize(newstart)'

### DIFF
--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -2382,7 +2382,6 @@ void icaltimezone_truncate_vtimezone(icalcomponent *vtz,
                         newstart.year = start.year - 1;
                         newstart.month = start.month;
                         newstart.day = start.day;
-                        (void)icaltime_normalize(newstart);
                         icalrecur_iterator_set_start(ritr, newstart);
                     }
                 }

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -3470,8 +3470,6 @@ icalcomponent *make_component(int i)
 
     t.day += i;
 
-    (void)icaltime_normalize(t);
-
     c = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT,
                             icalproperty_new_method(ICAL_METHOD_REQUEST),
                             icalcomponent_vanew(ICAL_VEVENT_COMPONENT,


### PR DESCRIPTION
Calling '(void)icaltime_normalize(newstart)' is a no-op