### PR TITLE
Fix use-after-free on icalreqstattype.debug

### DIFF
--- a/design-data/ical-value-types.csv
+++ b/design-data/ical-value-types.csv
@@ -30,7 +30,7 @@
 "CLASS","5019","(m)enum icalproperty_class","string","unitary","X=10300;PUBLIC;PRIVATE;CONFIDENTIAL;NONE=10399"
 
 "#Other non-standard",,,,
-"REQUEST-STATUS","5009","(a)struct icalreqstattype","string","unitary"
+"REQUEST-STATUS","5009","(m)struct icalreqstattype","string","unitary"
 "GEO","5004","(m)struct icalgeotype","tuple","unitary",
 "STRING","5007","(a)const char*","string","unitary",
 "X","5022","(m)const char*","string","unitary",

--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -538,6 +538,49 @@ const char *icalvalue_get_binary(const icalvalue *value)
     return (const char *) icalattach_get_data(value->data.v_attach);
 }
 
+void icalvalue_set_requeststatus(icalvalue *value, struct icalreqstattype v)
+{
+    struct icalvalue_impl *impl;
+
+    icalerror_check_arg_rv((value != 0), "value");
+
+    icalerror_check_value_type(value, ICAL_REQUESTSTATUS_VALUE);
+    impl = (struct icalvalue_impl *)value;
+
+    if (impl->data.v_requeststatus.debug != 0) {
+        icalmemory_free_buffer((void *)impl->data.v_requeststatus.debug);
+    }
+
+    impl->data.v_requeststatus = v;
+
+    if (v.debug != 0) {
+        impl->data.v_requeststatus.debug = icalmemory_strdup(v.debug);
+    }
+
+    icalvalue_reset_kind(impl);
+}
+
+icalvalue *icalvalue_new_requeststatus(struct icalreqstattype v)
+{
+    struct icalvalue_impl *impl = icalvalue_new_impl(ICAL_REQUESTSTATUS_VALUE);
+
+    icalvalue_set_requeststatus((icalvalue *) impl, v);
+    return (icalvalue *) impl;
+}
+
+struct icalreqstattype icalvalue_get_requeststatus(const icalvalue *value)
+{
+    struct icalreqstattype rs;
+
+    rs.code = ICAL_UNKNOWN_STATUS;
+    rs.desc = NULL;
+    rs.debug = NULL;
+
+    icalerror_check_arg_rx((value != 0), "value", rs);
+    icalerror_check_value_type(value, ICAL_REQUESTSTATUS_VALUE);
+    return ((struct icalvalue_impl *)value)->data.v_requeststatus;
+}
+
 /* The remaining interfaces are 'new', 'set' and 'get' for each of the value
 types */
 

--- a/src/libical/icalderivedvalue.h.in
+++ b/src/libical/icalderivedvalue.h.in
@@ -89,6 +89,10 @@ LIBICAL_ICAL_EXPORT void icalvalue_reset_kind(icalvalue *value);
 #define icalvalue_set_relatedto icalvalue_set_text
 #define icalvalue_get_relatedto icalvalue_get_text
 
+LIBICAL_ICAL_EXPORT icalvalue *icalvalue_new_requeststatus(struct icalreqstattype v);
+LIBICAL_ICAL_EXPORT struct icalreqstattype icalvalue_get_requeststatus(const icalvalue *value);
+LIBICAL_ICAL_EXPORT void icalvalue_set_requeststatus(icalvalue *value, struct icalreqstattype v);
+
 <insert_code_here>
 
 LIBICAL_ICAL_EXPORT icalvalue *icalvalue_new_class(enum icalproperty_class v);

--- a/src/libical/icaltypes.h
+++ b/src/libical/icaltypes.h
@@ -42,11 +42,10 @@ LIBICAL_ICAL_EXPORT bool icaltriggertype_is_null_trigger(struct icaltriggertype 
 
 LIBICAL_ICAL_EXPORT bool icaltriggertype_is_bad_trigger(struct icaltriggertype tr);
 
-/* struct icalreqstattype. This struct contains two string pointers,
-but don't try to free either of them. The "desc" string is a pointer
-to a static table inside the library.  Don't try to free it. The
-"debug" string is allocated in the ring buffer. Don't try to free it
-either.
+/* struct icalreqstattype. This struct contains two string pointers.
+The "desc" string is a pointer to a static table inside the library.
+Don't try to free it. The "debug" string is owned by the icalvalue
+and should not be freed manually.
 
 BTW, you would get that original string from
 *icalproperty_get_requeststatus() or icalvalue_get_text(), when

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -141,6 +141,19 @@ icalvalue *icalvalue_clone(const icalvalue *old)
         break;
     }
 
+    case ICAL_REQUESTSTATUS_VALUE: {
+        clone->data = old->data;
+        if (old->data.v_requeststatus.debug != 0) {
+            clone->data.v_requeststatus.debug = icalmemory_strdup(old->data.v_requeststatus.debug);
+            if (clone->data.v_requeststatus.debug == 0) {
+                clone->parent = 0;
+                icalvalue_free(clone);
+                return 0;
+            }
+        }
+        break;
+    }
+
     default: {
         /* all of the other types are stored as values, not
                pointers, so we can just copy the whole structure. */
@@ -814,6 +827,14 @@ void icalvalue_free(icalvalue *v)
         if (v->data.v_recur != 0) {
             icalrecurrencetype_unref(v->data.v_recur);
             v->data.v_recur = NULL;
+        }
+        break;
+    }
+
+    case ICAL_REQUESTSTATUS_VALUE: {
+        if (v->data.v_requeststatus.debug != 0) {
+            icalmemory_free_buffer((void *)v->data.v_requeststatus.debug);
+            v->data.v_requeststatus.debug = 0;
         }
         break;
     }


### PR DESCRIPTION
This was found by OSS-Fuzz in
https://issues.oss-fuzz.com/issues/392948871
https://oss-fuzz.com/testcase-detail/5183821498089472

The root cause of the use-after-free was that the `debug` string in `icalreqstattype` was allocated from a temporary ring buffer but stored in a persistent `icalvalue`. When the ring buffer wrapped, the memory was freed while still in use.

The fix required making the `debug` string persistent when stored in an `icalvalue`. This involved modifying generated files by editing their inputs:
1. Changed the generation flag for `REQUEST-STATUS` in `design-data/ical-value-types.csv` to `(m)` (manual).
2. Manually implemented `icalvalue_new/set/get_requeststatus` in `src/libical/icalderivedvalue.c.in`. The `set` function now creates a persistent copy of the `debug` string using `icalmemory_strdup`.
3. Manually added declarations for these functions in `src/libical/icalderivedvalue.h.in`.
4. Updated `icalvalue_free` in `src/libical/icalvalue.c` to free the persistent `debug` string.
5. Updated `icalvalue_clone` in `src/libical/icalvalue.c` to duplicate the persistent `debug` string, preventing double-frees.
6. Updated documentation in `src/libical/icaltypes.h`.