### PR TITLE
pkg-config: Split the pkg-config files per library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,6 +992,32 @@ if(LIBICAL_DEVMODE)
 endif()
 libical_option(LIBICAL_BUILD_EXAMPLES "Build examples." True)
 
+########### Configure pkg-config variables #########
+
+set(VERSION "${CMAKE_PROJECT_VERSION}")
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}")
+if(IS_ABSOLUTE ${LIB_INSTALL_DIR})
+  set(libdir "${LIB_INSTALL_DIR}")
+else()
+  set(libdir "\${prefix}/${LIB_INSTALL_DIR}")
+endif()
+if(IS_ABSOLUTE ${INCLUDE_INSTALL_DIR})
+  set(includedir "${INCLUDE_INSTALL_DIR}")
+else()
+  set(includedir "\${prefix}/include")
+endif()
+if(CMAKE_THREAD_LIBS_INIT)
+  set(PTHREAD_LIBS_PRIVATE "\nLibs.private: ${CMAKE_THREAD_LIBS_INIT}")
+else()
+  set(PTHREAD_LIBS_PRIVATE "")
+endif()
+if(ICU_FOUND)
+  set(REQUIRES_PRIVATE_ICU "\nRequires.private: icu-i18n")
+else()
+  set(REQUIRES_PRIVATE_ICU "")
+endif()
+
 ################# build subdirs ########################
 
 if(CMAKE_C_COMPILER_IS_GCC OR CMAKE_C_COMPILER_IS_CLANG)
@@ -1048,35 +1074,6 @@ if(ICAL_BUILD_DOCS)
 else()
   set(ICAL_GLIB_BUILD_DOCS)
 endif()
-
-########### create and install pkg-config file #########
-
-set(VERSION "${CMAKE_PROJECT_VERSION}")
-set(prefix "${CMAKE_INSTALL_PREFIX}")
-set(exec_prefix "\${prefix}")
-if(IS_ABSOLUTE ${LIB_INSTALL_DIR})
-  set(libdir "${LIB_INSTALL_DIR}")
-else()
-  set(libdir "\${exec_prefix}/${LIB_INSTALL_DIR}")
-endif()
-if(IS_ABSOLUTE ${INCLUDE_INSTALL_DIR})
-  set(includedir "${INCLUDE_INSTALL_DIR}")
-else()
-  set(includedir "\${prefix}/include")
-endif()
-if(DEFINED CMAKE_THREAD_LIBS_INIT)
-  set(PTHREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}")
-else()
-  set(PTHREAD_LIBS "")
-endif()
-if(ICU_FOUND)
-  set(REQUIRES_PRIVATE_ICU "Requires.private: icu-i18n") #for libical.pc
-else()
-  set(REQUIRES_PRIVATE_ICU "")
-endif()
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libical.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libical.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libical.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
 
 ########### Create and install the CMake Config files ##########
 include(CMakePackageConfigHelpers)

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -267,7 +267,7 @@ check_type_size(
   SIZEOF_WINT_T
 )
 
-include(FindThreads)
+find_package(Threads)
 check_library_exists(
   pthread
   pthread_attr_get_np

--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -363,6 +363,9 @@ if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(TARGETS ical-static EXPORT icalTargets DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libical.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libical.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libical.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+
 ########### next target ###############
 
 if(WITH_CXX_BINDINGS)

--- a/src/libical/libical.pc.in
+++ b/src/libical/libical.pc.in
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 
 prefix=@prefix@
-exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
 Name: libical
 Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @CMAKE_PROJECT_VERSION@
-Libs: -L${libdir} -lical -licalss -licalvcal -licalvcard
-Libs.private: @PTHREAD_LIBS@
-@REQUIRES_PRIVATE_ICU@
+Libs: -L${libdir} -lical@PTHREAD_LIBS_PRIVATE@@REQUIRES_PRIVATE_ICU@
 Cflags: -I${includedir}

--- a/src/libicalss/CMakeLists.txt
+++ b/src/libicalss/CMakeLists.txt
@@ -171,6 +171,9 @@ if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(TARGETS icalss-static EXPORT icalTargets DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libicalss.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libicalss.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libicalss.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+
 ########### next target ###############
 
 if(WITH_CXX_BINDINGS)

--- a/src/libicalss/libicalss.pc.in
+++ b/src/libicalss/libicalss.pc.in
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright Contributors to the libical project
+# SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libicalss
+Description: @CMAKE_PROJECT_DESCRIPTION@ (Storage Support)
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @CMAKE_PROJECT_VERSION@
+Libs: -L${libdir} -licalss@PTHREAD_LIBS_PRIVATE@
+Requires: libical
+Cflags: -I${includedir}

--- a/src/libicalvcal/CMakeLists.txt
+++ b/src/libicalvcal/CMakeLists.txt
@@ -103,6 +103,9 @@ if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(TARGETS icalvcal-static EXPORT icalTargets DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libicalvcal.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libicalvcal.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libicalvcal.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+
 ########### install files ###############
 
 install(

--- a/src/libicalvcal/libicalvcal.pc.in
+++ b/src/libicalvcal/libicalvcal.pc.in
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright Contributors to the libical project
+# SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libicalvcal
+Description: @CMAKE_PROJECT_DESCRIPTION@ (VCal)
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @CMAKE_PROJECT_VERSION@
+Libs: -L${libdir} -licalvcal
+Requires: libical
+Cflags: -I${includedir}

--- a/src/libicalvcard/CMakeLists.txt
+++ b/src/libicalvcard/CMakeLists.txt
@@ -279,6 +279,9 @@ if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
   install(TARGETS icalvcard-static EXPORT icalTargets DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libicalvcard.pc.in ${CMAKE_CURRENT_BINARY_DIR}/icalvcard.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libicalvcard.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+
 ########### install files ###############
 
 install(

--- a/src/libicalvcard/libicalvcard.pc.in
+++ b/src/libicalvcard/libicalvcard.pc.in
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright Contributors to the libical project
+# SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+
+prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libicalvcard
+Description: @CMAKE_PROJECT_DESCRIPTION@ (VCard)
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @CMAKE_PROJECT_VERSION@
+Libs: -L${libdir} -licalvcard
+Requires: libical
+Cflags: -I${includedir}


### PR DESCRIPTION
Allow consumers to only link the the library they need.

Closes: #983