### PR TITLE
libical-glib: Hide some target options in the installed CMake files

### DIFF
--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -24,16 +24,17 @@ if(NOT DEFINED LIBXML2_DEFINITIONS)
 endif()
 target_compile_options(
   ical-glib-src-generator
-  PUBLIC
+  PRIVATE
     ${GLIB_CFLAGS}
     ${LIBXML2_DEFINITIONS}
     -DG_LOG_DOMAIN=\"src-generator\"
 )
 target_link_libraries(
   ical-glib-src-generator
-  ${GLIB_LDFLAGS}
-  ${GOBJECT_LDFLAGS}
-  ${LIBXML2_LIBRARIES}
+  PRIVATE
+    ${GLIB_LDFLAGS}
+    ${GOBJECT_LDFLAGS}
+    ${LIBXML2_LIBRARIES}
 )
 
 install(


### PR DESCRIPTION
The build paths could be shown in the installed .cmake files, thus hide them from there, because they are needed.

Closes https://github.com/libical/libical/issues/532