### PR TITLE
libicalvcard API fixes

### DIFF
--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -567,71 +567,7 @@ void vcardcomponent_strip_errors(vcardcomponent *comp)
         }
     }
 }
-#if 0
-/* Hack. This will change the state of the iterators */
-void vcardcomponent_convert_errors(vcardcomponent *comp)
-{
-    vcardproperty *p, *next_p;
-    vcardcomponent *c;
 
-    for (p = vcardcomponent_get_first_property(card, VCARD_ANY_PROPERTY); p != 0; p = next_p) {
-
-        next_p = vcardcomponent_get_next_property(card, VCARD_ANY_PROPERTY);
-
-        if (vcardproperty_isa(p) == VCARD_XLICERROR_PROPERTY) {
-            struct icalreqstattype rst;
-            icalparameter *param =
-                vcardproperty_get_first_parameter(p, VCARD_XLICERRORTYPE_PARAMETER);
-
-            rst.code = ICAL_UNKNOWN_STATUS;
-            rst.desc = 0;
-
-            switch (vcardparameter_get_xlicerrortype(param)) {
-
-            case ICAL_XLICERRORTYPE_PARAMETERNAMEPARSEERROR:{
-                    rst.code = ICAL_3_2_INVPARAM_STATUS;
-                    break;
-                }
-            case ICAL_XLICERRORTYPE_PARAMETERVALUEPARSEERROR:{
-                    rst.code = ICAL_3_3_INVPARAMVAL_STATUS;
-                    break;
-                }
-            case ICAL_XLICERRORTYPE_PROPERTYPARSEERROR:{
-                    rst.code = ICAL_3_0_INVPROPNAME_STATUS;
-                    break;
-                }
-            case ICAL_XLICERRORTYPE_VALUEPARSEERROR:{
-                    rst.code = ICAL_3_1_INVPROPVAL_STATUS;
-                    break;
-                }
-            case ICAL_XLICERRORTYPE_CARDPARSEERROR:{
-                    rst.code = ICAL_3_4_INVCOMP_STATUS;
-                    break;
-                }
-
-            default:{
-                    break;
-                }
-            }
-            if (rst.code != ICAL_UNKNOWN_STATUS) {
-
-                rst.debug = vcardproperty_get_xlicerror(p);
-                vcardcomponent_add_property(card, vcardproperty_new_requeststatus(rst));
-
-                vcardcomponent_remove_property(card, p);
-                vcardproperty_free(p);
-                p = NULL;
-            }
-        }
-    }
-
-    for (c = vcardcomponent_get_first_card(card, ICAL_ANY_CARD);
-         c != 0; c = vcardcomponent_get_next_card(card, ICAL_ANY_CARD)) {
-
-        vcardcomponent_convert_errors(c);
-    }
-}
-#endif
 struct vcardcomponent_kind_map {
     vcardcomponent_kind kind;
     char name[20];

--- a/src/libicalvcard/vcardcomponent.h
+++ b/src/libicalvcard/vcardcomponent.h
@@ -91,13 +91,6 @@ LIBICAL_VCARD_EXPORT vcardcomponent_kind vcardcomponent_string_to_kind(const cha
 
 LIBICAL_VCARD_EXPORT const char *vcardcomponent_kind_to_string(vcardcomponent_kind kind);
 
-/**
- *  This takes 2 VCARD components and merges the second one into the first.
- *  comp_to_merge will no longer exist after calling this function.
- */
-LIBICAL_VCARD_EXPORT void vcardcomponent_merge_component(vcardcomponent *comp,
-                                                         vcardcomponent *comp_to_merge);
-
 /* Iteration Routines. There are two forms of iterators, internal and
 external. The internal ones came first, and are almost completely
 sufficient, but they fail badly when you want to construct a loop that
@@ -131,13 +124,6 @@ LIBICAL_VCARD_EXPORT vcardproperty *vcardcomponent_get_first_property(vcardcompo
 LIBICAL_VCARD_EXPORT vcardproperty *vcardcomponent_get_next_property(vcardcomponent *component,
                                                                      vcardproperty_kind kind);
 
-/**
- *  This takes 2 VCARD components and merges the second one into the first.
- *  comp_to_merge will no longer exist after calling this function.
- */
-LIBICAL_VCARD_EXPORT void vcardcomponent_merge_card(vcardcomponent *card,
-                                                    vcardcomponent *card_to_merge);
-
 /***** Working with embedded error properties *****/
 
 /* Check the component against itip rules and insert error properties*/
@@ -153,9 +139,6 @@ LIBICAL_VCARD_EXPORT int vcardcomponent_count_errors(vcardcomponent *card);
 
 /** @brief Removes all X-LIC-ERROR properties*/
 LIBICAL_VCARD_EXPORT void vcardcomponent_strip_errors(vcardcomponent *card);
-
-/** @brief Converts some X-LIC-ERROR properties into RETURN-STATUS properties*/
-LIBICAL_VCARD_EXPORT void vcardcomponent_convert_errors(vcardcomponent *card);
 
 /**
  * @brief Normalizes (reorders and sorts the properties) the specified vcard @p comp.

--- a/src/libicalvcard/vcardderivedvalue.h.in
+++ b/src/libicalvcard/vcardderivedvalue.h.in
@@ -62,7 +62,7 @@ typedef enum vcard_clientpidmap_field {
     VCARD_CLIENTPIDMAP_ID = 0,
     VCARD_CLIENTPIDMAP_URI,
     VCARD_NUM_CLIENTPIDMAP_FIELDS
-} vcard_clientidmap_field;
+} vcard_clientpidmap_field;
 
 typedef struct vcardvalue_impl vcardvalue;
 

--- a/src/libicalvcard/vcardvalue.h
+++ b/src/libicalvcard/vcardvalue.h
@@ -43,16 +43,6 @@ LIBICAL_VCARD_EXPORT const char *vcardvalue_kind_to_string(const vcardvalue_kind
 /** Check validity of a specific vcardvalue_kind **/
 LIBICAL_VCARD_EXPORT bool vcardvalue_kind_is_valid(const vcardvalue_kind kind);
 
-/** Encode a character string in ical format, escape certain characters, etc. */
-LIBICAL_VCARD_EXPORT int vcardvalue_encode_ical_string(const char *szText,
-                                                       char *szEncText,
-                                                       int MaxBufferLen);
-
-/** Extract the original character string encoded by the above function **/
-LIBICAL_VCARD_EXPORT int vcardvalue_decode_ical_string(const char *szText,
-                                                       char *szDecText,
-                                                       int nMaxBufferLen);
-
 /* Duplicate and dequote a TEXT value */
 LIBICAL_VCARD_EXPORT char *vcardvalue_strdup_and_dequote_text(const char **str,
                                                               const char *sep);


### PR DESCRIPTION
There are few public declarations in the vcard library, which do not have their bodies in the code, thus rather remove them. There's also a  typo in an enum name. Found it during https://github.com/libical/libical/issues/844 .

Closes https://github.com/libical/libical/issues/985