### PR TITLE
Link ICU components in the right order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,8 +311,8 @@ endif()
 find_package(
   ICU
   COMPONENTS
-    uc
     i18n
+    uc
     data
 )
 set_package_properties(


### PR DESCRIPTION
When static linking, a library that refers to symbols in another library has to come before the latter library in the linker command line.

Before this change, I get linker errors like the following.  With this change, no error.

```
FAILED: src/test/icalrecurtest
: && /nix/store/m8ggqv2dfrw6raz49ipnnab98cljx1k2-x86_64-unknown-linux-musl-gcc-wrapper-14.3.0/bin/x86_64-unknown-linux-musl-g++ -O2       -fvisibility=hidden       -Weffc++ -Wno-deprecated -Wall -Wextra -Woverloaded-virtual -Winit-self -Wunused       -Wno-div-by-zero -Wundef -Wpointer-arith -Wtype-limits -Wwrite-strings -Wreturn-type -Wunused-but-set-variable -Wlogical-op -Wsizeof-pointer-memaccess -Wreorder -Wformat-security -Wredundant-decls -Wunreachable-code -Wvarargs -D_XOPEN_SOURCE=500 -D_DEFAULT_SOURCE -D_GNU_SOURCE -Wall -Wextra -Wformat -Wformat=2 -Wconversion -Wsign-conversion -Wtrampolines -Wimplicit-fallthrough -Wbidi-chars=any -Wformat-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fstrict-flex-arrays=3 -fstack-clash-protection -fstack-protector-strong -fcf-protection=full -fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing -O3 -DNDEBUG -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,relro -Wl,--as-needed -Wl,--no-copy-dt-needed-entries -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,relro -Wl,--as-needed -Wl,--no-copy-dt-needed-entries src/test/CMakeFiles/icalrecurtest.dir/icalrecur_test.c.o -o src/test/icalrecurtest  lib/libical.a  lib/libicalss.a  lib/libicalvcal.a  lib/libical.a  /nix>
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao): in function `ucal_getAvailable_76':
(.text.ucal_getAvailable_76+0x1): undefined reference to `uloc_getAvailable_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao): in function `ucal_countAvailable_76':
(.text.ucal_countAvailable_76+0x1): undefined reference to `uloc_countAvailable_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao): in function `ucal_getKeywordValuesForLocale_76':
(.text.ucal_getKeywordValuesForLocale_76+0xec): undefined reference to `ulist_createEmptyList_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.ucal_getKeywordValuesForLocale_76+0x132): undefined reference to `ulist_resetList_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.ucal_getKeywordValuesForLocale_76+0x260): undefined reference to `ulist_addItemEndList_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.ucal_getKeywordValuesForLocale_76+0x2e2): undefined reference to `ulist_containsString_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.ucal_getKeywordValuesForLocale_76+0x2f6): undefined reference to `ulist_addItemEndList_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.ucal_getKeywordValuesForLocale_76+0x304): undefined reference to `ulist_deleteList_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.ucal_getKeywordValuesForLocale_76+0x333): undefined reference to `ulist_deleteList_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao):(.data.rel.ro._ZL20defaultKeywordValues+0x10): undefined reference to `ulist_close_keyword_values_iterator_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao):(.data.rel.ro._ZL20defaultKeywordValues+0x18): undefined reference to `ulist_count_keyword_values_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao):(.data.rel.ro._ZL20defaultKeywordValues+0x28): undefined reference to `ulist_next_keyword_value_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(ucal.ao):(.data.rel.ro._ZL20defaultKeywordValues+0x30): undefined reference to `ulist_reset_keyword_values_iterator_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::SharedCalendar::~SharedCalendar()':
(.text._ZN6icu_7614SharedCalendarD2Ev+0x32): undefined reference to `icu_76::SharedObject::~SharedObject()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::BasicCalendarFactory::~BasicCalendarFactory()':
(.text._ZN6icu_7620BasicCalendarFactoryD2Ev+0xf): undefined reference to `icu_76::LocaleKeyFactory::~LocaleKeyFactory()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::DefaultCalendarFactory::~DefaultCalendarFactory()':
(.text._ZN6icu_7622DefaultCalendarFactoryD2Ev+0xf): undefined reference to `icu_76::ICUResourceBundleFactory::~ICUResourceBundleFactory()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::CalendarService::~CalendarService()':
(.text._ZN6icu_7615CalendarServiceD2Ev+0xf): undefined reference to `icu_76::ICULocaleService::~ICULocaleService()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::LocaleCacheKey<icu_76::SharedCalendar>::clone() const':
(.text._ZNK6icu_7614LocaleCacheKeyINS_14SharedCalendarEE5cloneEv[_ZNK6icu_7614LocaleCacheKeyINS_14SharedCalendarEE5cloneEv]+0x65): undefined reference to `icu_76::CacheKeyBase::~CacheKeyBase()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::CalendarService::isDefault() const':
(.text._ZNK6icu_7615CalendarService9isDefaultEv[_ZNK6icu_7615CalendarService9isDefaultEv]+0x5): undefined reference to `icu_76::ICUService::countFactories() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::initCalendarService(UErrorCode&) [clone .cold]':
(.text.unlikely._ZN6icu_76L19initCalendarServiceER10UErrorCode+0x16): undefined reference to `icu_76::ICULocaleService::~ICULocaleService()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::initCalendarService(UErrorCode&)':
(.text._ZN6icu_76L19initCalendarServiceER10UErrorCode+0xa9): undefined reference to `icu_76::ICULocaleService::ICULocaleService(icu_76::UnicodeString const&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_76L19initCalendarServiceER10UErrorCode+0xe1): undefined reference to `icu_76::ICUResourceBundleFactory::ICUResourceBundleFactory()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_76L19initCalendarServiceER10UErrorCode+0xfe): undefined reference to `icu_76::ICUService::registerFactory(icu_76::ICUServiceFactory*, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_76L19initCalendarServiceER10UErrorCode+0x12c): undefined reference to `icu_76::LocaleKeyFactory::LocaleKeyFactory(int)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::getAvailableLocales(int&)':
(.text._ZN6icu_768Calendar19getAvailableLocalesERi+0x1): undefined reference to `icu_76::Locale::getAvailableLocales(int&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::getLocale(ULocDataLocaleType, UErrorCode&) const':
(.text._ZNK6icu_768Calendar9getLocaleE18ULocDataLocaleTypeR10UErrorCode+0x34): undefined reference to `icu_76::LocaleBased::getLocale(ULocDataLocaleType, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::getLocaleID(ULocDataLocaleType, UErrorCode&) const':
(.text._ZNK6icu_768Calendar11getLocaleIDE18ULocDataLocaleTypeR10UErrorCode+0x30): undefined reference to `icu_76::LocaleBased::getLocaleID(ULocDataLocaleType, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::LocaleCacheKey<icu_76::SharedCalendar>::~LocaleCacheKey()':
(.text._ZN6icu_7614LocaleCacheKeyINS_14SharedCalendarEED2Ev[_ZN6icu_7614LocaleCacheKeyINS_14SharedCalendarEED5Ev]+0x3b): undefined reference to `icu_76::CacheKeyBase::~CacheKeyBase()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::setWeekData(icu_76::Locale const&, char const*, UErrorCode&)':
(.text._ZN6icu_768Calendar11setWeekDataERKNS_6LocaleEPKcR10UErrorCode+0x31e): undefined reference to `icu_76::LocaleBased::setLocaleIDs(char const*, char const*)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::makeInstance(icu_76::Locale const&, UErrorCode&)':
(.text._ZN6icu_768Calendar12makeInstanceERKNS_6LocaleER10UErrorCode+0xd2): undefined reference to `icu_76::LocaleUtility::initLocaleFromName(icu_76::UnicodeString const&, icu_76::Locale&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768Calendar12makeInstanceERKNS_6LocaleER10UErrorCode+0x112): undefined reference to `icu_76::ICULocaleService::get(icu_76::Locale const&, int, icu_76::Locale*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768Calendar12makeInstanceERKNS_6LocaleER10UErrorCode+0x1d4): undefined reference to `icu_76::ICULocaleService::get(icu_76::Locale const&, int, icu_76::Locale*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::LocaleCacheKey<icu_76::SharedCalendar>::createObject(void const*, UErrorCode&) const':
(.text._ZNK6icu_7614LocaleCacheKeyINS_14SharedCalendarEE12createObjectEPKvR10UErrorCode+0x69): undefined reference to `icu_76::SharedObject::addRef() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::DefaultCalendarFactory::create(icu_76::ICUServiceKey const&, icu_76::ICUService const*, UErrorCode&) const':
(.text._ZNK6icu_7622DefaultCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode[_ZNK6icu_7622DefaultCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode]+0x31): undefined reference to `typeinfo for icu_76::LocaleKey'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7622DefaultCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode[_ZNK6icu_7622DefaultCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode]+0x38): undefined reference to `typeinfo for icu_76::ICUServiceKey'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::BasicCalendarFactory::create(icu_76::ICUServiceKey const&, icu_76::ICUService const*, UErrorCode&) const':
(.text._ZNK6icu_7620BasicCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode[_ZNK6icu_7620BasicCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode]+0x33): undefined reference to `typeinfo for icu_76::LocaleKey'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7620BasicCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode[_ZNK6icu_7620BasicCalendarFactory6createERKNS_13ICUServiceKeyEPKNS_10ICUServiceER10UErrorCode]+0x3a): undefined reference to `typeinfo for icu_76::ICUServiceKey'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::LocaleCacheKey<icu_76::SharedCalendar>::~LocaleCacheKey()':
(.text._ZN6icu_7614LocaleCacheKeyINS_14SharedCalendarEED0Ev[_ZN6icu_7614LocaleCacheKeyINS_14SharedCalendarEED5Ev]+0x36): undefined reference to `icu_76::CacheKeyBase::~CacheKeyBase()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `void icu_76::UnifiedCache::getByLocale<icu_76::SharedCalendar>(icu_76::Locale const&, icu_76::SharedCalendar const*&, UErrorCode&)':
(.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0x2e): undefined reference to `icu_76::UnifiedCache::getInstance(UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0xdf): undefined reference to `icu_76::CacheKeyBase::~CacheKeyBase()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0x123): undefined reference to `icu_76::UnifiedCache::_get(icu_76::CacheKeyBase const&, icu_76::SharedObject const*&, void const*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0x141): undefined reference to `icu_76::SharedObject::removeRef() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0x186): undefined reference to `icu_76::SharedObject::removeRef() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0x1a5): undefined reference to `icu_76::SharedObject::addRef() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode[_ZN6icu_7612UnifiedCache11getByLocaleINS_14SharedCalendarEEEvRKNS_6LocaleERPKT_R10UErrorCode]+0x20c): undefined reference to `icu_76::CacheKeyBase::~CacheKeyBase()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::createInstance(icu_76::TimeZone*, icu_76::Locale const&, UErrorCode&)':
(.text._ZN6icu_768Calendar14createInstanceEPNS_8TimeZoneERKNS_6LocaleER10UErrorCode+0x56): undefined reference to `icu_76::SharedObject::removeRef() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao): in function `icu_76::Calendar::getCalendarTypeFromLocale(icu_76::Locale const&, char*, int, UErrorCode&)':
(.text._ZN6icu_768Calendar25getCalendarTypeFromLocaleERKNS_6LocaleEPciR10UErrorCode+0x69): undefined reference to `icu_76::SharedObject::removeRef() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTIN6icu_7614SharedCalendarE[_ZTIN6icu_7614SharedCalendarE]+0x10): undefined reference to `typeinfo for icu_76::SharedObject'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTIN6icu_768CacheKeyINS_14SharedCalendarEEE[_ZTIN6icu_768CacheKeyINS_14SharedCalendarEEE]+0x10): undefined reference to `typeinfo for icu_76::CacheKeyBase'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTIN6icu_7620BasicCalendarFactoryE[_ZTIN6icu_7620BasicCalendarFactoryE]+0x10): undefined reference to `typeinfo for icu_76::LocaleKeyFactory'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTIN6icu_7622DefaultCalendarFactoryE[_ZTIN6icu_7622DefaultCalendarFactoryE]+0x10): undefined reference to `typeinfo for icu_76::ICUResourceBundleFactory'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTIN6icu_7615CalendarServiceE[_ZTIN6icu_7615CalendarServiceE]+0x10): undefined reference to `typeinfo for icu_76::ICULocaleService'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7620BasicCalendarFactoryE[_ZTVN6icu_7620BasicCalendarFactoryE]+0x20): undefined reference to `icu_76::LocaleKeyFactory::getDynamicClassID() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7620BasicCalendarFactoryE[_ZTVN6icu_7620BasicCalendarFactoryE]+0x38): undefined reference to `icu_76::LocaleKeyFactory::getDisplayName(icu_76::UnicodeString const&, icu_76::Locale const&, icu_76::UnicodeString&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7620BasicCalendarFactoryE[_ZTVN6icu_7620BasicCalendarFactoryE]+0x40): undefined reference to `icu_76::LocaleKeyFactory::handlesKey(icu_76::ICUServiceKey const&, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7620BasicCalendarFactoryE[_ZTVN6icu_7620BasicCalendarFactoryE]+0x48): undefined reference to `icu_76::LocaleKeyFactory::handleCreate(icu_76::Locale const&, int, icu_76::ICUService const*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7620BasicCalendarFactoryE[_ZTVN6icu_7620BasicCalendarFactoryE]+0x50): undefined reference to `icu_76::LocaleKeyFactory::getSupportedIDs(UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7622DefaultCalendarFactoryE[_ZTVN6icu_7622DefaultCalendarFactoryE]+0x20): undefined reference to `icu_76::ICUResourceBundleFactory::getDynamicClassID() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7622DefaultCalendarFactoryE[_ZTVN6icu_7622DefaultCalendarFactoryE]+0x30): undefined reference to `icu_76::LocaleKeyFactory::updateVisibleIDs(icu_76::Hashtable&, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7622DefaultCalendarFactoryE[_ZTVN6icu_7622DefaultCalendarFactoryE]+0x38): undefined reference to `icu_76::LocaleKeyFactory::getDisplayName(icu_76::UnicodeString const&, icu_76::Locale const&, icu_76::UnicodeString&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7622DefaultCalendarFactoryE[_ZTVN6icu_7622DefaultCalendarFactoryE]+0x40): undefined reference to `icu_76::LocaleKeyFactory::handlesKey(icu_76::ICUServiceKey const&, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7622DefaultCalendarFactoryE[_ZTVN6icu_7622DefaultCalendarFactoryE]+0x48): undefined reference to `icu_76::ICUResourceBundleFactory::handleCreate(icu_76::Locale const&, int, icu_76::ICUService const*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7622DefaultCalendarFactoryE[_ZTVN6icu_7622DefaultCalendarFactoryE]+0x50): undefined reference to `icu_76::ICUResourceBundleFactory::getSupportedIDs(UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x20): undefined reference to `icu_76::ICUNotifier::addListener(icu_76::EventListener const*, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x28): undefined reference to `icu_76::ICUNotifier::removeListener(icu_76::EventListener const*, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x30): undefined reference to `icu_76::ICUNotifier::notifyChanged()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x38): undefined reference to `icu_76::ICUService::acceptsListener(icu_76::EventListener const&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x40): undefined reference to `icu_76::ICUService::notifyListener(icu_76::EventListener&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x48): undefined reference to `icu_76::ICUService::getKey(icu_76::ICUServiceKey&, icu_76::UnicodeString*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x50): undefined reference to `icu_76::ICULocaleService::registerInstance(icu_76::UObject*, icu_76::UnicodeString const&, signed char, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x58): undefined reference to `icu_76::ICUService::registerFactory(icu_76::ICUServiceFactory*, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x60): undefined reference to `icu_76::ICUService::unregister(void const*, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x68): undefined reference to `icu_76::ICUService::reset()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x78): undefined reference to `icu_76::ICULocaleService::createKey(icu_76::UnicodeString const*, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x88): undefined reference to `icu_76::ICUService::createSimpleFactory(icu_76::UObject*, icu_76::UnicodeString const&, signed char, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0x90): undefined reference to `icu_76::ICUService::reInitializeFactories()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0xa0): undefined reference to `icu_76::ICUService::clearCaches()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0xa8): undefined reference to `icu_76::ICULocaleService::registerInstance(icu_76::UObject*, icu_76::Locale const&, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0xb0): undefined reference to `icu_76::ICULocaleService::registerInstance(icu_76::UObject*, icu_76::Locale const&, int, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0xb8): undefined reference to `icu_76::ICULocaleService::registerInstance(icu_76::UObject*, icu_76::Locale const&, int, int, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0xc0): undefined reference to `icu_76::ICULocaleService::getAvailableLocales() const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(calendar.ao):(.data.rel.ro._ZTVN6icu_7615CalendarServiceE[_ZTVN6icu_7615CalendarServiceE]+0xc8): undefined reference to `icu_76::ICULocaleService::createKey(icu_76::UnicodeString const*, int, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(timezone.ao): in function `icu_76::TimeZone::parseCustomID(icu_76::UnicodeString const&, int&, int&, int&, int&)':
(.text._ZN6icu_768TimeZone13parseCustomIDERKNS_13UnicodeStringERiS4_S4_S4_+0x6f): undefined reference to `u_strncasecmp_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TimeZone13parseCustomIDERKNS_13UnicodeStringERiS4_S4_S4_+0xf3): undefined reference to `icu_76::ICU_Utility::parseNumber(icu_76::UnicodeString const&, int&, signed char)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TimeZone13parseCustomIDERKNS_13UnicodeStringERiS4_S4_S4_+0x168): undefined reference to `icu_76::ICU_Utility::parseNumber(icu_76::UnicodeString const&, int&, signed char)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TimeZone13parseCustomIDERKNS_13UnicodeStringERiS4_S4_S4_+0x1cd): undefined reference to `icu_76::ICU_Utility::parseNumber(icu_76::UnicodeString const&, int&, signed char)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseSingleLocalizedDigit(icu_76::UnicodeString const&, int, int&) const':
(.text._ZNK6icu_7614TimeZoneFormat25parseSingleLocalizedDigitERKNS_13UnicodeStringEiRi+0x56): undefined reference to `u_charDigitValue_76'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseOffsetFieldsWithPattern(icu_76::UnicodeString const&, int, icu_76::UVector*, signed char, int&, int&, int&) const':
(.text._ZNK6icu_7614TimeZoneFormat28parseOffsetFieldsWithPatternERKNS_13UnicodeStringEiPNS_7UVectorEaRiS6_S6_+0x116): undefined reference to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseOffsetLocalizedGMTPattern(icu_76::UnicodeString const&, int, signed char, int&) const':
(.text._ZNK6icu_7614TimeZoneFormat30parseOffsetLocalizedGMTPatternERKNS_13UnicodeStringEiaRi+0x13e): undefined reference to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7614TimeZoneFormat30parseOffsetLocalizedGMTPatternERKNS_13UnicodeStringEiaRi+0x1a9): undefined reference to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseOffsetDefaultLocalizedGMT(icu_76::UnicodeString const&, int, int&) const':
(.text._ZNK6icu_7614TimeZoneFormat30parseOffsetDefaultLocalizedGMTERKNS_13UnicodeStringEiRi+0x65): undefined reference to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseOffsetLocalizedGMT(icu_76::UnicodeString const&, icu_76::ParsePosition&, signed char, signed char*) const':
(.text._ZNK6icu_7614TimeZoneFormat23parseOffsetLocalizedGMTERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0x121): undefined reference to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao):(.text._ZNK6icu_7614TimeZoneFormat23parseOffsetLocalizedGMTERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0x1bb): more undefined references to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const' follow
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseOffsetISO8601(icu_76::UnicodeString const&, icu_76::ParsePosition&, signed char, signed char*) const [clone .cold]':
(.text.unlikely._ZNK6icu_7614TimeZoneFormat18parseOffsetISO8601ERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0x4): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.unlikely._ZNK6icu_7614TimeZoneFormat18parseOffsetISO8601ERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0xc): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parseOffsetISO8601(icu_76::UnicodeString const&, icu_76::ParsePosition&, signed char, signed char*) const':
(.text._ZNK6icu_7614TimeZoneFormat18parseOffsetISO8601ERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0xaf): undefined reference to `vtable for icu_76::ParsePosition'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7614TimeZoneFormat18parseOffsetISO8601ERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0x120): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7614TimeZoneFormat18parseOffsetISO8601ERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0x1c4): undefined reference to `vtable for icu_76::ParsePosition'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7614TimeZoneFormat18parseOffsetISO8601ERKNS_13UnicodeStringERNS_13ParsePositionEaPa+0x207): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parse(UTimeZoneFormatStyle, icu_76::UnicodeString const&, icu_76::ParsePosition&, int, UTimeZoneFormatTimeType*) const [clone .cold]':
(.text.unlikely._ZNK6icu_7614TimeZoneFormat5parseE20UTimeZoneFormatStyleRKNS_13UnicodeStringERNS_13ParsePositionEiP23UTimeZoneFormatTimeType+0x2c): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzfmt.ao): in function `icu_76::TimeZoneFormat::parse(UTimeZoneFormatStyle, icu_76::UnicodeString const&, icu_76::ParsePosition&, int, UTimeZoneFormatTimeType*) const':
(.text._ZNK6icu_7614TimeZoneFormat5parseE20UTimeZoneFormatStyleRKNS_13UnicodeStringERNS_13ParsePositionEiP23UTimeZoneFormatTimeType+0x99): undefined reference to `vtable for icu_76::ParsePosition'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_7614TimeZoneFormat5parseE20UTimeZoneFormatStyleRKNS_13UnicodeStringERNS_13ParsePositionEiP23UTimeZoneFormatTimeType+0x2c6): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzgnames.ao): in function `icu_76::TZGNCore::getGenericLocationName(icu_76::UnicodeString const&)':
(.text._ZN6icu_768TZGNCore22getGenericLocationNameERKNS_13UnicodeStringE+0x1ea): undefined reference to `icu_76::SimpleFormatter::format(icu_76::UnicodeString const&, icu_76::UnicodeString&, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TZGNCore22getGenericLocationNameERKNS_13UnicodeStringE+0x342): undefined reference to `icu_76::SimpleFormatter::format(icu_76::UnicodeString const&, icu_76::UnicodeString&, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzgnames.ao): in function `icu_76::TZGNCore::getPartialLocationName(icu_76::UnicodeString const&, icu_76::UnicodeString const&, signed char, icu_76::UnicodeString const&)':
(.text._ZN6icu_768TZGNCore22getPartialLocationNameERKNS_13UnicodeStringES3_aS3_+0x288): undefined reference to `icu_76::SimpleFormatter::format(icu_76::UnicodeString const&, icu_76::UnicodeString const&, icu_76::UnicodeString&, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzgnames.ao): in function `icu_76::TZGNCore::initialize(icu_76::Locale const&, UErrorCode&)':
(.text._ZN6icu_768TZGNCore10initializeERKNS_6LocaleER10UErrorCode+0x172): undefined reference to `icu_76::SimpleFormatter::applyPatternMinMaxArguments(icu_76::UnicodeString const&, int, int, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TZGNCore10initializeERKNS_6LocaleER10UErrorCode+0x18f): undefined reference to `icu_76::SimpleFormatter::applyPatternMinMaxArguments(icu_76::UnicodeString const&, int, int, UErrorCode&)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TZGNCore10initializeERKNS_6LocaleER10UErrorCode+0x1a5): undefined reference to `icu_76::LocaleDisplayNames::createInstance(icu_76::Locale const&, UDialectHandling)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzgnames.ao): in function `icu_76::TZGNCore::TZGNCore(icu_76::Locale const&, UErrorCode&) [clone .cold]':
(.text.unlikely._ZN6icu_768TZGNCoreC2ERKNS_6LocaleER10UErrorCode+0x21): undefined reference to `icu_76::SimpleFormatter::~SimpleFormatter()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text.unlikely._ZN6icu_768TZGNCoreC2ERKNS_6LocaleER10UErrorCode+0x2d): undefined reference to `icu_76::SimpleFormatter::~SimpleFormatter()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzgnames.ao): in function `icu_76::TZGNCore::~TZGNCore()':
(.text._ZN6icu_768TZGNCoreD2Ev+0x48): undefined reference to `icu_76::SimpleFormatter::~SimpleFormatter()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZN6icu_768TZGNCoreD2Ev+0x54): undefined reference to `icu_76::SimpleFormatter::~SimpleFormatter()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tzgnames.ao): in function `icu_76::TZGNCore::formatGenericNonLocationName(icu_76::TimeZone const&, UTimeZoneGenericNameType, double, icu_76::UnicodeString&) const':
(.text._ZNK6icu_768TZGNCore28formatGenericNonLocationNameERKNS_8TimeZoneE24UTimeZoneGenericNameTypedRNS_13UnicodeStringE+0x692): undefined reference to `icu_76::UnicodeString::doCaseCompare(int, int, char16_t const*, int, int, unsigned int) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tznames_impl.ao): in function `icu_76::TextTrieMap::search(icu_76::CharacterNode*, icu_76::UnicodeString const&, int, int, icu_76::TextTrieMapSearchResultHandler*, UErrorCode&) const':
(.text._ZNK6icu_7611TextTrieMap6searchEPNS_13CharacterNodeERKNS_13UnicodeStringEiiPNS_30TextTrieMapSearchResultHandlerER10UErrorCode+0x153): undefined reference to `icu_76::UnicodeString::foldCase(unsigned int)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(tznames_impl.ao): in function `icu_76::TextTrieMap::putImpl(icu_76::UnicodeString const&, void*, UErrorCode&)':
(.text._ZN6icu_7611TextTrieMap7putImplERKNS_13UnicodeStringEPvR10UErrorCode+0x135): undefined reference to `icu_76::UnicodeString::foldCase(unsigned int)'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(format.ao): in function `icu_76::Format::parseObject(icu_76::UnicodeString const&, icu_76::Formattable&, UErrorCode&) const [clone .cold]':
(.text.unlikely._ZNK6icu_766Format11parseObjectERKNS_13UnicodeStringERNS_11FormattableER10UErrorCode+0x4): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(format.ao): in function `icu_76::Format::parseObject(icu_76::UnicodeString const&, icu_76::Formattable&, UErrorCode&) const':
(.text._ZNK6icu_766Format11parseObjectERKNS_13UnicodeStringERNS_11FormattableER10UErrorCode+0x25): undefined reference to `vtable for icu_76::ParsePosition'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text._ZNK6icu_766Format11parseObjectERKNS_13UnicodeStringERNS_11FormattableER10UErrorCode+0x57): undefined reference to `icu_76::ParsePosition::~ParsePosition()'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(format.ao): in function `icu_76::Format::getLocale(ULocDataLocaleType, UErrorCode&) const':
(.text._ZNK6icu_766Format9getLocaleE18ULocDataLocaleTypeR10UErrorCode+0x31): undefined reference to `icu_76::LocaleBased::getLocale(ULocDataLocaleType, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(format.ao): in function `icu_76::Format::getLocaleID(ULocDataLocaleType, UErrorCode&) const':
(.text._ZNK6icu_766Format11getLocaleIDE18ULocDataLocaleTypeR10UErrorCode+0x2d): undefined reference to `icu_76::LocaleBased::getLocaleID(ULocDataLocaleType, UErrorCode&) const'
/nix/store/s417mccczz3vscmsb5g9h7x040gvinfy-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/iiw1j4i5p4hlf78qd9cgwi3d4l9z4n63-icu4c-static-x86_64-unknown-linux-musl-76.1/lib/libicui18n.a(format.ao): in function `icu_76::Format::setLocaleIDs(char const*, char const*)':
(.text._ZN6icu_766Format12setLocaleIDsEPKcS2_+0x2d): undefined reference to `icu_76::LocaleBased::setLocaleIDs(char const*, char const*)'
collect2: error: ld returned 1 exit status
```