### PR TITLE
Support multi-valued iCalendar parameters

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -466,7 +466,10 @@ typedef int IO_SIZE_T;
 typedef unsigned int IO_SSIZE_T;
 #else
 typedef size_t IO_SIZE_T;
+#cmakedefine HAVE_SSIZE_T
+#if !defined(HAVE_SSIZE_T)
 typedef ssize_t IO_SSIZE_T;
+#endif
 #endif
 
 #if defined(_MSC_VER)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -466,10 +466,7 @@ typedef int IO_SIZE_T;
 typedef unsigned int IO_SSIZE_T;
 #else
 typedef size_t IO_SIZE_T;
-#cmakedefine HAVE_SSIZE_T
-#if !defined(HAVE_SSIZE_T)
 typedef ssize_t IO_SSIZE_T;
-#endif
 #endif
 
 #if defined(_MSC_VER)

--- a/design-data/ical-parameters.csv
+++ b/design-data/ical-parameters.csv
@@ -3,14 +3,14 @@
 "CHARSET","3","const char*",
 "CN","4","const char*",
 "CUTYPE","5","icalparameter_cutype","X=20100;INDIVIDUAL;GROUP;RESOURCE;ROOM;UNKNOWN;NONE=20199"
-"DELEGATED-FROM","6","const char*",
-"DELEGATED-TO","7","const char*",
+"DELEGATED-FROM","6","const char*",,is_multivalued
+"DELEGATED-TO","7","const char*",,is_multivalued
 "DIR","8","const char*",
 "ENCODING","10","icalparameter_encoding","X=20300;8BIT;BASE64;NONE=20399"
 "FBTYPE","11","icalparameter_fbtype","X=20400;FREE;BUSY;BUSY-UNAVAILABLE;BUSY-TENTATIVE;NONE=20499"
 "FMTTYPE","12","const char*",
 "LANGUAGE","14","const char*",
-"MEMBER","18","const char*",
+"MEMBER","18","const char*",,is_multivalued
 "#PARTSTAT=FAILED from draft-apthorp-ical-tasks",,,
 "PARTSTAT","20","icalparameter_partstat","X=20600;NEEDS-ACTION;ACCEPTED;DECLINED;TENTATIVE;DELEGATED;COMPLETED;IN-PROCESS;FAILED;NONE=20699"
 "RANGE","21","icalparameter_range","X=20700;THISANDPRIOR;THISANDFUTURE;NONE=20799"
@@ -68,9 +68,9 @@
 "SUBSTATE","45","icalparameter_substate",X=21900;OK;ERROR;SUSPENDED;NONE=21999",
 
 "#Parameters from New Properties for iCalendar","RFC 7986 Section 6"
-"DISPLAY","46","icalparameter_display",X=22000;BADGE;GRAPHIC;FULLSIZE;THUMBNAIL;NONE=22099",
+"DISPLAY","46","icalparameter_display",X=22000;BADGE;GRAPHIC;FULLSIZE;THUMBNAIL;NONE=22099",is_multivalued
 "EMAIL","50","const char*",
-"FEATURE","48","icalparameter_feature",X=22100;AUDIO;CHAT;FEED;MODERATOR;PHONE;SCREEN;VIDEO;NONE=22199",
+"FEATURE","48","icalparameter_feature",X=22100;AUDIO;CHAT;FEED;MODERATOR;PHONE;SCREEN;VIDEO;NONE=22199",is_multivalued
 "LABEL","49","const char*",
 
 "#VPATCH Extension Parameters","draft-daboo-icalendar-vpatch"

--- a/scripts/mkderivedparameters.pl
+++ b/scripts/mkderivedparameters.pl
@@ -177,36 +177,34 @@ sub insert_code
       $count++;
       $out .= "    {${ucprefix}_${uc}_PARAMETER, \"$param\"";
 
-      if ($opt_v) {
-          my $type  = $params{$param}->{"C"};
-          if ($type =~ /char/) {
-              $out .= ", ${ucprefix}_TEXT_VALUE";
+      my $type  = $params{$param}->{"C"};
+      if ($type =~ /char/) {
+          $out .= ", ${ucprefix}_TEXT_VALUE";
 
-          } elsif ($type =~ /int/) {
-              $out .= ", ${ucprefix}_INTEGER_VALUE";
+      } elsif ($type =~ /int/) {
+          $out .= ", ${ucprefix}_INTEGER_VALUE";
 
-          } elsif ($type =~ /vcardtimetype/) {
-              $out .= ", ${ucprefix}_DATEANDORTIME_VALUE";
+      } elsif ($opt_v && $type =~ /vcardtimetype/) {
+          $out .= ", ${ucprefix}_DATEANDORTIME_VALUE";
 
-          } elsif ($type =~ /vcardstructured/) {
-              $out .= ", ${ucprefix}_STRUCTURED_VALUE";
+      } elsif ($opt_v && $type =~ /vcardstructured/) {
+          $out .= ", ${ucprefix}_STRUCTURED_VALUE";
 
-          } else {
-              $out .= ", ${ucprefix}_X_VALUE";
+      } else {
+          $out .= ", ${ucprefix}_X_VALUE";
+      }
+
+      my @flags = @{$params{$param}->{'flags'}};
+      if (@flags) {
+          my $sep = ", ";
+          foreach $flag (@flags) {
+              $flag =~ s/-//g;
+              $flag  = uc($flag);
+              $out .= "${sep}${ucprefix}_PARAMETER_${flag}";
+              $sep = " | ";
           }
-
-          my @flags = @{$params{$param}->{'flags'}};
-          if (@flags) {
-              my $sep = ", ";
-              foreach $flag (@flags) {
-                  $flag =~ s/-//g;
-                  $flag  = uc($flag);
-                  $out .= "${sep}${ucprefix}_PARAMETER_${flag}";
-                  $sep = " | ";
-              }
-          } else {
-              $out .= ", 0";
-          }
+      } else {
+          $out .= ", 0";
       }
 
       $out .= "},\n";
@@ -214,11 +212,7 @@ sub insert_code
     $count += 1;
     print "static const struct ${lcprefix}parameter_kind_map parameter_map[$count] = {\n";
     print $out;
-    if ($opt_v) {
-        print "    { ${ucprefix}_NO_PARAMETER, \"\", ${ucprefix}_NO_VALUE, 0}\n};\n\n";
-    } else {
-        print "    { ${ucprefix}_NO_PARAMETER, \"\"}\n};\n\n";
-    }
+    print "    { ${ucprefix}_NO_PARAMETER, \"\", ${ucprefix}_NO_VALUE, 0}\n};\n\n";
 
     # Create the parameter value map
     $out   = "";
@@ -270,39 +264,44 @@ sub insert_code
     my $uc = uc($lc);
 
     my $is_multivalued = 0;
-    if ($opt_v) {
-        my @flags = @{$params{$param}->{'flags'}};
-        if (@flags) {
-            foreach $flag (@flags) {
-                $flag =~ s/-//g;
-                $flag  = uc($flag);
-                if ($flag eq 'IS_MULTIVALUED') {
-                    $is_multivalued = 1;
-                    last;
-                }
+    my @flags = @{$params{$param}->{'flags'}};
+    if (@flags) {
+        foreach $flag (@flags) {
+            $flag =~ s/-//g;
+            $flag  = uc($flag);
+            if ($flag eq 'IS_MULTIVALUED') {
+                $is_multivalued = 1;
+                last;
             }
         }
     }
 
-    my $singletype;
     my $apitype;
     my $charorenum;
     my $set_code;
     my $pointer_check;
     my $pointer_check_v;
     my $xrange;
+    # Only relevant for multivalued
+    my $singletype;
+    my $elemtype;
+    my $charorenum_nth;
 
     if ($type =~ /char/) {
         $type =~ s/char\*/char \*/;
 
         if ($is_multivalued) {
+            $elemtype = $type;
             $singletype = $type;
-            $type = "vcardstrarray *";
-            $apitype = "vcardstrarray";
+            $type = "${lcprefix}strarray *";
+            $apitype = "${lcprefix}strarray";
             $charorenum =
                 "    icalerror_check_arg_rz((param != 0), \"param\");\n    return param->values;";
 
-            $set_code = "if (param->values != NULL) {\n        vcardstrarray_free(param->values);\n    }\n    ((struct ${lcprefix}parameter_impl *)param)->values = v;";
+            $charorenum_nth =
+                "   icalerror_check_arg_rz((param != 0), \"param\");\n    if (param->values && ${lcprefix}strarray_size(param->values)) {\n        return ${lcprefix}strarray_element_at(param->values, position);\n    } else {\n        return NULL;\n    }";
+
+            $set_code = "if (param->values != NULL) {\n        ${lcprefix}strarray_free(param->values);\n    }\n    ((struct ${lcprefix}parameter_impl *)param)->values = v;";
 
         } else {
             $charorenum =
@@ -349,13 +348,17 @@ sub insert_code
     } else {
 
         if ($is_multivalued) {
-            $singletype = "vcardenumarray_element *";
-            $type = "vcardenumarray *";
-            $apitype = "vcardenumarray";
+            $elemtype = $type;
+            $singletype = "${lcprefix}enumarray_element *";
+            $type = "${lcprefix}enumarray *";
+            $apitype = "${lcprefix}enumarray";
             $charorenum =
                 "    icalerror_check_arg_rz((param != 0), \"param\");\n    return param->values;";
 
-            $set_code = "if (param->values != NULL) {\n        vcardenumarray_free(param->values);\n    }\n    ((struct ${lcprefix}parameter_impl *)param)->values = v;";
+            $charorenum_nth =
+                "   icalerror_check_arg((param != 0), \"param\");\n    if (param && param->values && ${lcprefix}enumarray_size(param->values)) {\n        const $singletype v = ${lcprefix}enumarray_element_at(param->values, position);\n        return v->val;\n    } else {\n        return ${ucprefix}_${uc}_NONE;\n    }";
+
+            $set_code = "if (param->values != NULL) {\n        ${lcprefix}enumarray_free(param->values);\n    }\n    ((struct ${lcprefix}parameter_impl *)param)->values = v;";
 
         } else {
             $xrange = "    if (param->string != 0) {\n        return ${ucprefix}_${uc}_X;\n    }\n"
@@ -374,12 +377,17 @@ sub insert_code
         }
     }
 
+    my $newfnsuffix;
+    if ($is_multivalued) {
+        $newfnsuffix = "_list";
+    }
+
     if ($opt_c) {
 
       print <<EOM;
 
 /* $param */
-${lcprefix}parameter *${lcprefix}parameter_new_${lc}($type v)
+${lcprefix}parameter *${lcprefix}parameter_new_${lc}${newfnsuffix}($type v)
 {
     struct ${lcprefix}parameter_impl *impl;
     icalerror_clear_errno();
@@ -416,6 +424,27 @@ EOM
       if ($is_multivalued) {
           print <<EOM;
 
+${lcprefix}parameter * ${lcprefix}parameter_new_${lc}($singletype v)
+{$pointer_check
+    ${apitype} *values = ${apitype}_new(1);
+    ${apitype}_add(values, v);
+    return ${lcprefix}parameter_new_${lc}${newfnsuffix}(values);
+}
+
+size_t ${lcprefix}parameter_get_${lc}_size(${lcprefix}parameter *param)
+{
+    icalerror_check_arg_rz((param != 0), "param");
+    if (param->values) {
+        return param->values->num_elements;
+    }
+    return 0;
+}
+
+${elemtype} ${lcprefix}parameter_get_${lc}_nth(${lcprefix}parameter *param, size_t position)
+{
+ $charorenum_nth
+}
+
 void ${lcprefix}parameter_add_${lc}(${lcprefix}parameter *param, ${singletype} v)
 {$pointer_check_v
     icalerror_check_arg_rv((param != 0), "param");
@@ -434,6 +463,7 @@ void ${lcprefix}parameter_remove_${lc}(${lcprefix}parameter *param, ${singletype
     ${apitype} *values = ((struct ${lcprefix}parameter_impl *)param)->values;
     if (values != 0) ${apitype}_remove(values, v);
 }
+
 EOM
       }
 
@@ -442,13 +472,16 @@ EOM
       print <<EOM;
 
 /* $param */
-LIBICAL_${ucprefix}_EXPORT ${lcprefix}parameter * ${lcprefix}parameter_new_${lc}($type v);
+LIBICAL_${ucprefix}_EXPORT ${lcprefix}parameter * ${lcprefix}parameter_new_${lc}${newfnsuffix}($type v);
 LIBICAL_${ucprefix}_EXPORT ${type} ${lcprefix}parameter_get_${lc}(const ${lcprefix}parameter *value);
 LIBICAL_${ucprefix}_EXPORT void ${lcprefix}parameter_set_${lc}(${lcprefix}parameter *value, ${type} v);
 EOM
 
       if ($is_multivalued) {
       print <<EOM;
+LIBICAL_${ucprefix}_EXPORT ${lcprefix}parameter * ${lcprefix}parameter_new_${lc}($singletype v);
+LIBICAL_${ucprefix}_EXPORT size_t ${lcprefix}parameter_get_${lc}_size(${lcprefix}parameter *param);
+LIBICAL_${ucprefix}_EXPORT ${elemtype} ${lcprefix}parameter_get_${lc}_nth(${lcprefix}parameter *param, size_t position);
 LIBICAL_${ucprefix}_EXPORT void ${lcprefix}parameter_add_${lc}(${lcprefix}parameter *value, ${singletype} v);
 LIBICAL_${ucprefix}_EXPORT void ${lcprefix}parameter_remove_${lc}(${lcprefix}parameter *value, ${singletype} v);
 EOM

--- a/scripts/mkderivedparameters.pl
+++ b/scripts/mkderivedparameters.pl
@@ -356,7 +356,7 @@ sub insert_code
                 "    icalerror_check_arg_rz((param != 0), \"param\");\n    return param->values;";
 
             $charorenum_nth =
-                "   icalerror_check_arg((param != 0), \"param\");\n    if (param && param->values && ${lcprefix}enumarray_size(param->values)) {\n        const $singletype v = ${lcprefix}enumarray_element_at(param->values, position);\n        return v->val;\n    } else {\n        return ${ucprefix}_${uc}_NONE;\n    }";
+                "   icalerror_check_arg((param != 0), \"param\");\n    if (param && param->values && ${lcprefix}enumarray_size(param->values)) {\n        const $singletype v = ${lcprefix}enumarray_element_at(param->values, position);\n        return (${elemtype})v->val;\n    } else {\n        return ${ucprefix}_${uc}_NONE;\n    }";
 
             $set_code = "if (param->values != NULL) {\n        ${lcprefix}enumarray_free(param->values);\n    }\n    ((struct ${lcprefix}parameter_impl *)param)->values = v;";
 

--- a/scripts/mkderivedparameters.pl
+++ b/scripts/mkderivedparameters.pl
@@ -425,8 +425,9 @@ EOM
           print <<EOM;
 
 ${lcprefix}parameter * ${lcprefix}parameter_new_${lc}($singletype v)
-{$pointer_check
-    ${apitype} *values = ${apitype}_new(1);
+{${apitype} *values;
+    $pointer_check
+    values = ${apitype}_new(1);
     ${apitype}_add(values, v);
     return ${lcprefix}parameter_new_${lc}${newfnsuffix}(values);
 }
@@ -446,21 +447,23 @@ ${elemtype} ${lcprefix}parameter_get_${lc}_nth(${lcprefix}parameter *param, size
 }
 
 void ${lcprefix}parameter_add_${lc}(${lcprefix}parameter *param, ${singletype} v)
-{$pointer_check_v
+{${apitype} **values;
+    $pointer_check_v
     icalerror_check_arg_rv((param != 0), "param");
     icalerror_clear_errno();
 
-    ${apitype} **values = &((struct ${lcprefix}parameter_impl *)param)->values;
+   values = &((struct ${lcprefix}parameter_impl *)param)->values;
     if (*values == 0) *values = ${apitype}_new(5);
     ${apitype}_add(*values, v);
 }
 
 void ${lcprefix}parameter_remove_${lc}(${lcprefix}parameter *param, ${singletype} v)
-{$pointer_check_v
+{${apitype} *values;
+    $pointer_check_v
     icalerror_check_arg_rv((param != 0), "param");
     icalerror_clear_errno();
 
-    ${apitype} *values = ((struct ${lcprefix}parameter_impl *)param)->values;
+    values = ((struct ${lcprefix}parameter_impl *)param)->values;
     if (values != 0) ${apitype}_remove(values, v);
 }
 

--- a/src/libical-glib/api/i-cal-derived-parameter.xml
+++ b/src/libical-glib/api/i-cal-derived-parameter.xml
@@ -354,12 +354,12 @@
     </method>
     <method name="i_cal_parameter_get_delegatedfrom" corresponds="icalparameter_get_delegatedfrom" kind="get" since="1.0">
         <parameter type="const ICalParameter *" name="value" comment="The #ICalParameter to be queried"/>
-        <returns type="const gchar *" annotation="nullable" comment="The property of the @value" />
+        <returns type="icalstrarray *" annotation="nullable" comment="The property of the @value" />
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_set_delegatedfrom" corresponds="icalparameter_set_delegatedfrom" kind="set" since="1.0">
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
-        <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
+        <parameter type="icalstrarray *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_delegatedto" corresponds="icalparameter_new_delegatedto" kind="constructor" since="1.0">
@@ -369,12 +369,12 @@
     </method>
     <method name="i_cal_parameter_get_delegatedto" corresponds="icalparameter_get_delegatedto" kind="get" since="1.0">
         <parameter type="const ICalParameter *" name="value" comment="The #ICalParameter to be queried"/>
-        <returns type="const gchar *" annotation="nullable" comment="The property of the @value" />
+        <returns type="icalstrarray *" annotation="nullable" comment="The property of the @value" />
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_set_delegatedto" corresponds="icalparameter_set_delegatedto" kind="set" since="1.0">
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
-        <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
+        <parameter type="icalstrarray *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_derived" corresponds="icalparameter_new_derived" kind="constructor" since="4.0">
@@ -408,7 +408,7 @@
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_display" corresponds="icalparameter_new_display" kind="constructor" since="3.0.15">
-        <parameter type="ICalParameterDisplay" name="value" comment="The #ICalParameterDisplay value of the new #ICalParameter"/>
+        <parameter type="icalenumarray_element *" name="value" comment="The icalenumarray element value of the new #ICalParameter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter" />
         <comment xml:space="preserve"></comment>
     </method>
@@ -419,7 +419,7 @@
     </method>
     <method name="i_cal_parameter_set_display" corresponds="icalparameter_set_display" kind="set" since="3.0.15">
         <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
-        <parameter type="ICalParameterDisplay" name="value" comment="The #ICalParameterDisplay to set into the @param"/>
+        <parameter type="icalenumarray *" name="value" comment="The icalenumarray to set into the @param"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_email" corresponds="icalparameter_new_email" kind="constructor" since="3.0.15">
@@ -483,7 +483,7 @@
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_feature" corresponds="icalparameter_new_feature" kind="constructor" since="3.0.15">
-        <parameter type="ICalParameterFeature" name="value" comment="The #ICalParameterFeature value of the new #ICalParameter"/>
+        <parameter type="icalenumarray_element *" name="value" comment="The icalenumarray value of the new #ICalParameter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter" />
         <comment xml:space="preserve"></comment>
     </method>
@@ -494,7 +494,7 @@
     </method>
     <method name="i_cal_parameter_set_feature" corresponds="icalparameter_set_feature" kind="set" since="3.0.15">
         <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
-        <parameter type="ICalParameterFeature" name="value" comment="The #ICalParameterFeature to set into the @param"/>
+        <parameter type="icalenumarray *" name="value" comment="The icalenumarray to set into the @param"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_filename" corresponds="icalparameter_new_filename" kind="constructor" since="2.0">
@@ -654,12 +654,12 @@
     </method>
     <method name="i_cal_parameter_get_member" corresponds="icalparameter_get_member" kind="get" since="1.0">
         <parameter type="const ICalParameter *" name="value" comment="The #ICalParameter to be queried"/>
-        <returns type="const gchar *" annotation="nullable" comment="The property of the @value" />
+        <returns type="icalstrarray *" annotation="nullable" comment="The property of the @value" />
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_set_member" corresponds="icalparameter_set_member" kind="set" since="1.0">
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
-        <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
+        <parameter type="icalstrarray *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_modified" corresponds="icalparameter_new_modified" kind="constructor" since="2.0">

--- a/src/libical-glib/api/i-cal-derived-parameter.xml
+++ b/src/libical-glib/api/i-cal-derived-parameter.xml
@@ -414,7 +414,7 @@
     </method>
     <method name="i_cal_parameter_get_display" corresponds="icalparameter_get_display" kind="get" since="3.0.15">
         <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
-        <returns type="ICalParameterDisplay" comment="The #ICalParameterDisplay value of the @param"/>
+        <returns type="icalenumarray *" comment="The icalenumarray value of the @param"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_set_display" corresponds="icalparameter_set_display" kind="set" since="3.0.15">
@@ -489,7 +489,7 @@
     </method>
     <method name="i_cal_parameter_get_feature" corresponds="icalparameter_get_feature" kind="get" since="3.0.15">
         <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
-        <returns type="ICalParameterFeature" comment="The #ICalParameterFeature value of the @param"/>
+        <returns type="icalenumarray *" comment="The icalenumarray value of the @param"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_set_feature" corresponds="icalparameter_set_feature" kind="set" since="3.0.15">

--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -211,6 +211,8 @@ set(
   icalattach.c
   icalcomponent.c
   icalcomponent.h
+  icalenumarray.c
+  icalenumarray.h
   icalenums.c
   icalenums.h
   icalerror.c
@@ -229,6 +231,8 @@ set(
   icalrecur.c
   icalrecur.h
   icalrestriction.h
+  icalstrarray.c
+  icalstrarray.h
   icaltime.c
   icaltime.h
   icaltz-util.c

--- a/src/libical/ical_file.cmake
+++ b/src/libical/ical_file.cmake
@@ -12,6 +12,8 @@ set(
   ${TOPS}/src/libical/icalenums.h
   ${TOPS}/src/libical/icaltypes.h
   ${TOPS}/src/libical/icalarray.h
+  ${TOPS}/src/libical/icalenumarray.h
+  ${TOPS}/src/libical/icalstrarray.h
   ${TOPS}/src/libical/icalrecur.h
   ${TOPS}/src/libical/icalattach.h
   ${TOPB}/src/libical/icalderivedvalue.h

--- a/src/libical/icalarray.c
+++ b/src/libical/icalarray.c
@@ -33,7 +33,7 @@ icalarray *icalarray_new(size_t element_size, size_t increment_size)
     }
 
     array->element_size = element_size;
-    array->increment_size = increment_size;
+    array->increment_size = increment_size ? increment_size : 1;
     array->num_elements = 0;
     array->space_allocated = 0;
     array->chunks = NULL;

--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -60,6 +60,25 @@ struct icalparameter_map
 
 <insert_code_here>
 
+icalvalue_kind icalparameter_kind_value_kind(const icalparameter_kind kind,
+                                               int *is_multivalued)
+{
+    int i, num_params;
+
+    num_params = (int)(sizeof(parameter_map) / sizeof(parameter_map[0]));
+    for (i = 0; i < num_params; i++) {
+        if (parameter_map[i].kind == kind) {
+            if (is_multivalued) {
+                *is_multivalued =
+                    (parameter_map[i].flags & ICAL_PARAMETER_IS_MULTIVALUED);
+            }
+            return (parameter_map[i].value_kind);
+        }
+    }
+
+    return 0;
+}
+
 bool icalparameter_kind_is_valid(const icalparameter_kind kind)
 {
     int i = 0;
@@ -176,6 +195,78 @@ int icalparameter_string_to_enum(const char *str)
     return 0;
 }
 
+
+static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind, const char *val)
+{
+    icalvalue_kind value_kind = icalparameter_kind_value_kind(kind, NULL);
+    icalarray *values;
+    int enum_start = 0, enum_end = 0;
+
+    if (value_kind == ICAL_TEXT_VALUE) {
+        values = icalstrarray_new(5);
+    } else {
+        values = icalenumarray_new(5);
+    }
+
+    if (value_kind != ICAL_TEXT_VALUE) {
+        int num_params =
+            (int)(sizeof(icalparameter_map) / sizeof(icalparameter_map[0]));
+        for (int i = 0; i < num_params && !enum_end; i++) {
+            if (kind == icalparameter_map[i].kind && !enum_start)
+                enum_start = i;
+            else if (kind != icalparameter_map[i].kind && enum_start)
+                enum_end = i;
+        }
+    }
+
+    do {
+        const char *end = val;
+        if (val[0] == '"') {
+            end = strchr(val + 1, '"');
+            if (end) val++;
+        }
+        else {
+            end = strchr(val, ',');
+        }
+        size_t val_len = end ? (size_t)(end - val) : strlen(val);
+
+        if (!val_len) break;
+
+        const char *next_val = end;
+        if (next_val && next_val[0] == '"')
+            next_val = strchr(next_val, ',');
+
+        if (next_val && next_val[0] == ',')
+            next_val++;
+
+        char *tmpbuf = icalmemory_new_buffer(val_len + 1);
+        strncpy(tmpbuf, val, val_len);
+        icalparameter_decode_value(tmpbuf);
+
+        if (value_kind == ICAL_TEXT_VALUE) {
+            icalstrarray_append(values, tmpbuf);
+        } else {
+            icalenumarray_element elem = { 0 };
+
+            for (int i = enum_start; i < enum_end; i++) {
+                if (strncasecmp(val, icalparameter_map[i].str, val_len) == 0) {
+                    elem.val = (int)icalparameter_map[i].enumeration;
+                    break;
+                }
+            }
+
+            if (!elem.val) elem.xvalue = tmpbuf;
+            icalenumarray_append(values, &elem);
+        }
+
+        icalmemory_free_buffer(tmpbuf);
+
+        val = next_val;
+    } while (val);
+
+    return values;
+}
+
 icalparameter *icalparameter_new_from_value_string(icalparameter_kind kind, const char *val)
 {
     struct icalparameter_impl *param = 0;
@@ -193,6 +284,10 @@ icalparameter *icalparameter_new_from_value_string(icalparameter_kind kind, cons
 
     if (kind == ICAL_GAP_PARAMETER) {
         param->duration = icaldurationtype_from_string(val);
+        return param;
+    }
+    else if (icalparameter_is_multivalued(param)) {
+        param->values = icalparameter_values_from_value_string(kind, val);
         return param;
     }
 

--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -33,7 +33,11 @@ struct icalparameter_kind_map
     icalparameter_kind kind;
     const char *name;
 
+    icalvalue_kind value_kind;
+    unsigned int flags;
 };
+
+#define ICAL_PARAMETER_IS_MULTIVALUED (1U<<0)
 
 /* This map associates the enumerations for the VALUE parameter with
    the kinds of VALUEs. */

--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -70,7 +70,7 @@ icalvalue_kind icalparameter_kind_value_kind(const icalparameter_kind kind,
         if (parameter_map[i].kind == kind) {
             if (is_multivalued) {
                 *is_multivalued =
-                    (parameter_map[i].flags & ICAL_PARAMETER_IS_MULTIVALUED);
+                    (int)(parameter_map[i].flags & ICAL_PARAMETER_IS_MULTIVALUED);
             }
             return (parameter_map[i].value_kind);
         }
@@ -209,9 +209,9 @@ static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind
     }
 
     if (value_kind != ICAL_TEXT_VALUE) {
-        int num_params =
-            (int)(sizeof(icalparameter_map) / sizeof(icalparameter_map[0]));
-        for (int i = 0; i < num_params && !enum_end; i++) {
+        int i;
+        int num_params = (int)(sizeof(icalparameter_map) / sizeof(icalparameter_map[0]));
+        for (i = 0; i < num_params && !enum_end; i++) {
             if (kind == icalparameter_map[i].kind && !enum_start)
                 enum_start = i;
             else if (kind != icalparameter_map[i].kind && enum_start)
@@ -220,7 +220,12 @@ static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind
     }
 
     do {
+        int i;
+        size_t val_len;
+        char *tmpbuf;
+        const char *next_val;
         const char *end = val;
+        icalenumarray_element elem;
         if (val[0] == '"') {
             end = strchr(val + 1, '"');
             if (end) val++;
@@ -228,27 +233,26 @@ static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind
         else {
             end = strchr(val, ',');
         }
-        size_t val_len = end ? (size_t)(end - val) : strlen(val);
+        val_len = end ? (size_t)(end - val) : strlen(val);
 
         if (!val_len) break;
 
-        const char *next_val = end;
+        next_val = end;
         if (next_val && next_val[0] == '"')
             next_val = strchr(next_val, ',');
 
         if (next_val && next_val[0] == ',')
             next_val++;
 
-        char *tmpbuf = icalmemory_new_buffer(val_len + 1);
+        tmpbuf = icalmemory_new_buffer(val_len + 1);
         strncpy(tmpbuf, val, val_len);
         icalparameter_decode_value(tmpbuf);
 
         if (value_kind == ICAL_TEXT_VALUE) {
             icalstrarray_append(values, tmpbuf);
         } else {
-            icalenumarray_element elem = { 0 };
-
-            for (int i = enum_start; i < enum_end; i++) {
+            elem.val = 0; elem.xvalue = NULL;
+            for (i = enum_start; i < enum_end; i++) {
                 if (strncasecmp(val, icalparameter_map[i].str, val_len) == 0) {
                     elem.val = (int)icalparameter_map[i].enumeration;
                     break;

--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -128,6 +128,8 @@ icalparameter_kind icalparameter_string_to_kind(const char *string)
 
     key.kind = ICAL_ANY_PARAMETER;
     key.name = string;
+    key.value_kind = ICAL_NO_VALUE;
+    key.flags = 0;
     result =
         bsearch(&key, parameter_map, sizeof(parameter_map) / sizeof(struct icalparameter_kind_map),
                 sizeof(struct icalparameter_kind_map),

--- a/src/libical/icalderivedparameter.h.in
+++ b/src/libical/icalderivedparameter.h.in
@@ -13,6 +13,8 @@
 
 #include "libical_ical_export.h"
 #include "icalduration.h"
+#include "icalenumarray.h"
+#include "icalstrarray.h"
 
 #include <stdbool.h>
 

--- a/src/libical/icalenumarray.c
+++ b/src/libical/icalenumarray.c
@@ -19,7 +19,7 @@
 #include <string.h>
 
 ssize_t icalenumarray_find(icalenumarray *array,
-                            const icalenumarray_element *needle)
+                           const icalenumarray_element *needle)
 {
     size_t i;
 
@@ -50,7 +50,7 @@ void icalenumarray_add(icalenumarray *array, const icalenumarray_element *add)
 }
 
 void icalenumarray_remove_element_at(icalenumarray *array,
-                                      ssize_t position)
+                                     ssize_t position)
 {
     icalenumarray_element *del = icalarray_element_at(array, (size_t)position);
 

--- a/src/libical/icalenumarray.c
+++ b/src/libical/icalenumarray.c
@@ -1,0 +1,107 @@
+/*======================================================================
+ FILE: icalenumarray.c
+
+ CREATOR: Ken Murchison 24 Aug 2022 <murch@fastmailteam.com>
+
+ SPDX-FileCopyrightText: 2022, Fastmail Pty. Ltd. (https://fastmail.com)
+
+ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+ ======================================================================*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "icalenumarray.h"
+#include "icalmemory.h"
+
+#include <string.h>
+
+ssize_t icalenumarray_find(icalenumarray *array,
+                            const icalenumarray_element *needle)
+{
+    size_t i;
+
+    for (i = 0; array && i < array->num_elements; i++) {
+        icalenumarray_element *e = icalarray_element_at(array, i);
+        if (!!e->xvalue == !!needle->xvalue &&
+            ((e->xvalue && !strcmp(e->xvalue, needle->xvalue)) ||
+             (!e->xvalue && (e->val == needle->val)))) {
+            return (ssize_t)i;
+        }
+    }
+
+    return -1;
+}
+
+void icalenumarray_append(icalenumarray *array, const icalenumarray_element *elem)
+{
+    icalenumarray_element copy = {
+        elem->val, elem->xvalue ? icalmemory_strdup(elem->xvalue) : NULL};
+
+    icalarray_append(array, &copy);
+}
+
+void icalenumarray_add(icalenumarray *array, const icalenumarray_element *add)
+{
+    if (icalenumarray_find(array, add) < 0)
+        icalenumarray_append(array, add);
+}
+
+void icalenumarray_remove_element_at(icalenumarray *array,
+                                      ssize_t position)
+{
+    icalenumarray_element *del = icalarray_element_at(array, (size_t)position);
+
+    if (del->xvalue)
+        icalmemory_free_buffer((char *)del->xvalue);
+    icalarray_remove_element_at(array, (size_t)position);
+}
+
+void icalenumarray_remove(icalenumarray *array, icalenumarray_element *del)
+{
+    ssize_t position = icalenumarray_find(array, del);
+
+    if (position >= 0)
+        icalenumarray_remove_element_at(array, position);
+}
+
+void icalenumarray_free(icalenumarray *array)
+{
+    while (array->num_elements)
+        icalenumarray_remove_element_at(array, (ssize_t)(array->num_elements - 1));
+    icalarray_free(array);
+}
+
+static int enumcmp(const icalenumarray_element *a, const icalenumarray_element *b)
+{
+    /* Sort X- values alphabetically, but last */
+    if (a->xvalue) {
+        if (b->xvalue)
+            return strcmp(a->xvalue, b->xvalue);
+        else
+            return 1;
+    } else if (b->xvalue) {
+        return -1;
+    } else {
+        return a->val - b->val;
+    }
+}
+
+void icalenumarray_sort(icalenumarray *array)
+{
+    icalarray_sort(array, (int (*)(const void *, const void *))&enumcmp);
+}
+
+icalenumarray *icalenumarray_clone(icalenumarray *array)
+{
+    icalenumarray *clone = icalenumarray_new(array->increment_size);
+    size_t i;
+
+    for (i = 0; i < array->num_elements; i++) {
+        icalenumarray_append(clone, icalenumarray_element_at(array, i));
+    }
+
+    return clone;
+}

--- a/src/libical/icalenumarray.c
+++ b/src/libical/icalenumarray.c
@@ -52,7 +52,8 @@ void icalenumarray_add(icalenumarray *array, const icalenumarray_element *add)
 void icalenumarray_remove_element_at(icalenumarray *array,
                                      size_t position)
 {
-    if (position >= icalenumarray_size(array)) return;
+    if (position >= icalenumarray_size(array))
+        return;
 
     icalenumarray_element *del = icalarray_element_at(array, position);
 
@@ -71,7 +72,6 @@ void icalenumarray_remove(icalenumarray *array, const icalenumarray_element *del
 
 void icalenumarray_free(icalenumarray *array)
 {
-
     for (size_t i = 0; i < icalenumarray_size(array); i++) {
         icalenumarray_element *del = icalarray_element_at(array, i);
         if (del->xvalue)

--- a/src/libical/icalenumarray.h
+++ b/src/libical/icalenumarray.h
@@ -32,8 +32,8 @@ typedef struct {
 
 #define icalenumarray_size(array) ((array)->num_elements)
 
-LIBICAL_ICAL_EXPORT ssize_t icalenumarray_find(icalenumarray *array,
-                                               const icalenumarray_element *needle);
+LIBICAL_ICAL_EXPORT size_t icalenumarray_find(icalenumarray *array,
+                                              const icalenumarray_element *needle);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_append(icalenumarray *array,
                                               const icalenumarray_element *elem);
@@ -42,9 +42,9 @@ LIBICAL_ICAL_EXPORT void icalenumarray_add(icalenumarray *array,
                                            const icalenumarray_element *add);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_remove_element_at(icalenumarray *array,
-                                                         ssize_t position);
+                                                         size_t position);
 LIBICAL_ICAL_EXPORT void icalenumarray_remove(icalenumarray *array,
-                                              icalenumarray_element *del);
+                                              const icalenumarray_element *del);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_free(icalenumarray *array);
 

--- a/src/libical/icalenumarray.h
+++ b/src/libical/icalenumarray.h
@@ -1,0 +1,55 @@
+/*======================================================================
+ FILE: icalenumarray.h
+
+ CREATOR: Ken Murchison 24 Aug 2022 <murch@fastmailteam.com>
+
+ SPDX-FileCopyrightText: 2022, Fastmail Pty. Ltd. (https://fastmail.com)
+
+ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+ ======================================================================*/
+
+#ifndef ICALENUMARRAY_H
+#define ICALENUMARRAY_H
+
+#include "libical_ical_export.h"
+#include "icalarray.h"
+
+#include <stdlib.h>
+
+typedef icalarray icalenumarray;
+
+typedef struct {
+    int val;
+    const char *xvalue;
+} icalenumarray_element;
+
+#define icalenumarray_new(increment_size) \
+    icalarray_new(sizeof(icalenumarray_element), increment_size)
+
+#define icalenumarray_element_at(array, position) \
+    ((const icalenumarray_element *)icalarray_element_at(array, position))
+
+#define icalenumarray_size(array) ((array)->num_elements)
+
+LIBICAL_ICAL_EXPORT ssize_t icalenumarray_find(icalenumarray *array,
+                                                 const icalenumarray_element *needle);
+
+LIBICAL_ICAL_EXPORT void icalenumarray_append(icalenumarray *array,
+                                                const icalenumarray_element *elem);
+
+LIBICAL_ICAL_EXPORT void icalenumarray_add(icalenumarray *array,
+                                             const icalenumarray_element *add);
+
+LIBICAL_ICAL_EXPORT void icalenumarray_remove_element_at(icalenumarray *array,
+                                                           ssize_t position);
+LIBICAL_ICAL_EXPORT void icalenumarray_remove(icalenumarray *array,
+                                                icalenumarray_element *del);
+
+LIBICAL_ICAL_EXPORT void icalenumarray_free(icalenumarray *array);
+
+LIBICAL_ICAL_EXPORT void icalenumarray_sort(icalenumarray *array);
+
+LIBICAL_ICAL_EXPORT icalenumarray *icalenumarray_clone(icalenumarray *array);
+
+#endif /* ICALENUMARRAY_H */

--- a/src/libical/icalenumarray.h
+++ b/src/libical/icalenumarray.h
@@ -12,6 +12,10 @@
 #ifndef ICALENUMARRAY_H
 #define ICALENUMARRAY_H
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "libical_ical_export.h"
 #include "icalarray.h"
 

--- a/src/libical/icalenumarray.h
+++ b/src/libical/icalenumarray.h
@@ -12,10 +12,6 @@
 #ifndef ICALENUMARRAY_H
 #define ICALENUMARRAY_H
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "libical_ical_export.h"
 #include "icalarray.h"
 

--- a/src/libical/icalenumarray.h
+++ b/src/libical/icalenumarray.h
@@ -33,18 +33,18 @@ typedef struct {
 #define icalenumarray_size(array) ((array)->num_elements)
 
 LIBICAL_ICAL_EXPORT ssize_t icalenumarray_find(icalenumarray *array,
-                                                 const icalenumarray_element *needle);
+                                               const icalenumarray_element *needle);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_append(icalenumarray *array,
-                                                const icalenumarray_element *elem);
+                                              const icalenumarray_element *elem);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_add(icalenumarray *array,
-                                             const icalenumarray_element *add);
+                                           const icalenumarray_element *add);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_remove_element_at(icalenumarray *array,
-                                                           ssize_t position);
+                                                         ssize_t position);
 LIBICAL_ICAL_EXPORT void icalenumarray_remove(icalenumarray *array,
-                                                icalenumarray_element *del);
+                                              icalenumarray_element *del);
 
 LIBICAL_ICAL_EXPORT void icalenumarray_free(icalenumarray *array);
 

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -447,5 +447,43 @@ bool icalparameter_has_same_name(icalparameter *param1, icalparameter *param2)
     return true;
 }
 
+/** Decode parameter value per RFC6868 */
+void icalparameter_decode_value(char *value)
+{
+    char *in, *out;
+
+    for (in = out = value; *in; in++, out++) {
+        int found_escaped_char = 0;
+
+        if (*in == '^') {
+            switch (*(in + 1)) {
+            case 'n':
+                *out = '\n';
+                found_escaped_char = 1;
+                break;
+            case '^':
+                *out = '^';
+                found_escaped_char = 1;
+                break;
+
+            case '\'':
+                *out = '"';
+                found_escaped_char = 1;
+                break;
+            }
+        }
+
+        if (found_escaped_char) {
+            ++in;
+        } else {
+            *out = *in;
+        }
+    }
+
+    while (*out)
+        *out++ = '\0';
+}
+
+
 /* Everything below this line is machine generated. Do not edit. */
 /* ALTREP */

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -111,9 +111,7 @@ icalparameter *icalparameter_clone(const icalparameter *old)
     }
 
     if (old->values != 0) {
-        clone->values = old->value_kind == ICAL_TEXT_VALUE ?
-            icalstrarray_clone(old->values) :
-            icalenumarray_clone(old->values);
+        clone->values = old->value_kind == ICAL_TEXT_VALUE ? icalstrarray_clone(old->values) : icalenumarray_clone(old->values);
         if (clone->values == 0) {
             clone->parent = 0;
             icalparameter_free(clone);
@@ -319,7 +317,7 @@ char *icalparameter_as_ical_string_r(icalparameter *param)
         const char *str = icalparameter_enum_to_string(param->data);
 
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, str);
-      } else if (param->values != 0) {
+    } else if (param->values != 0) {
         size_t i;
         const char *sep = "";
 
@@ -533,7 +531,6 @@ void icalparameter_decode_value(char *value)
     while (*out)
         *out++ = '\0';
 }
-
 
 /* Everything below this line is machine generated. Do not edit. */
 /* ALTREP */

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -20,6 +20,7 @@
 
 #include "libical_ical_export.h"
 #include "icalderivedparameter.h"
+#include "icalderivedvalue.h"
 
 /* Declared in icalderivedparameter.h */
 /*typedef struct icalparameter_impl icalparameter;*/
@@ -618,6 +619,10 @@ LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_string_to_kind(const char *
  * @since 3.0.4
  */
 LIBICAL_ICAL_EXPORT bool icalparameter_kind_is_valid(const icalparameter_kind kind);
+
+LIBICAL_ICAL_EXPORT icalvalue_kind icalparameter_kind_value_kind(const icalparameter_kind kind, int *is_multivalued);
+
+LIBICAL_ICAL_EXPORT bool icalparameter_is_multivalued(icalparameter *param);
 
 /** Decode parameter value per RFC6868 */
 LIBICAL_ICAL_EXPORT void icalparameter_decode_value(char *value);

--- a/src/libical/icalparameter.h
+++ b/src/libical/icalparameter.h
@@ -619,4 +619,7 @@ LIBICAL_ICAL_EXPORT icalparameter_kind icalparameter_string_to_kind(const char *
  */
 LIBICAL_ICAL_EXPORT bool icalparameter_kind_is_valid(const icalparameter_kind kind);
 
+/** Decode parameter value per RFC6868 */
+LIBICAL_ICAL_EXPORT void icalparameter_decode_value(char *value);
+
 #endif

--- a/src/libical/icalparameter_cxx.cpp
+++ b/src/libical/icalparameter_cxx.cpp
@@ -147,14 +147,25 @@ icalparameter_kind ICalParameter::string_to_kind(const std::string &str)
 }
 
 /* DELEGATED-FROM */
-std::string ICalParameter::get_delegatedfrom() const
+std::vector<std::string> ICalParameter::get_delegatedfrom() const
 {
-    return static_cast<std::string>(icalparameter_get_delegatedfrom(imp));
+    std::vector<std::string> vals;
+    icalstrarray *c_vals = icalparameter_get_delegatedfrom(imp);
+    if (c_vals) {
+        for (size_t i = 0; i < icalstrarray_size(c_vals); ++i) {
+            vals.push_back(std::string(icalstrarray_element_at(c_vals, i)));
+        }
+    }
+    return vals;
 }
 
-void ICalParameter::set_delegatedfrom(const std::string &v)
+void ICalParameter::set_delegatedfrom(const std::vector<std::string> &v)
 {
-    icalparameter_set_delegatedfrom(imp, v.c_str());
+    icalstrarray *c_vals = icalstrarray_new(v.size());
+    for (size_t i = 0; i < v.size(); i++) {
+        icalstrarray_append(c_vals, v[i].c_str());
+    }
+    icalparameter_set_delegatedfrom(imp, c_vals);
 }
 
 /* RELATED */
@@ -268,14 +279,25 @@ void ICalParameter::set_range(const icalparameter_range &v)
 }
 
 /* DELEGATED-TO */
-std::string ICalParameter::get_delegatedto() const
+std::vector<std::string> ICalParameter::get_delegatedto() const
 {
-    return static_cast<std::string>(icalparameter_get_delegatedto(imp));
+    std::vector<std::string> vals;
+    icalstrarray *c_vals = icalparameter_get_delegatedto(imp);
+    if (c_vals) {
+        for (size_t i = 0; i < icalstrarray_size(c_vals); ++i) {
+            vals.push_back(std::string(icalstrarray_element_at(c_vals, i)));
+        }
+    }
+    return vals;
 }
 
-void ICalParameter::set_delegatedto(const std::string &v)
+void ICalParameter::set_delegatedto(const std::vector<std::string> &v)
 {
-    icalparameter_set_delegatedto(imp, v.c_str());
+    icalstrarray *c_vals = icalstrarray_new(v.size());
+    for (size_t i = 0; i < v.size(); i++) {
+        icalstrarray_append(c_vals, v[i].c_str());
+    }
+    icalparameter_set_delegatedto(imp, c_vals);
 }
 
 /* CN */
@@ -334,14 +356,25 @@ void ICalParameter::set_xlicerrortype(const icalparameter_xlicerrortype &v)
 }
 
 /* MEMBER */
-std::string ICalParameter::get_member() const
+std::vector<std::string> ICalParameter::get_member() const
 {
-    return static_cast<std::string>(icalparameter_get_member(imp));
+    std::vector<std::string> vals;
+    icalstrarray *c_vals = icalparameter_get_member(imp);
+    if (c_vals) {
+        for (size_t i = 0; i < icalstrarray_size(c_vals); ++i) {
+            vals.push_back(std::string(icalstrarray_element_at(c_vals, i)));
+        }
+    }
+    return vals;
 }
 
-void ICalParameter::set_member(const std::string &v)
+void ICalParameter::set_member(const std::vector<std::string> &v)
 {
-    icalparameter_set_member(imp, v.c_str());
+    icalstrarray *c_vals = icalstrarray_new(v.size());
+    for (size_t i = 0; i < v.size(); i++) {
+        icalstrarray_append(c_vals, v[i].c_str());
+    }
+    icalparameter_set_member(imp, c_vals);
 }
 
 /* X */

--- a/src/libical/icalparameter_cxx.h
+++ b/src/libical/icalparameter_cxx.h
@@ -21,6 +21,7 @@ extern "C" {
 }
 
 #include <string>
+#include <vector>
 
 namespace LibICal
 {
@@ -68,8 +69,8 @@ public:
 
 public:
     /* DELEGATED-FROM */
-    std::string get_delegatedfrom() const;
-    void set_delegatedfrom(const std::string &v);
+    std::vector<std::string> get_delegatedfrom() const;
+    void set_delegatedfrom(const std::vector<std::string> &v);
 
     /* RELATED */
     icalparameter_related get_related() const;
@@ -112,8 +113,8 @@ public:
     void set_range(const icalparameter_range &v);
 
     /* DELEGATED-TO */
-    std::string get_delegatedto() const;
-    void set_delegatedto(const std::string &v);
+    std::vector<std::string> get_delegatedto() const;
+    void set_delegatedto(const std::vector<std::string> &v);
 
     /* CN */
     std::string get_cn() const;
@@ -136,8 +137,8 @@ public:
     void set_xlicerrortype(const icalparameter_xlicerrortype &v);
 
     /* MEMBER */
-    std::string get_member() const;
-    void set_member(const std::string &v);
+    std::vector<std::string> get_member() const;
+    void set_member(const std::vector<std::string> &v);
 
     /* X */
     std::string get_x() const;

--- a/src/libical/icalparameterimpl.h
+++ b/src/libical/icalparameterimpl.h
@@ -30,7 +30,7 @@ struct icalparameter_impl {
 
     int data;
     struct icaldurationtype duration;
-    icalarray *values;  /* array of enums or strings */
+    icalarray *values; /* array of enums or strings */
 };
 
 #endif /*ICALPARAMETER_IMPL */

--- a/src/libical/icalparameterimpl.h
+++ b/src/libical/icalparameterimpl.h
@@ -25,8 +25,12 @@ struct icalparameter_impl {
     const char *x_name;
     icalproperty *parent;
 
+    icalvalue_kind value_kind;
+    int is_multivalued;
+
     int data;
     struct icaldurationtype duration;
+    icalarray *values;  /* array of enums or strings */
 };
 
 #endif /*ICALPARAMETER_IMPL */

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -204,43 +204,6 @@ static char *parser_get_prop_name(char *line, char **end)
     return str;
 }
 
-/** Decode parameter value per RFC6868 */
-static void parser_decode_param_value(char *value)
-{
-    char *in, *out;
-
-    for (in = out = value; *in; in++, out++) {
-        int found_escaped_char = 0;
-
-        if (*in == '^') {
-            switch (*(in + 1)) {
-            case 'n':
-                *out = '\n';
-                found_escaped_char = 1;
-                break;
-            case '^':
-                *out = '^';
-                found_escaped_char = 1;
-                break;
-
-            case '\'':
-                *out = '"';
-                found_escaped_char = 1;
-                break;
-            }
-        }
-
-        if (found_escaped_char) {
-            ++in;
-        } else {
-            *out = *in;
-        }
-    }
-
-    while (*out)
-        *out++ = '\0';
-}
-
 static bool parser_get_param_name_stack(char *line, char *name, size_t name_length,
                                         char *value, size_t value_length)
 {
@@ -286,7 +249,7 @@ static bool parser_get_param_name_stack(char *line, char *name, size_t name_leng
     strncpy(value, next, requested_value_length);
     value[requested_value_length] = 0;
 
-    parser_decode_param_value(value);
+    icalparameter_decode_value(value);
 
     return true;
 }
@@ -322,7 +285,7 @@ static char *parser_get_param_name_heap(char *line, char **end)
         *end = make_segment(*end, *end + strlen(*end));
     }
 
-    parser_decode_param_value(*end);
+    icalparameter_decode_value(*end);
 
     return str;
 }

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -261,7 +261,8 @@ static bool parser_get_param_name_stack(char *line, char *name, size_t name_leng
     memcpy(value, next, requested_value_length);
     value[requested_value_length] = 0;
 
-    if (!is_multivalued) icalparameter_decode_value(value);
+    if (!is_multivalued)
+        icalparameter_decode_value(value);
 
     return true;
 }
@@ -302,7 +303,8 @@ static char *parser_get_param_name_heap(char *line, char **end)
         *end = make_segment(*end, *end + strlen(*end));
     }
 
-    if (!is_multivalued) icalparameter_decode_value(*end);
+    if (!is_multivalued)
+        icalparameter_decode_value(*end);
 
     return str;
 }

--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -19,7 +19,7 @@
 #include <string.h>
 
 size_t icalstrarray_find(icalstrarray *array,
-                          const char *needle)
+                         const char *needle)
 {
     size_t i;
 
@@ -47,7 +47,8 @@ void icalstrarray_add(icalstrarray *array, const char *add)
 
 void icalstrarray_remove_element_at(icalstrarray *array, size_t position)
 {
-    if (position >= icalstrarray_size(array)) return;
+    if (position >= icalstrarray_size(array))
+        return;
 
     char **del = icalarray_element_at(array, position);
 
@@ -67,8 +68,9 @@ void icalstrarray_remove(icalstrarray *array, const char *del)
 void icalstrarray_free(icalstrarray *array)
 {
     for (size_t i = 0; i < array->num_elements; i++) {
-      char **del = icalarray_element_at(array, i);
-      if (del && *del) icalmemory_free_buffer(*del);
+        char **del = icalarray_element_at(array, i);
+        if (del && *del)
+            icalmemory_free_buffer(*del);
     }
 
     icalarray_free(array);

--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -1,0 +1,93 @@
+/*======================================================================
+ FILE: icalstrarray.c
+
+ CREATOR: Ken Murchison 24 Aug 2022
+
+ SPDX-FileCopyrightText: 2022, Fastmail Pty. Ltd. (https://fastmail.com)
+
+ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+ ======================================================================*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "icalstrarray.h"
+#include "icalmemory.h"
+
+#include <string.h>
+
+ssize_t icalstrarray_find(icalstrarray *array,
+                           const char *needle)
+{
+    size_t i;
+
+    for (i = 0; i < array->num_elements; i++) {
+        if (!strcmp(needle, icalstrarray_element_at(array, i))) {
+            return (ssize_t)i;
+        }
+    }
+
+    return -1;
+}
+
+void icalstrarray_append(icalstrarray *array, const char *elem)
+{
+    char *copy = icalmemory_strdup(elem);
+
+    icalarray_append(array, &copy);
+}
+
+void icalstrarray_add(icalstrarray *array, const char *add)
+{
+    if (icalstrarray_find(array, add) < 0)
+        icalstrarray_append(array, add);
+}
+
+void icalstrarray_remove_element_at(icalstrarray *array, ssize_t position)
+{
+    char **del = icalarray_element_at(array, (size_t)position);
+
+    if (del && *del)
+        icalmemory_free_buffer(*del);
+    icalarray_remove_element_at(array, (size_t)position);
+}
+
+void icalstrarray_remove(icalstrarray *array, const char *del)
+{
+    ssize_t position = icalstrarray_find(array, del);
+
+    if (position >= 0)
+        icalstrarray_remove_element_at(array, position);
+}
+
+void icalstrarray_free(icalstrarray *array)
+{
+    ssize_t i = (ssize_t)(array->num_elements - 1);
+    while (i >= 0)
+        icalstrarray_remove_element_at(array, i--);
+    icalarray_free(array);
+}
+
+static int strpcmp(const char **a, const char **b)
+{
+    return strcmp(*a, *b);
+}
+
+void icalstrarray_sort(icalstrarray *array)
+{
+    icalarray_sort(array, (int (*)(const void *, const void *))&strpcmp);
+}
+
+icalstrarray *icalstrarray_clone(icalstrarray *array)
+{
+    icalstrarray *clone = icalstrarray_new(array->increment_size);
+    size_t i;
+
+    for (i = 0; i < array->num_elements; i++) {
+        icalstrarray_append(clone, icalstrarray_element_at(array, i));
+    }
+
+    return clone;
+}

--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -19,7 +19,7 @@
 #include <string.h>
 
 ssize_t icalstrarray_find(icalstrarray *array,
-                           const char *needle)
+                          const char *needle)
 {
     size_t i;
 

--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -18,18 +18,18 @@
 
 #include <string.h>
 
-ssize_t icalstrarray_find(icalstrarray *array,
+size_t icalstrarray_find(icalstrarray *array,
                           const char *needle)
 {
     size_t i;
 
     for (i = 0; i < array->num_elements; i++) {
         if (!strcmp(needle, icalstrarray_element_at(array, i))) {
-            return (ssize_t)i;
+            return i;
         }
     }
 
-    return -1;
+    return array->num_elements;
 }
 
 void icalstrarray_append(icalstrarray *array, const char *elem)
@@ -41,32 +41,36 @@ void icalstrarray_append(icalstrarray *array, const char *elem)
 
 void icalstrarray_add(icalstrarray *array, const char *add)
 {
-    if (icalstrarray_find(array, add) < 0)
+    if (icalstrarray_find(array, add) >= icalstrarray_size(array))
         icalstrarray_append(array, add);
 }
 
-void icalstrarray_remove_element_at(icalstrarray *array, ssize_t position)
+void icalstrarray_remove_element_at(icalstrarray *array, size_t position)
 {
-    char **del = icalarray_element_at(array, (size_t)position);
+    if (position >= icalstrarray_size(array)) return;
+
+    char **del = icalarray_element_at(array, position);
 
     if (del && *del)
         icalmemory_free_buffer(*del);
-    icalarray_remove_element_at(array, (size_t)position);
+    icalarray_remove_element_at(array, position);
 }
 
 void icalstrarray_remove(icalstrarray *array, const char *del)
 {
-    ssize_t position = icalstrarray_find(array, del);
+    size_t position = icalstrarray_find(array, del);
 
-    if (position >= 0)
+    if (position < icalstrarray_size(array))
         icalstrarray_remove_element_at(array, position);
 }
 
 void icalstrarray_free(icalstrarray *array)
 {
-    ssize_t i = (ssize_t)(array->num_elements - 1);
-    while (i >= 0)
-        icalstrarray_remove_element_at(array, i--);
+    for (size_t i = 0; i < array->num_elements; i++) {
+      char **del = icalarray_element_at(array, i);
+      if (del && *del) icalmemory_free_buffer(*del);
+    }
+
     icalarray_free(array);
 }
 

--- a/src/libical/icalstrarray.h
+++ b/src/libical/icalstrarray.h
@@ -12,6 +12,10 @@
 #ifndef ICALSTRARRAY_H
 #define ICALSTRARRAY_H
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "libical_ical_export.h"
 #include "icalarray.h"
 

--- a/src/libical/icalstrarray.h
+++ b/src/libical/icalstrarray.h
@@ -1,0 +1,54 @@
+/*======================================================================
+ FILE: icalstrarray.h
+
+ CREATOR: Ken Murchison 24 Aug 2022
+
+ SPDX-FileCopyrightText: 2022, Fastmail Pty. Ltd. (https://fastmail.com)
+
+ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+ ======================================================================*/
+
+#ifndef ICALSTRARRAY_H
+#define ICALSTRARRAY_H
+
+#include "libical_ical_export.h"
+#include "icalarray.h"
+
+#include <stdlib.h>
+
+typedef icalarray icalstrarray;
+
+#define icalstrarray_new(increment_size) \
+    icalarray_new(sizeof(char *), increment_size)
+
+#define icalstrarray_element_at(array, position) \
+    *((const char **)icalarray_element_at(array, position))
+
+#define icalstrarray_size(array) ((array)->num_elements)
+
+LIBICAL_ICAL_EXPORT ssize_t icalstrarray_find(icalstrarray *array,
+                                                const char *needle);
+
+LIBICAL_ICAL_EXPORT void icalstrarray_append(icalstrarray *array,
+                                               const char *elem);
+
+LIBICAL_ICAL_EXPORT void icalstrarray_add(icalstrarray *array,
+                                            const char *add);
+
+LIBICAL_ICAL_EXPORT void icalstrarray_remove_element_at(icalstrarray *array,
+                                                          ssize_t position);
+
+LIBICAL_ICAL_EXPORT void icalstrarray_remove(icalstrarray *array,
+                                               const char *del);
+
+LIBICAL_ICAL_EXPORT void icalstrarray_free(icalstrarray *array);
+
+LIBICAL_ICAL_EXPORT void icalstrarray_sort(icalstrarray *array);
+
+LIBICAL_ICAL_EXPORT char *icalstrarray_as_ical_string_r(const icalstrarray *array,
+                                                           const char sep);
+
+LIBICAL_ICAL_EXPORT icalstrarray *icalstrarray_clone(icalstrarray *array);
+
+#endif /* ICALSTRARRAY_H */

--- a/src/libical/icalstrarray.h
+++ b/src/libical/icalstrarray.h
@@ -28,26 +28,26 @@ typedef icalarray icalstrarray;
 #define icalstrarray_size(array) ((array)->num_elements)
 
 LIBICAL_ICAL_EXPORT ssize_t icalstrarray_find(icalstrarray *array,
-                                                const char *needle);
+                                              const char *needle);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_append(icalstrarray *array,
-                                               const char *elem);
+                                             const char *elem);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_add(icalstrarray *array,
-                                            const char *add);
+                                          const char *add);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_remove_element_at(icalstrarray *array,
-                                                          ssize_t position);
+                                                        ssize_t position);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_remove(icalstrarray *array,
-                                               const char *del);
+                                             const char *del);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_free(icalstrarray *array);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_sort(icalstrarray *array);
 
 LIBICAL_ICAL_EXPORT char *icalstrarray_as_ical_string_r(const icalstrarray *array,
-                                                           const char sep);
+                                                        const char sep);
 
 LIBICAL_ICAL_EXPORT icalstrarray *icalstrarray_clone(icalstrarray *array);
 

--- a/src/libical/icalstrarray.h
+++ b/src/libical/icalstrarray.h
@@ -12,10 +12,6 @@
 #ifndef ICALSTRARRAY_H
 #define ICALSTRARRAY_H
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "libical_ical_export.h"
 #include "icalarray.h"
 

--- a/src/libical/icalstrarray.h
+++ b/src/libical/icalstrarray.h
@@ -27,8 +27,8 @@ typedef icalarray icalstrarray;
 
 #define icalstrarray_size(array) ((array)->num_elements)
 
-LIBICAL_ICAL_EXPORT ssize_t icalstrarray_find(icalstrarray *array,
-                                              const char *needle);
+LIBICAL_ICAL_EXPORT size_t icalstrarray_find(icalstrarray *array,
+                                             const char *needle);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_append(icalstrarray *array,
                                              const char *elem);
@@ -37,7 +37,7 @@ LIBICAL_ICAL_EXPORT void icalstrarray_add(icalstrarray *array,
                                           const char *add);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_remove_element_at(icalstrarray *array,
-                                                        ssize_t position);
+                                                        size_t position);
 
 LIBICAL_ICAL_EXPORT void icalstrarray_remove(icalstrarray *array,
                                              const char *del);

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -349,7 +349,7 @@ int vcardcomponent_count_properties(vcardcomponent *comp,
                 if (param) {
                     const char *altid = vcardparameter_get_altid(param);
 
-                    if (vcardstrarray_find(altids, altid) != -1)
+                    if (vcardstrarray_find(altids, altid) >= vcardstrarray_size(altids))
                         continue;
 
                     vcardstrarray_append(altids, altid);
@@ -850,11 +850,11 @@ static void comp_to_v4(vcardcomponent *impl)
         param = vcardproperty_get_first_parameter(prop, VCARD_TYPE_PARAMETER);
         if (param) {
             vcardenumarray_element pref = {VCARD_TYPE_PREF, NULL};
-            ssize_t i;
+            size_t i;
 
             types = vcardparameter_get_type(param);
             i = vcardenumarray_find(types, &pref);
-            if (i >= 0) {
+            if (i < vcardenumarray_size(types)) {
                 vcardenumarray_remove_element_at(types, i);
                 if (!vcardenumarray_size(types)) {
                     vcardproperty_remove_parameter_by_ref(prop, param);
@@ -958,7 +958,7 @@ static void comp_to_v4(vcardcomponent *impl)
                         }
 
                         /* Remove this TYPE */
-                        vcardenumarray_remove_element_at(types, (ssize_t)i);
+                        vcardenumarray_remove_element_at(types, i);
                         if (!vcardenumarray_size(types)) {
                             vcardproperty_remove_parameter_by_ref(prop, param);
                         }

--- a/src/libicalvcard/vcardenumarray.c
+++ b/src/libicalvcard/vcardenumarray.c
@@ -93,3 +93,15 @@ void vcardenumarray_sort(vcardenumarray *array)
 {
     icalarray_sort(array, (int (*)(const void *, const void *))&enumcmp);
 }
+
+vcardenumarray *vcardenumarray_clone(vcardenumarray *array)
+{
+    vcardenumarray *clone = vcardenumarray_new(array->increment_size);
+    size_t i;
+
+    for (i = 0; i < array->num_elements; i++) {
+        vcardenumarray_append(clone, vcardenumarray_element_at(array, i));
+    }
+
+    return clone;
+}

--- a/src/libicalvcard/vcardenumarray.c
+++ b/src/libicalvcard/vcardenumarray.c
@@ -19,7 +19,7 @@
 #include <string.h>
 
 ssize_t vcardenumarray_find(vcardenumarray *array,
-                            vcardenumarray_element *needle)
+                            const vcardenumarray_element *needle)
 {
     size_t i;
 
@@ -35,7 +35,7 @@ ssize_t vcardenumarray_find(vcardenumarray *array,
     return -1;
 }
 
-void vcardenumarray_append(vcardenumarray *array, vcardenumarray_element *elem)
+void vcardenumarray_append(vcardenumarray *array, const vcardenumarray_element *elem)
 {
     vcardenumarray_element copy = {
         elem->val, elem->xvalue ? icalmemory_strdup(elem->xvalue) : NULL};
@@ -43,7 +43,7 @@ void vcardenumarray_append(vcardenumarray *array, vcardenumarray_element *elem)
     icalarray_append(array, &copy);
 }
 
-void vcardenumarray_add(vcardenumarray *array, vcardenumarray_element *add)
+void vcardenumarray_add(vcardenumarray *array, const vcardenumarray_element *add)
 {
     if (vcardenumarray_find(array, add) < 0)
         vcardenumarray_append(array, add);
@@ -59,7 +59,7 @@ void vcardenumarray_remove_element_at(vcardenumarray *array,
     icalarray_remove_element_at(array, (size_t)position);
 }
 
-void vcardenumarray_remove(vcardenumarray *array, vcardenumarray_element *del)
+void vcardenumarray_remove(vcardenumarray *array, const vcardenumarray_element *del)
 {
     ssize_t position = vcardenumarray_find(array, del);
 

--- a/src/libicalvcard/vcardenumarray.c
+++ b/src/libicalvcard/vcardenumarray.c
@@ -52,7 +52,8 @@ void vcardenumarray_add(vcardenumarray *array, const vcardenumarray_element *add
 void vcardenumarray_remove_element_at(vcardenumarray *array,
                                       size_t position)
 {
-    if (position >= vcardenumarray_size(array)) return;
+    if (position >= vcardenumarray_size(array))
+        return;
 
     vcardenumarray_element *del = icalarray_element_at(array, position);
 
@@ -71,7 +72,6 @@ void vcardenumarray_remove(vcardenumarray *array, const vcardenumarray_element *
 
 void vcardenumarray_free(vcardenumarray *array)
 {
-
     for (size_t i = 0; i < vcardenumarray_size(array); i++) {
         vcardenumarray_element *del = icalarray_element_at(array, i);
         if (del->xvalue)

--- a/src/libicalvcard/vcardenumarray.c
+++ b/src/libicalvcard/vcardenumarray.c
@@ -18,8 +18,8 @@
 
 #include <string.h>
 
-ssize_t vcardenumarray_find(vcardenumarray *array,
-                            const vcardenumarray_element *needle)
+size_t vcardenumarray_find(vcardenumarray *array,
+                           const vcardenumarray_element *needle)
 {
     size_t i;
 
@@ -28,11 +28,11 @@ ssize_t vcardenumarray_find(vcardenumarray *array,
         if (!!e->xvalue == !!needle->xvalue &&
             ((e->xvalue && !strcmp(e->xvalue, needle->xvalue)) ||
              (!e->xvalue && (e->val == needle->val)))) {
-            return (ssize_t)i;
+            return i;
         }
     }
 
-    return -1;
+    return vcardenumarray_size(array);
 }
 
 void vcardenumarray_append(vcardenumarray *array, const vcardenumarray_element *elem)
@@ -45,32 +45,39 @@ void vcardenumarray_append(vcardenumarray *array, const vcardenumarray_element *
 
 void vcardenumarray_add(vcardenumarray *array, const vcardenumarray_element *add)
 {
-    if (vcardenumarray_find(array, add) < 0)
+    if (vcardenumarray_find(array, add) >= vcardenumarray_size(array))
         vcardenumarray_append(array, add);
 }
 
 void vcardenumarray_remove_element_at(vcardenumarray *array,
-                                      ssize_t position)
+                                      size_t position)
 {
-    vcardenumarray_element *del = icalarray_element_at(array, (size_t)position);
+    if (position >= vcardenumarray_size(array)) return;
+
+    vcardenumarray_element *del = icalarray_element_at(array, position);
 
     if (del->xvalue)
         icalmemory_free_buffer((char *)del->xvalue);
-    icalarray_remove_element_at(array, (size_t)position);
+    icalarray_remove_element_at(array, position);
 }
 
 void vcardenumarray_remove(vcardenumarray *array, const vcardenumarray_element *del)
 {
-    ssize_t position = vcardenumarray_find(array, del);
+    size_t position = vcardenumarray_find(array, del);
 
-    if (position >= 0)
+    if (position < vcardenumarray_size(array))
         vcardenumarray_remove_element_at(array, position);
 }
 
 void vcardenumarray_free(vcardenumarray *array)
 {
-    while (array->num_elements)
-        vcardenumarray_remove_element_at(array, (ssize_t)(array->num_elements - 1));
+
+    for (size_t i = 0; i < vcardenumarray_size(array); i++) {
+        vcardenumarray_element *del = icalarray_element_at(array, i);
+        if (del->xvalue)
+            icalmemory_free_buffer((char *)del->xvalue);
+    }
+
     icalarray_free(array);
 }
 

--- a/src/libicalvcard/vcardenumarray.h
+++ b/src/libicalvcard/vcardenumarray.h
@@ -33,18 +33,18 @@ typedef struct {
 #define vcardenumarray_size(array) ((array)->num_elements)
 
 LIBICAL_VCARD_EXPORT ssize_t vcardenumarray_find(vcardenumarray *array,
-                                                 vcardenumarray_element *needle);
+                                                 const vcardenumarray_element *needle);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_append(vcardenumarray *array,
-                                                vcardenumarray_element *elem);
+                                                const vcardenumarray_element *elem);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_add(vcardenumarray *array,
-                                             vcardenumarray_element *add);
+                                             const vcardenumarray_element *add);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_remove_element_at(vcardenumarray *array,
                                                            ssize_t position);
 LIBICAL_VCARD_EXPORT void vcardenumarray_remove(vcardenumarray *array,
-                                                vcardenumarray_element *del);
+                                                const vcardenumarray_element *del);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_free(vcardenumarray *array);
 

--- a/src/libicalvcard/vcardenumarray.h
+++ b/src/libicalvcard/vcardenumarray.h
@@ -32,8 +32,8 @@ typedef struct {
 
 #define vcardenumarray_size(array) ((array)->num_elements)
 
-LIBICAL_VCARD_EXPORT ssize_t vcardenumarray_find(vcardenumarray *array,
-                                                 const vcardenumarray_element *needle);
+LIBICAL_VCARD_EXPORT size_t vcardenumarray_find(vcardenumarray *array,
+                                                const vcardenumarray_element *needle);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_append(vcardenumarray *array,
                                                 const vcardenumarray_element *elem);
@@ -42,7 +42,7 @@ LIBICAL_VCARD_EXPORT void vcardenumarray_add(vcardenumarray *array,
                                              const vcardenumarray_element *add);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_remove_element_at(vcardenumarray *array,
-                                                           ssize_t position);
+                                                           size_t position);
 LIBICAL_VCARD_EXPORT void vcardenumarray_remove(vcardenumarray *array,
                                                 const vcardenumarray_element *del);
 

--- a/src/libicalvcard/vcardenumarray.h
+++ b/src/libicalvcard/vcardenumarray.h
@@ -50,4 +50,6 @@ LIBICAL_VCARD_EXPORT void vcardenumarray_free(vcardenumarray *array);
 
 LIBICAL_VCARD_EXPORT void vcardenumarray_sort(vcardenumarray *array);
 
+LIBICAL_VCARD_EXPORT vcardenumarray *vcardenumarray_clone(vcardenumarray *array);
+
 #endif /* VCARDENUMARRAY_H */

--- a/src/libicalvcard/vcardparameter.c
+++ b/src/libicalvcard/vcardparameter.c
@@ -108,9 +108,7 @@ vcardparameter *vcardparameter_clone(const vcardparameter *old)
     }
 
     if (old->values != 0) {
-        clone->values = old->value_kind == VCARD_TEXT_VALUE ?
-            vcardstrarray_clone(old->values) :
-            vcardenumarray_clone(old->values);
+        clone->values = old->value_kind == VCARD_TEXT_VALUE ? vcardstrarray_clone(old->values) : vcardenumarray_clone(old->values);
         if (clone->values == 0) {
             clone->parent = 0;
             vcardparameter_free(clone);

--- a/src/libicalvcard/vcardparameter.c
+++ b/src/libicalvcard/vcardparameter.c
@@ -107,6 +107,17 @@ vcardparameter *vcardparameter_clone(const vcardparameter *old)
         }
     }
 
+    if (old->values != 0) {
+        clone->values = old->value_kind == VCARD_TEXT_VALUE ?
+            vcardstrarray_clone(old->values) :
+            vcardenumarray_clone(old->values);
+        if (clone->values == 0) {
+            clone->parent = 0;
+            vcardparameter_free(clone);
+            return 0;
+        }
+    }
+
     return clone;
 }
 

--- a/src/libicalvcard/vcardproperty.c
+++ b/src/libicalvcard/vcardproperty.c
@@ -1131,9 +1131,7 @@ void vcardproperty_add_type_parameter(vcardproperty *prop,
         types = vcardparameter_get_type(param);
         vcardenumarray_add(types, type);
     } else {
-        types = vcardenumarray_new(1);
-        vcardenumarray_add(types, type);
-        param = vcardparameter_new_type(types);
+        param = vcardparameter_new_type(type);
         vcardproperty_add_parameter(prop, param);
     }
 }

--- a/src/libicalvcard/vcardstrarray.c
+++ b/src/libicalvcard/vcardstrarray.c
@@ -47,7 +47,8 @@ void vcardstrarray_add(vcardstrarray *array, const char *add)
 
 void vcardstrarray_remove_element_at(vcardstrarray *array, size_t position)
 {
-    if (position >= vcardstrarray_size(array)) return;
+    if (position >= vcardstrarray_size(array))
+        return;
 
     char **del = icalarray_element_at(array, position);
 
@@ -67,8 +68,9 @@ void vcardstrarray_remove(vcardstrarray *array, const char *del)
 void vcardstrarray_free(vcardstrarray *array)
 {
     for (size_t i = 0; i < vcardstrarray_size(array); i++) {
-      char **del = icalarray_element_at(array, i);
-      if (del && *del) icalmemory_free_buffer(*del);
+        char **del = icalarray_element_at(array, i);
+        if (del && *del)
+            icalmemory_free_buffer(*del);
     }
 
     icalarray_free(array);

--- a/src/libicalvcard/vcardstrarray.c
+++ b/src/libicalvcard/vcardstrarray.c
@@ -18,18 +18,18 @@
 
 #include <string.h>
 
-ssize_t vcardstrarray_find(vcardstrarray *array,
-                           const char *needle)
+size_t vcardstrarray_find(vcardstrarray *array,
+                          const char *needle)
 {
     size_t i;
 
     for (i = 0; i < array->num_elements; i++) {
         if (!strcmp(needle, vcardstrarray_element_at(array, i))) {
-            return (ssize_t)i;
+            return i;
         }
     }
 
-    return -1;
+    return array->num_elements;
 }
 
 void vcardstrarray_append(vcardstrarray *array, const char *elem)
@@ -41,32 +41,36 @@ void vcardstrarray_append(vcardstrarray *array, const char *elem)
 
 void vcardstrarray_add(vcardstrarray *array, const char *add)
 {
-    if (vcardstrarray_find(array, add) < 0)
+    if (vcardstrarray_find(array, add) >= vcardstrarray_size(array))
         vcardstrarray_append(array, add);
 }
 
-void vcardstrarray_remove_element_at(vcardstrarray *array, ssize_t position)
+void vcardstrarray_remove_element_at(vcardstrarray *array, size_t position)
 {
-    char **del = icalarray_element_at(array, (size_t)position);
+    if (position >= vcardstrarray_size(array)) return;
+
+    char **del = icalarray_element_at(array, position);
 
     if (del && *del)
         icalmemory_free_buffer(*del);
-    icalarray_remove_element_at(array, (size_t)position);
+    icalarray_remove_element_at(array, position);
 }
 
 void vcardstrarray_remove(vcardstrarray *array, const char *del)
 {
-    ssize_t position = vcardstrarray_find(array, del);
+    size_t position = vcardstrarray_find(array, del);
 
-    if (position >= 0)
+    if (position < vcardstrarray_size(array))
         vcardstrarray_remove_element_at(array, position);
 }
 
 void vcardstrarray_free(vcardstrarray *array)
 {
-    ssize_t i = (ssize_t)(array->num_elements - 1);
-    while (i >= 0)
-        vcardstrarray_remove_element_at(array, i--);
+    for (size_t i = 0; i < vcardstrarray_size(array); i++) {
+      char **del = icalarray_element_at(array, i);
+      if (del && *del) icalmemory_free_buffer(*del);
+    }
+
     icalarray_free(array);
 }
 

--- a/src/libicalvcard/vcardstrarray.c
+++ b/src/libicalvcard/vcardstrarray.c
@@ -79,3 +79,15 @@ void vcardstrarray_sort(vcardstrarray *array)
 {
     icalarray_sort(array, (int (*)(const void *, const void *))&strpcmp);
 }
+
+vcardstrarray *vcardstrarray_clone(vcardstrarray *array)
+{
+    vcardstrarray *clone = vcardstrarray_new(array->increment_size);
+    size_t i;
+
+    for (i = 0; i < array->num_elements; i++) {
+        vcardstrarray_append(clone, vcardstrarray_element_at(array, i));
+    }
+
+    return clone;
+}

--- a/src/libicalvcard/vcardstrarray.h
+++ b/src/libicalvcard/vcardstrarray.h
@@ -49,4 +49,6 @@ LIBICAL_VCARD_EXPORT void vcardstrarray_sort(vcardstrarray *array);
 LIBICAL_VCARD_EXPORT char *vcardstrarray_as_vcard_string_r(const vcardstrarray *array,
                                                            const char sep);
 
+LIBICAL_VCARD_EXPORT vcardstrarray *vcardstrarray_clone(vcardstrarray *array);
+
 #endif /* VCARDSTRARRAY_H */

--- a/src/libicalvcard/vcardstrarray.h
+++ b/src/libicalvcard/vcardstrarray.h
@@ -47,7 +47,7 @@ LIBICAL_VCARD_EXPORT void vcardstrarray_free(vcardstrarray *array);
 LIBICAL_VCARD_EXPORT void vcardstrarray_sort(vcardstrarray *array);
 
 LIBICAL_VCARD_EXPORT char *vcardstrarray_as_vcard_string_r(const vcardstrarray *array,
-                                                          const char sep);
+                                                           const char sep);
 
 LIBICAL_VCARD_EXPORT vcardstrarray *vcardstrarray_clone(vcardstrarray *array);
 

--- a/src/libicalvcard/vcardstrarray.h
+++ b/src/libicalvcard/vcardstrarray.h
@@ -27,8 +27,8 @@ typedef icalarray vcardstrarray;
 
 #define vcardstrarray_size(array) ((array)->num_elements)
 
-LIBICAL_VCARD_EXPORT ssize_t vcardstrarray_find(vcardstrarray *array,
-                                                const char *needle);
+LIBICAL_VCARD_EXPORT size_t vcardstrarray_find(vcardstrarray *array,
+                                               const char *needle);
 
 LIBICAL_VCARD_EXPORT void vcardstrarray_append(vcardstrarray *array,
                                                const char *elem);
@@ -37,7 +37,7 @@ LIBICAL_VCARD_EXPORT void vcardstrarray_add(vcardstrarray *array,
                                             const char *add);
 
 LIBICAL_VCARD_EXPORT void vcardstrarray_remove_element_at(vcardstrarray *array,
-                                                          ssize_t position);
+                                                          size_t position);
 
 LIBICAL_VCARD_EXPORT void vcardstrarray_remove(vcardstrarray *array,
                                                const char *del);
@@ -47,7 +47,7 @@ LIBICAL_VCARD_EXPORT void vcardstrarray_free(vcardstrarray *array);
 LIBICAL_VCARD_EXPORT void vcardstrarray_sort(vcardstrarray *array);
 
 LIBICAL_VCARD_EXPORT char *vcardstrarray_as_vcard_string_r(const vcardstrarray *array,
-                                                           const char sep);
+                                                          const char sep);
 
 LIBICAL_VCARD_EXPORT vcardstrarray *vcardstrarray_clone(vcardstrarray *array);
 

--- a/src/test/libicalvcard/vcard_test.c
+++ b/src/test/libicalvcard/vcard_test.c
@@ -205,7 +205,7 @@ static void test_add_props(vcardcomponent *card)
     vcardproperty *prop =
         vcardproperty_vanew_note("Test vCard",
                                  vcardparameter_new_language("en"),
-                                 vcardparameter_new_pid(sa),
+                                 vcardparameter_new_pid_list(sa),
                                  (void *)0);
     vcardcomponent_add_property(card, prop);
     vcardproperty_set_group(prop, "group1");

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -5666,13 +5666,13 @@ static void verify_comp_attendee(icalcomponent *comp)
 
     prop = icalcomponent_get_first_property(comp, ICAL_ATTENDEE_PROPERTY);
     str_is("value", icalproperty_get_attendee(prop), "mailto:att1");
-    str_is("member", get_param(ICAL_MEMBER_PARAMETER, member), "member");
+    str_is("member", icalparameter_get_member_nth(icalproperty_get_first_parameter(prop, ICAL_MEMBER_PARAMETER), 0),  "member");
     ok("cutype", get_param(ICAL_CUTYPE_PARAMETER, cutype) == ICAL_CUTYPE_INDIVIDUAL);
     ok("role", get_param(ICAL_ROLE_PARAMETER, role) == ICAL_ROLE_CHAIR);
     ok("partstat", get_param(ICAL_PARTSTAT_PARAMETER, partstat) == ICAL_PARTSTAT_NEEDSACTION);
     ok("rsvp", (get_param(ICAL_RSVP_PARAMETER, rsvp) == ICAL_RSVP_FALSE));
-    str_is("delegatedfrom", get_param(ICAL_DELEGATEDFROM_PARAMETER, delegatedfrom), "mailto:delgfrom");
-    str_is("delegatedto", get_param(ICAL_DELEGATEDTO_PARAMETER, delegatedto), "mailto:delgto");
+    str_is("delegatedfrom", icalparameter_get_delegatedfrom_nth(icalproperty_get_first_parameter(prop, ICAL_DELEGATEDFROM_PARAMETER), 0),  "mailto:delgfrom");
+    str_is("delegatedto", icalparameter_get_delegatedto_nth(icalproperty_get_first_parameter(prop, ICAL_DELEGATEDTO_PARAMETER), 0),  "mailto:delgto");
     str_is("sentby", get_param(ICAL_SENTBY_PARAMETER, sentby), "mailto:sentby");
     str_is("cn", get_param(ICAL_CN_PARAMETER, cn), "First attendee");
     str_is("language", get_param(ICAL_LANGUAGE_PARAMETER, language), "en_US");
@@ -5684,26 +5684,24 @@ void test_attendees(void)
 {
     icalcomponent *comp, *clone;
     icalproperty *prop;
-    icalparameter *param;
     const char *str;
 
     comp = icalcomponent_new_vevent();
     prop = icalproperty_new(ICAL_ATTENDEE_PROPERTY);
     icalproperty_set_attendee(prop, "mailto:att1");
-#define set_param(_kind, _suffix, _value)    \
-    param = icalparameter_new(_kind);        \
-    icalproperty_add_parameter(prop, param); \
-    icalparameter_set_##_suffix(param, _value);
-    set_param(ICAL_MEMBER_PARAMETER, member, "member");
-    set_param(ICAL_CUTYPE_PARAMETER, cutype, ICAL_CUTYPE_INDIVIDUAL);
-    set_param(ICAL_ROLE_PARAMETER, role, ICAL_ROLE_CHAIR);
-    set_param(ICAL_PARTSTAT_PARAMETER, partstat, ICAL_PARTSTAT_NEEDSACTION);
-    set_param(ICAL_RSVP_PARAMETER, rsvp, ICAL_RSVP_FALSE);
-    set_param(ICAL_DELEGATEDFROM_PARAMETER, delegatedfrom, "mailto:delgfrom");
-    set_param(ICAL_DELEGATEDTO_PARAMETER, delegatedto, "mailto:delgto");
-    set_param(ICAL_SENTBY_PARAMETER, sentby, "mailto:sentby");
-    set_param(ICAL_CN_PARAMETER, cn, "First attendee");
-    set_param(ICAL_LANGUAGE_PARAMETER, language, "en_US");
+#define set_param(_suffix, _value)    \
+    icalproperty_add_parameter(prop, \
+        icalparameter_new_##_suffix(_value))
+    set_param(member, "member");
+    set_param(cutype, ICAL_CUTYPE_INDIVIDUAL);
+    set_param(role, ICAL_ROLE_CHAIR);
+    set_param(partstat, ICAL_PARTSTAT_NEEDSACTION);
+    set_param(rsvp, ICAL_RSVP_FALSE);
+    set_param(delegatedfrom, "mailto:delgfrom");
+    set_param(delegatedto, "mailto:delgto");
+    set_param(sentby, "mailto:sentby");
+    set_param(cn, "First attendee");
+    set_param(language, "en_US");
 #undef set_param
 
     icalcomponent_add_property(comp, prop);
@@ -6048,6 +6046,39 @@ static void test_icalparameter_parse_multivalued(void)
     icalcomponent_free(comp);
 }
 
+static void test_icalparameter_create_multivalued(void)
+{
+    icalparameter *param;
+
+    param = icalparameter_new(ICAL_DISPLAY_PARAMETER);
+
+    icalenumarray *display = icalenumarray_new(5);
+    icalenumarray_element elem = { 0 };
+    elem.val = ICAL_DISPLAY_BADGE;
+    icalenumarray_append(display, &elem);
+    elem.val = ICAL_DISPLAY_X;
+    elem.xvalue = "X-FOO";
+    icalenumarray_append(display, &elem);
+    icalparameter_set_display(param, display);
+
+    str_is("DISPLAY", icalparameter_as_ical_string(param),
+            "DISPLAY=BADGE,X-FOO");
+
+    icalparameter_free(param);
+
+    param = icalparameter_new(ICAL_MEMBER_PARAMETER);
+
+    icalstrarray *member = icalenumarray_new(5);
+    icalstrarray_append(member, "mailto:member1");
+    icalstrarray_append(member, "mailto:member2");
+    icalparameter_set_member(param, member);
+
+    str_is("MEMBER", icalparameter_as_ical_string(param),
+            "MEMBER=\"mailto:member1\",\"mailto:member2\"");
+
+    icalparameter_free(param);
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -6220,6 +6251,7 @@ int main(int argc, char *argv[])
     test_run("Test external parameter iterator", test_icalparamiter, do_test, do_header);
     test_run("Test property enum value string conversion", test_icalproperty_enum_convert_string, do_test, do_header);
     test_run("Test parsing multi-valued parameters", test_icalparameter_parse_multivalued, do_test, do_header);
+    test_run("Test creating multi-valued parameters", test_icalparameter_create_multivalued, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6003,6 +6003,51 @@ static void test_icalproperty_enum_convert_string(void)
            icalenum_resourcetype_to_string(rtype), "PROJECTOR");
 }
 
+static void test_icalparameter_parse_multivalued(void)
+{
+    char buffer[4096] = {0};
+    strcat(buffer, "BEGIN:VEVENT\r\n");
+
+    const char *display_param_str =
+        "IMAGE;VALUE=URI;DISPLAY=X-FOO,BADGE:http://local/img2.png\r\n";
+    strcat(buffer, display_param_str);
+
+    const char *delegatedfrom_param_str =
+        "ATTENDEE;DELEGATED-FROM=\"mailto:d1\",\"mailto:d2\":mailto:delgfrom\r\n";
+    strcat(buffer, delegatedfrom_param_str);
+
+    const char *delegatedto_param_str =
+        "ATTENDEE;DELEGATED-TO=\"mailto:d1\",\"mailto:d2\":mailto:delgto\r\n";
+    strcat(buffer, delegatedto_param_str);
+
+    const char *member_param_str =
+        "ATTENDEE;MEMBER=\"mailto:d1\",\"mailto:d2\":mailto:member\r\n";
+    strcat(buffer, member_param_str);
+
+    strcat(buffer, "END:VEVENT\r\n");
+
+    icalcomponent *comp = icalcomponent_new_from_string(buffer);
+    icalproperty *prop;
+
+    prop = icalcomponent_get_first_property(comp, ICAL_ANY_PROPERTY);
+    str_is("DISPLAY", icalproperty_as_ical_string(prop),
+            display_param_str);
+
+    prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY);
+    str_is("DELEGATED-FROM", icalproperty_as_ical_string(prop),
+            delegatedfrom_param_str);
+
+    prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY);
+    str_is("DELEGATED-TO", icalproperty_as_ical_string(prop),
+            delegatedto_param_str);
+
+    prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY);
+    str_is("MEMBER", icalproperty_as_ical_string(prop),
+            member_param_str);
+
+    icalcomponent_free(comp);
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -6174,6 +6219,7 @@ int main(int argc, char *argv[])
     test_run("Test external property iterator", test_icalpropiter, do_test, do_header);
     test_run("Test external parameter iterator", test_icalparamiter, do_test, do_header);
     test_run("Test property enum value string conversion", test_icalproperty_enum_convert_string, do_test, do_header);
+    test_run("Test parsing multi-valued parameters", test_icalparameter_parse_multivalued, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -5666,13 +5666,13 @@ static void verify_comp_attendee(icalcomponent *comp)
 
     prop = icalcomponent_get_first_property(comp, ICAL_ATTENDEE_PROPERTY);
     str_is("value", icalproperty_get_attendee(prop), "mailto:att1");
-    str_is("member", icalparameter_get_member_nth(icalproperty_get_first_parameter(prop, ICAL_MEMBER_PARAMETER), 0),  "member");
+    str_is("member", icalparameter_get_member_nth(icalproperty_get_first_parameter(prop, ICAL_MEMBER_PARAMETER), 0), "member");
     ok("cutype", get_param(ICAL_CUTYPE_PARAMETER, cutype) == ICAL_CUTYPE_INDIVIDUAL);
     ok("role", get_param(ICAL_ROLE_PARAMETER, role) == ICAL_ROLE_CHAIR);
     ok("partstat", get_param(ICAL_PARTSTAT_PARAMETER, partstat) == ICAL_PARTSTAT_NEEDSACTION);
     ok("rsvp", (get_param(ICAL_RSVP_PARAMETER, rsvp) == ICAL_RSVP_FALSE));
-    str_is("delegatedfrom", icalparameter_get_delegatedfrom_nth(icalproperty_get_first_parameter(prop, ICAL_DELEGATEDFROM_PARAMETER), 0),  "mailto:delgfrom");
-    str_is("delegatedto", icalparameter_get_delegatedto_nth(icalproperty_get_first_parameter(prop, ICAL_DELEGATEDTO_PARAMETER), 0),  "mailto:delgto");
+    str_is("delegatedfrom", icalparameter_get_delegatedfrom_nth(icalproperty_get_first_parameter(prop, ICAL_DELEGATEDFROM_PARAMETER), 0), "mailto:delgfrom");
+    str_is("delegatedto", icalparameter_get_delegatedto_nth(icalproperty_get_first_parameter(prop, ICAL_DELEGATEDTO_PARAMETER), 0), "mailto:delgto");
     str_is("sentby", get_param(ICAL_SENTBY_PARAMETER, sentby), "mailto:sentby");
     str_is("cn", get_param(ICAL_CN_PARAMETER, cn), "First attendee");
     str_is("language", get_param(ICAL_LANGUAGE_PARAMETER, language), "en_US");
@@ -5689,9 +5689,9 @@ void test_attendees(void)
     comp = icalcomponent_new_vevent();
     prop = icalproperty_new(ICAL_ATTENDEE_PROPERTY);
     icalproperty_set_attendee(prop, "mailto:att1");
-#define set_param(_suffix, _value)    \
+#define set_param(_suffix, _value)   \
     icalproperty_add_parameter(prop, \
-        icalparameter_new_##_suffix(_value))
+                               icalparameter_new_##_suffix(_value))
     set_param(member, "member");
     set_param(cutype, ICAL_CUTYPE_INDIVIDUAL);
     set_param(role, ICAL_ROLE_CHAIR);
@@ -6029,19 +6029,19 @@ static void test_icalparameter_parse_multivalued(void)
 
     prop = icalcomponent_get_first_property(comp, ICAL_ANY_PROPERTY);
     str_is("DISPLAY", icalproperty_as_ical_string(prop),
-            display_param_str);
+           display_param_str);
 
     prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY);
     str_is("DELEGATED-FROM", icalproperty_as_ical_string(prop),
-            delegatedfrom_param_str);
+           delegatedfrom_param_str);
 
     prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY);
     str_is("DELEGATED-TO", icalproperty_as_ical_string(prop),
-            delegatedto_param_str);
+           delegatedto_param_str);
 
     prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY);
     str_is("MEMBER", icalproperty_as_ical_string(prop),
-            member_param_str);
+           member_param_str);
 
     icalcomponent_free(comp);
 }
@@ -6053,7 +6053,7 @@ static void test_icalparameter_create_multivalued(void)
     param = icalparameter_new(ICAL_DISPLAY_PARAMETER);
 
     icalenumarray *display = icalenumarray_new(5);
-    icalenumarray_element elem = { 0 };
+    icalenumarray_element elem = {0};
     elem.val = ICAL_DISPLAY_BADGE;
     icalenumarray_append(display, &elem);
     elem.val = ICAL_DISPLAY_X;
@@ -6062,7 +6062,7 @@ static void test_icalparameter_create_multivalued(void)
     icalparameter_set_display(param, display);
 
     str_is("DISPLAY", icalparameter_as_ical_string(param),
-            "DISPLAY=BADGE,X-FOO");
+           "DISPLAY=BADGE,X-FOO");
 
     icalparameter_free(param);
 
@@ -6074,7 +6074,7 @@ static void test_icalparameter_create_multivalued(void)
     icalparameter_set_member(param, member);
 
     str_is("MEMBER", icalparameter_as_ical_string(param),
-            "MEMBER=\"mailto:member1\",\"mailto:member2\"");
+           "MEMBER=\"mailto:member1\",\"mailto:member2\"");
 
     icalparameter_free(param);
 }

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6007,7 +6007,7 @@ static void test_icalparameter_parse_multivalued(void)
     strcat(buffer, "BEGIN:VEVENT\r\n");
 
     const char *display_param_str =
-        "IMAGE;VALUE=URI;DISPLAY=X-FOO,BADGE:http://local/img2.png\r\n";
+        "IMAGE;VALUE=URI;DISPLAY=X-FOO,BADGE:https://local/img2.png\r\n";
     strcat(buffer, display_param_str);
 
     const char *delegatedfrom_param_str =


### PR DESCRIPTION
This adds support for multi-valued iCalendar parameters. It fixes https://github.com/libical/libical/issues/243

This is working code, but I will leave it as draft until some more experimentation. It supports multiple values for the following parameters:
- DELEGATED-FROM (RFC 5545)
- DELEGATED-TO (RFC 5545)
- MEMBER (RFC 5545)
- DISPLAY (RFC 7986)
- FEATURE (RFC 7986)

Currently, the libical parser discards all but the first parameter value for the DELEGATED-FROM, DELEGATED-TO and MEMBER parameters. This is because the parser ignores any value that follows a quoted-string parameter value. For DISPLAY, it parses all comma-separated enum values but stores them as a single X-parameter value.

Consequently, libical currently does not allow to process multiple values of these parameters or preserve them when rendering the in-memory representation back to iCalendar.

This patch fixes that by reusing the multi-value parameter support that already was available in libicalvcard.

This change is not backwards-compatible, neither for libical or libicalvcard. The changes were made to help migrating existing codebases:

- The `get_foo` function now returns a list of values. A new `get_foo_nth` function allows to access the nth parameter value, a new `get_foo_size` function indicates the length of the parameter value list.
- The `set_foo` function now takes a list of values.
- The `new_foo` constructors take a single value as argument, as this is compatible with libical and likely to be the common usage pattern. To construct a parameter with a list of values, a `new_foo_list` constructor is defined.

The C++ compatibility layer is updated but the glib integration currently is not.