### PR TITLE
icaltime: Populate icaltimetype::zone on convert

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -294,7 +294,8 @@ icaltime_t icaltime_as_timet_with_zone(const struct icaltimetype tt, const icalt
     local_tt.is_date = 0;
 
     /* Use our timezone functions to convert to UTC. */
-    icaltimezone_convert_time(&local_tt, (icaltimezone *)zone, utc_zone);
+    if (tt.zone != utc_zone)
+        icaltimezone_convert_time(&local_tt, (icaltimezone *)zone, utc_zone);
 
     /* Copy the icaltimetype to a struct tm. */
     memset(&stm, 0, sizeof(struct tm));

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -802,6 +802,7 @@ void icaltimezone_convert_time(struct icaltimetype *tt,
        of our UTC time and adding it. */
     utc_offset = icaltimezone_get_utc_offset_of_utc_time(to_zone, tt, &is_daylight);
     tt->is_daylight = is_daylight;
+    tt->zone = to_zone;
     icaltime_adjust(tt, 0, 0, 0, utc_offset);
 }
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6573,6 +6573,38 @@ static void test_clone_xcomponent(void)
     icalcomponent_free(ical);
 }
 
+static void test_icaltime_proper_zone(void)
+{
+    icaltimetype first, second;
+    icaltimezone *utc = icaltimezone_get_utc_timezone();
+    icaltimezone *first_zone = icaltimezone_get_builtin_timezone("Europe/Brussels");
+    icaltimezone *second_zone = icaltimezone_get_builtin_timezone("America/New_York");
+
+    first = icaltime_current_time_with_zone(first_zone);
+    ok("first::zone is not NULL", (icaltime_get_timezone(first) != NULL));
+    ok("first::zone is not UTC", (icaltime_get_timezone(first) != utc));
+    ok("first::zone preserves zone", (icaltime_get_timezone(first) == first_zone));
+
+    second = icaltime_current_time_with_zone(second_zone);
+    ok("second::zone is not NULL", (icaltime_get_timezone(second) != NULL));
+    ok("second::zone is not UTC", (icaltime_get_timezone(second) != utc));
+    ok("second::zone preserves zone", (icaltime_get_timezone(second) == second_zone));
+
+    ok("first is before or same with the second", (icaltime_compare(first, second) <= 0));
+
+    second = first;
+    ok("first is the same as the second after assignment", (icaltime_compare(first, second) == 0));
+    ok("second::zone is first zone", (icaltime_get_timezone(second) == first_zone));
+
+    icaltimezone_convert_time(&first, first_zone, second_zone);
+    ok("converted first::zone is second zone", (icaltime_get_timezone(first) == second_zone));
+    ok("first is the same as the second after first's convert", (icaltime_compare(first, second) == 0));
+
+    second = icaltime_convert_to_zone(second, utc);
+    ok("converted second::zone is UTC", (icaltime_get_timezone(second) == utc));
+    ok("first is the same as the second after second's convert", (icaltime_compare(first, second) == 0));
+}
+
 int main(int argc, char *argv[])
 {
 #if !defined(HAVE_UNISTD_H)
@@ -6754,8 +6786,9 @@ int main(int argc, char *argv[])
     test_run("Test enum arrays", test_icalenumarray, do_test, do_header);
     test_run("Test serializing x-component", test_xcomponent_as_string, do_test, do_header);
     test_run("Test cloning x-component", test_clone_xcomponent, do_test, do_header);
-
     test_run("Test manipulating tzid", test_tzid_setter, do_test, do_header);
+    test_run("Test icaltime proper zone set", test_icaltime_proper_zone, do_test, do_header);
+
     /** OPTIONAL TESTS go here... **/
 
 #if defined(WITH_CXX_BINDINGS)


### PR DESCRIPTION
When the icaltimetype structure is converted to a different time zone, its 'zone' member should be updated as well, to reflect the actual zone the time structure represents.

Closes https://github.com/libical/libical/issues/571