### PR TITLE
Remove icalrecurrencetype_rscale_is_supported()

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -89,6 +89,11 @@ The following functions have been added:
 ### Removed functions
 
 * `icalrecurrencetype_clear()` has been removed.
+
+* `icalrecurrencetype_rscale_is_supported()` has been removed as
+   RSCALE=GREGORIAN is supported without libicu now.
+   Replace `icalrecurrencetype_rscale_is_supported()` calls with a true condition.
+
 * These deprecated functions have been removed:
   * `caldat()`
   * `juldat()`

--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -57,10 +57,6 @@
         <element name="ICAL_BY_SETPOS_SIZE"/>
         <element name="ICAL_BY_DAY_SIZE"/>
     </enum>
-    <method name="i_cal_recurrence_rscale_is_supported" corresponds="icalrecurrencetype_rscale_is_supported" kind="get" since="2.0">
-	<returns type="gboolean" comment="Whether rscale is supported"/>
-	<comment xml:space="preserve">Checks whether rscale is supported.</comment>
-    </method>
     <method name="i_cal_recurrence_rscale_supported_calendars" corresponds="icalrecurrencetype_rscale_supported_calendars" kind="other" since="2.0">
 	<returns type="ICalArray *" annotation="transfer full" translator_argus="NULL, FALSE" comment="Array of calendars. Currently always NULL."/>
 	<comment xml:space="preserve">Gets an array of calendars supporting rscale (currently always return NULL).</comment>

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -173,11 +173,6 @@ static ICAL_GLOBAL_VAR ical_invalid_rrule_handling invalidRruleHandling = ICAL_R
 
 #define LEAP_MONTH 0x1000
 
-bool icalrecurrencetype_rscale_is_supported(void)
-{
-    return true;
-}
-
 /****************** Forward declarations ******************/
 static void icalrecurrencetype_clear(struct icalrecurrencetype *recur);
 static short daymask_find_next_bit(const unsigned long *days, short start_idx);
@@ -564,14 +559,9 @@ static int icalrecur_add_byrules(struct icalrecur_parser *parser, icalrecurrence
         if (*t) {
             /* Check for leap month suffix (RSCALE only) */
             if (by == &parser->rt->by[ICAL_BY_MONTH] && strcmp(t, "L") == 0) {
-                /* cppcheck-suppress knownConditionTrueFalse; we might return false some day */
-                if (icalrecurrencetype_rscale_is_supported()) {
-                    /* The "L" suffix in a BYMONTH recur-rule-part
-                       is encoded by setting a high-order bit */
-                    v |= LEAP_MONTH;
-                } else {
-                    return -2;
-                }
+                /* The "L" suffix in a BYMONTH recur-rule-part
+                    is encoded by setting a high-order bit */
+                v |= LEAP_MONTH;
             } else {
                 return -1;
             }

--- a/src/libical/icalrecur.h
+++ b/src/libical/icalrecur.h
@@ -219,8 +219,6 @@ LIBICAL_ICAL_EXPORT void icalrecurrencetype_ref(struct icalrecurrencetype *recur
  */
 LIBICAL_ICAL_EXPORT void icalrecurrencetype_unref(struct icalrecurrencetype *recur);
 
-LIBICAL_ICAL_EXPORT bool icalrecurrencetype_rscale_is_supported(void);
-
 LIBICAL_ICAL_EXPORT icalarray *icalrecurrencetype_rscale_supported_calendars(void);
 
 /**


### PR DESCRIPTION
icalrecurrencetype_rscale_is_supported always returned true because we support RSCALE=GREGORIAN even without libicu.

fixes: #954