### PR TITLE
Fix serializing and cloning x-components

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -280,7 +280,7 @@ char *icalcomponent_as_ical_string_r(const icalcomponent *impl)
     }
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, "END:");
-    icalmemory_append_string(&buf, &buf_ptr, &buf_size, icalcomponent_kind_to_string(kind));
+    icalmemory_append_string(&buf, &buf_ptr, &buf_size, kind_string);
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, newline);
 
     return buf;

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -139,6 +139,10 @@ icalcomponent *icalcomponent_clone(const icalcomponent *old)
         return 0;
     }
 
+    if (old->x_name) {
+        clone->x_name = icalmemory_strdup(old->x_name);
+    }
+
     for (itr = pvl_head(old->properties); itr != 0; itr = pvl_next(itr)) {
         p = (icalproperty *)pvl_data(itr);
         icalcomponent_add_property(clone, icalproperty_clone(p));

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6443,6 +6443,25 @@ static void test_icalenumarray(void)
     icalenumarray_free(array);
 }
 
+static void test_xcomponent_as_string(void)
+{
+    const char *str =
+        "BEGIN:VCALENDAR\r\n"
+        "BEGIN:X-FOO\r\n"
+        "UID:5D0D3350\r\n"
+        "END:X-FOO\r\n"
+        "END:VCALENDAR\r\n";
+
+    icalcomponent *ical = icalcomponent_new_from_string(str);
+
+    ok("Parsed VCALENDAR",
+       (ical != NULL) && icalcomponent_isa(ical) == ICAL_VCALENDAR_COMPONENT);
+
+    str_is("Assert iCalendar", icalcomponent_as_ical_string(ical), str);
+
+    icalcomponent_free(ical);
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -6620,6 +6639,7 @@ int main(int argc, char *argv[])
     test_run("Test creating multi-valued parameters", test_icalparameter_create_multivalued, do_test, do_header);
     test_run("Test string arrays", test_icalstrarray, do_test, do_header);
     test_run("Test enum arrays", test_icalenumarray, do_test, do_header);
+    test_run("Test serializing x-component", test_xcomponent_as_string, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6462,6 +6462,31 @@ static void test_xcomponent_as_string(void)
     icalcomponent_free(ical);
 }
 
+static void test_clone_xcomponent(void)
+{
+    const char *str =
+        "BEGIN:VCALENDAR\r\n"
+        "BEGIN:X-FOO\r\n"
+        "UID:5D0D3350\r\n"
+        "END:X-FOO\r\n"
+        "END:VCALENDAR\r\n";
+
+    icalcomponent *ical = icalcomponent_new_from_string(str);
+
+    ok("Parsed VCALENDAR",
+       (ical != NULL) && icalcomponent_isa(ical) == ICAL_VCALENDAR_COMPONENT);
+
+    icalcomponent *clone = icalcomponent_clone(ical);
+
+    ok("Cloned VCALENDAR",
+       (clone != NULL) && icalcomponent_isa(clone) == ICAL_VCALENDAR_COMPONENT);
+
+    str_is("Assert iCalendar", icalcomponent_as_ical_string(clone), str);
+
+    icalcomponent_free(clone);
+    icalcomponent_free(ical);
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -6640,6 +6665,7 @@ int main(int argc, char *argv[])
     test_run("Test string arrays", test_icalstrarray, do_test, do_header);
     test_run("Test enum arrays", test_icalenumarray, do_test, do_header);
     test_run("Test serializing x-component", test_xcomponent_as_string, do_test, do_header);
+    test_run("Test cloning x-component", test_clone_xcomponent, do_test, do_header);
 
     /** OPTIONAL TESTS go here... **/
 


### PR DESCRIPTION
This fixes two bugs with x-components. The `END` content line of a x-component was `END:X` instead of the name of the x-component, e.g. `END:X-FOO`. When cloning an x-component, its name wasn't set which made serialization abort.