### PR TITLE
libical-glib: Add enum array append/add functions

### DIFF
--- a/src/libical-glib/api/i-cal-enum-array.xml
+++ b/src/libical-glib/api/i-cal-enum-array.xml
@@ -19,16 +19,70 @@
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be freed"/>
 		<comment xml:space="preserve">Frees the #ICalEnumArray.</comment>
 	</method>
+	<method name="i_cal_enum_array_element_append_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to append"/>
+		<comment xml:space="preserve">Appends an integer value to the @array. See also i_cal_enum_array_element_add_value(), i_cal_enum_array_element_append_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_element_append_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
+		<comment xml:space="preserve">Appends an X (custom) value to the @array. See also i_cal_enum_array_element_add_x_value(), i_cal_enum_array_element_append_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_element_add_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to append"/>
+		<comment xml:space="preserve">Adds an integer value to the @array, omitting duplicates. See also i_cal_enum_array_element_append_value(), i_cal_enum_array_element_add_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_element_add_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
+		<comment xml:space="preserve">Adds an X (custom) value to the @array, omitting duplicates. See also i_cal_enum_array_element_append_x_value(), i_cal_enum_array_element_add_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
 	<method name="i_cal_enumarray_remove_element_at" corresponds="icalenumarray_remove_element_at" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array"  comment="The #ICalEnumArray to be modified"/>
 		<parameter type="gint" name="position" comment="The position in which the element will be removed from the array"/>
 		<comment xml:space="preserve">Removes the element at the @position from the array.</comment>
 	</method>
-	<method name="i_cal_enumarray_element_at" corresponds="icalenumarray_element_at" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_element_get_value_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be queried"/>
 		<parameter type="gint" name="position" comment="The position the target element is located"/>
-		<returns type="const icalenumarray_element *" annotation="transfer none, nullable" comment="The element located at the @position in the @array"/>
-		<comment xml:space="preserve">Gets the element located in the @position in the @array. NULL if position if out of bound.</comment>
+		<returns type="gint" comment="The element integer value located at the @position in the @array"/>
+		<comment xml:space="preserve">Gets the element integer value located in the @position in the @array. Zero if position is out of bounds.</comment>
+		<custom>    const icalenumarray_element *elem;
+    g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), 0);
+    elem = icalenumarray_element_at((icalenumarray *)i_cal_object_get_native((ICalObject *)array), position);
+    if (elem == NULL)
+        return 0;
+    return elem->val;</custom>
+	</method>
+	<method name="i_cal_enum_array_element_get_xvalue_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be queried"/>
+		<parameter type="gint" name="position" comment="The position the target element is located"/>
+		<returns type="const gchar *" annotation="transfer none,nullable" comment="The element X value located at the @position in the @array"/>
+		<comment xml:space="preserve">Gets the element X value located in the @position in the @array. %NULL if position is out of bounds.</comment>
+		<custom>    const icalenumarray_element *elem;
+    g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), 0);
+    elem = icalenumarray_element_at((icalenumarray *)i_cal_object_get_native((ICalObject *)array), position);
+    if (elem == NULL)
+        return 0;
+    return elem->xvalue;</custom>
 	</method>
 	<method name="i_cal_enumarray_sort" corresponds="icalenumarray_sort" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be sorted"/>


### PR DESCRIPTION
Rather than adding a wrapper around the array element type, I decided to create special functions for the two members of the array. It had been simpler memory wise and in the code too, for a price of diverging from the libical non-glib API.