### PR TITLE
Set LINKER_LANGUAGE for doesnothing

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,6 +28,10 @@ add_dependencies(
   icalss
   icalvcal
 )
+if(WITH_CXX_BINDINGS)
+  # https://github.com/libical/libical/pull/656
+  set_property(TARGET doesnothing PROPERTY LINKER_LANGUAGE CXX)
+endif()
 
 if(NOT STATIC_ONLY)
   target_link_libraries(


### PR DESCRIPTION
This is needed for the same reason as icalrecurtest in the linked PR, as another C program linking with a C++ library.

Since the previous PR, I've learned a bit more about the situation here. As you can read in https://github.com/pkgconf/pkgconf/issues/377, it's basically an unsolved problem to use dependencies that might or might not have C++ code in them, but it's at least possible to do the right thing within a single project like this.