### PR TITLE
Remove the PVL_USE_MACROS conditional compile macro

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -22,6 +22,11 @@ you can handle code that no longer exists in 4.0 with:
      #endif
 ```
 
+## PVL_USE_MACROS
+
+The `PVL_USE_MACROS` conditional compile macro is removed.
+The pvl unit always compiles the `pvl_data` function and never uses the macro version.
+
 ## C library
 
 ### Modified functions

--- a/scripts/buildtests.sh
+++ b/scripts/buildtests.sh
@@ -456,7 +456,6 @@ CPPCHECK() {
     -D _fallthrough="" \
     -D MIN="" \
     -D sleep="" \
-    -U PVL_USE_MACROS \
     -I "$TOP/src/libical" \
     -I "$TOP/src/libicalss" \
     -I "$TOP/src/libicalvcal" \

--- a/src/libical/pvl.c
+++ b/src/libical/pvl.c
@@ -44,14 +44,13 @@ static ICAL_GLOBAL_VAR int pvl_elem_count = 0;
 static ICAL_GLOBAL_VAR int pvl_list_count = 0;
 
 /**
-  struct pvl_list_t
-
-  The list structure. This is the handle for the entire list
-
-  This type is also private. Use pvl_list instead
-
-  */
-
+ *  struct pvl_list_t
+ *
+ * The list structure. This is the handle for the entire list
+ *
+ * This type is private. Always use pvl_list instead.
+ *
+ */
 typedef struct pvl_list_t {
     int MAGIC;               /**< Magic Identifier */
     struct pvl_elem_t *head; /**< Head of list */
@@ -59,6 +58,20 @@ typedef struct pvl_list_t {
     int count;               /**< Number of items in the list */
     struct pvl_elem_t *p;    /**< Pointer used for iterators */
 } pvl_list_t;
+
+/**
+ * struct pvl_elem_t
+ *
+ * The element structure.
+ *
+ * This type is private. Always use pvl_elem instead.
+ */
+typedef struct pvl_elem_t {
+    int MAGIC;                /**< Magic Identifier */
+    void *d;                  /**< Pointer to data user is storing */
+    struct pvl_elem_t *next;  /**< Next element */
+    struct pvl_elem_t *prior; /**< Prior element */
+} pvl_elem_t;
 
 /**
  * @brief Creates a new list, clears the pointers and assigns a magic number
@@ -501,7 +514,6 @@ pvl_elem pvl_tail(pvl_list L)
     return (pvl_elem)L->tail;
 }
 
-#if !defined(PVL_USE_MACROS)
 void *pvl_data(pvl_elem E)
 {
     if (E == 0) {
@@ -510,8 +522,6 @@ void *pvl_data(pvl_elem E)
 
     return E->d;
 }
-
-#endif
 
 /**
  * @brief Call a function for every item in the list.

--- a/src/libical/pvl.h
+++ b/src/libical/pvl.h
@@ -14,19 +14,6 @@
 typedef struct pvl_list_t *pvl_list;
 typedef struct pvl_elem_t *pvl_elem;
 
-/**
- * This type is private. Always use pvl_elem instead. The struct would
- * not even appear in this header except to make code in the USE_MACROS
- * blocks work
- */
-
-typedef struct pvl_elem_t {
-    int MAGIC;                /**< Magic Identifier */
-    void *d;                  /**< Pointer to data user is storing */
-    struct pvl_elem_t *next;  /**< Next element */
-    struct pvl_elem_t *prior; /**< Prior element */
-} pvl_elem_t;
-
 /* Create new lists or elements */
 LIBICAL_ICAL_EXPORT pvl_elem pvl_new_element(void *d, pvl_elem next, pvl_elem prior);
 
@@ -70,11 +57,7 @@ LIBICAL_ICAL_EXPORT pvl_elem pvl_next(pvl_elem e);
 LIBICAL_ICAL_EXPORT pvl_elem pvl_prior(pvl_elem e);
 
 /* get the data in the list */
-#if !defined(PVL_USE_MACROS)
 LIBICAL_ICAL_EXPORT void *pvl_data(pvl_elem);
-#else
-#define pvl_data(x) x == 0 ? 0 : ((struct pvl_elem_t *)x)->d;
-#endif
 
 /* Find an element for which a function returns true */
 typedef int (*pvl_findf)(void *a, void *b); /*a is list elem, b is other data */


### PR DESCRIPTION
always use  the pvl_data() function but compile it as an inline

fixes: #977