### PR TITLE
cppcheck fixes unusedVariable

### DIFF
--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -1654,7 +1654,6 @@ static void icaltimezone_parse_zone_tab(void)
     size_t filename_len;
     int latitude_degrees = 0, latitude_minutes = 0, latitude_seconds = 0;
     int longitude_degrees = 0, longitude_minutes = 0, longitude_seconds = 0;
-    icaltimezone zone;
 
     icalerror_assert(builtin_timezones == NULL, "Parsing zones.tab file multiple times");
 
@@ -1734,6 +1733,7 @@ static void icaltimezone_parse_zone_tab(void)
                 continue;
             }
         }
+        icaltimezone zone;
         icaltimezone_init(&zone);
         zone.location = icalmemory_strdup(location);
 


### PR DESCRIPTION
Move the `icaltimezone zone` declaration in-scope to fix an unusedVariable warning. (will be the case if compiling without builtin timezones)