### PR TITLE
libical-glib: Add missing enum/str array APIs

### DIFF
--- a/src/libical-glib/api/i-cal-enum-array.xml
+++ b/src/libical-glib/api/i-cal-enum-array.xml
@@ -4,65 +4,15 @@
   SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 -->
 
- <structure namespace="ICal" name="EnumArray" native="icalenumarray" destroy_func="icalenumarray_free">
-	<method name="i_cal_enumarray_size" corresponds="icalenumarray_size" kind="other" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
-		<returns type="gint" comment="The size of current array."/>
-		<comment>Gets the size of the array.</comment>
+<structure namespace="ICal" name="EnumArray" native="icalenumarray" destroy_func="icalenumarray_free">
+	<method name="i_cal_enum_array_new" corresponds="icalenumarray_new" kind="constructor" since="4.0">
+		<parameter type="gint" name="increment_size" comment="how many slots to allocate on array expansion"/>
+		<returns type="ICalEnumArray *" annotation="transfer full" comment="a new #ICalEnumArray."/>
+		<comment>Creates a new #ICalEnumArray.</comment>
 	</method>
-	<method name="i_cal_enumarray_clone" corresponds="icalenumarray_clone" kind="clone" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" annotation="in" comment="The #ICalEnumArray to be cloned"/>
-		<returns type="ICalEnumArray *" annotation="transfer full" translator_argus="NULL" comment="The newly cloned #ICalEnumArray with the same value as the @array"/>
-		<comment xml:space="preserve">Creates a deep copy of #ICalEnumArray with the same properties as the @array.</comment>
-	</method>
-	<method name="i_cal_enumarray_free" corresponds="icalenumarray_free" annotation="skip" kind="destructor" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be freed"/>
-		<comment xml:space="preserve">Frees the #ICalEnumArray.</comment>
-	</method>
-	<method name="i_cal_enum_array_element_append_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
-		<parameter type="gint" name="value" comment="The integer value to append"/>
-		<comment xml:space="preserve">Appends an integer value to the @array. See also i_cal_enum_array_element_add_value(), i_cal_enum_array_element_append_x_value()</comment>
-		<custom>    icalenumarray_element elem = { 0 };
-    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
-    elem.val = value;
-    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
-	</method>
-	<method name="i_cal_enum_array_element_append_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
-		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
-		<comment xml:space="preserve">Appends an X (custom) value to the @array. See also i_cal_enum_array_element_add_x_value(), i_cal_enum_array_element_append_value()</comment>
-		<custom>    icalenumarray_element elem = { 0 };
-    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
-    elem.xvalue = xvalue;
-    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
-	</method>
-	<method name="i_cal_enum_array_element_add_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
-		<parameter type="gint" name="value" comment="The integer value to append"/>
-		<comment xml:space="preserve">Adds an integer value to the @array, omitting duplicates. See also i_cal_enum_array_element_append_value(), i_cal_enum_array_element_add_x_value()</comment>
-		<custom>    icalenumarray_element elem = { 0 };
-    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
-    elem.val = value;
-    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
-	</method>
-	<method name="i_cal_enum_array_element_add_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
-		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
-		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
-		<comment xml:space="preserve">Adds an X (custom) value to the @array, omitting duplicates. See also i_cal_enum_array_element_append_x_value(), i_cal_enum_array_element_add_value()</comment>
-		<custom>    icalenumarray_element elem = { 0 };
-    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
-    elem.xvalue = xvalue;
-    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
-	</method>
-	<method name="i_cal_enumarray_remove_element_at" corresponds="icalenumarray_remove_element_at" kind="other" since="4.0">
-		<parameter type="ICalEnumArray *" name="array"  comment="The #ICalEnumArray to be modified"/>
-		<parameter type="gint" name="position" comment="The position in which the element will be removed from the array"/>
-		<comment xml:space="preserve">Removes the element at the @position from the array.</comment>
-	</method>
-	<method name="i_cal_enum_array_element_get_value_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_get_value_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be queried"/>
-		<parameter type="gint" name="position" comment="The position the target element is located"/>
+		<parameter type="gsize" name="position" comment="The position the target element is located"/>
 		<returns type="gint" comment="The element integer value located at the @position in the @array"/>
 		<comment xml:space="preserve">Gets the element integer value located in the @position in the @array. Zero if position is out of bounds.</comment>
 		<custom>    const icalenumarray_element *elem;
@@ -72,19 +22,112 @@
         return 0;
     return elem->val;</custom>
 	</method>
-	<method name="i_cal_enum_array_element_get_xvalue_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_get_xvalue_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be queried"/>
-		<parameter type="gint" name="position" comment="The position the target element is located"/>
+		<parameter type="gsize" name="position" comment="The position the target element is located"/>
 		<returns type="const gchar *" annotation="transfer none,nullable" comment="The element X value located at the @position in the @array"/>
 		<comment xml:space="preserve">Gets the element X value located in the @position in the @array. %NULL if position is out of bounds.</comment>
 		<custom>    const icalenumarray_element *elem;
-    g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), 0);
+    g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), NULL);
     elem = icalenumarray_element_at((icalenumarray *)i_cal_object_get_native((ICalObject *)array), position);
     if (elem == NULL)
-        return 0;
+        return NULL;
     return elem->xvalue;</custom>
 	</method>
-	<method name="i_cal_enumarray_sort" corresponds="icalenumarray_sort" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_size" corresponds="icalenumarray_size" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<returns type="gsize" error_return_value="((gsize)-1)" comment="The size of current array."/>
+		<comment>Gets the size of the array.</comment>
+	</method>
+	<method name="i_cal_enum_array_find_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to search for"/>
+		<returns type="gsize" error_return_value="((gsize)-1)" comment="The index of the value in the @array, or an index out of bounds, if not found."/>
+		<comment xml:space="preserve">Searches for an integer value in the @array. See also i_cal_enum_array_find_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), (gsize) -1);
+    elem.val = value;
+    return icalenumarray_find((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_find_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to search for"/>
+		<returns type="gsize" error_return_value="((gsize)-1)" comment="The index of the value in the @array, or an index out of bounds, if not found."/>
+		<comment xml:space="preserve">Searches for an integer value in the @array. See also i_cal_enum_array_find_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), (gsize) -1);
+    elem.xvalue = xvalue;
+    return icalenumarray_find((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_append_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to append"/>
+		<comment xml:space="preserve">Appends an integer value to the @array. See also i_cal_enum_array_add_value(), i_cal_enum_array_append_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_append_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
+		<comment xml:space="preserve">Appends an X (custom) value to the @array. See also i_cal_enum_array_add_x_value(), i_cal_enum_array_append_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_add_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to append"/>
+		<comment xml:space="preserve">Adds an integer value to the @array, omitting duplicates. See also i_cal_enum_array_append_value(), i_cal_enum_array_add_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_add_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
+		<comment xml:space="preserve">Adds an X (custom) value to the @array, omitting duplicates. See also i_cal_enum_array_append_x_value(), i_cal_enum_array_add_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_remove_element_at" corresponds="icalenumarray_remove_element_at" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array"  comment="The #ICalEnumArray to be modified"/>
+		<parameter type="gsize" name="position" comment="The position in which the element will be removed from the array"/>
+		<comment xml:space="preserve">Removes the element at the @position from the array.</comment>
+	</method>
+	<method name="i_cal_enum_array_remove_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to remove"/>
+		<comment xml:space="preserve">Removes all occurrences of an integer value from the @array. See also i_cal_enum_array_remove_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_remove((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_remove_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to remove"/>
+		<comment xml:space="preserve">Removes all occurrences of an X (custom) value from the @array. See also i_cal_enum_array_remove_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_remove((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_free" corresponds="icalenumarray_free" annotation="skip" kind="destructor" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be freed"/>
+		<comment xml:space="preserve">Frees the #ICalEnumArray.</comment>
+	</method>
+	<method name="i_cal_enum_array_sort" corresponds="icalenumarray_sort" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be sorted"/>
+	</method>
+	<method name="i_cal_enum_array_clone" corresponds="icalenumarray_clone" kind="clone" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" annotation="in" comment="The #ICalEnumArray to be cloned"/>
+		<returns type="ICalEnumArray *" annotation="transfer full" translator_argus="NULL" comment="The newly cloned #ICalEnumArray with the same value as the @array"/>
+		<comment xml:space="preserve">Creates a deep copy of #ICalEnumArray with the same properties as the @array.</comment>
 	</method>
 </structure>

--- a/src/libical-glib/api/i-cal-str-array.xml
+++ b/src/libical-glib/api/i-cal-str-array.xml
@@ -5,32 +5,58 @@
 -->
 
  <structure namespace="ICal" name="StrArray" native="icalstrarray" destroy_func="icalstrarray_free">
-	<method name="i_cal_strarray_size" corresponds="icalstrarray_size" kind="other" since="4.0">
-		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray"/>
-		<returns type="gint" comment="The size of current array."/>
-		<comment>Gets the size of the array.</comment>
+	<method name="i_cal_str_array_new" corresponds="icalstrarray_new" kind="constructor" since="4.0">
+		<parameter type="gint" name="increment_size" comment="how many slots to allocate on array expansion"/>
+		<returns type="ICalStrArray *" annotation="transfer full" comment="a new #ICalStrArray."/>
+		<comment>Creates a new #ICalStrArray.</comment>
 	</method>
-	<method name="i_cal_strarray_clone" corresponds="icalstrarray_clone" kind="clone" since="4.0">
-		<parameter type="ICalStrArray *" name="array" annotation="in" comment="The #ICalStrArray to be cloned"/>
-		<returns type="ICalStrArray *" annotation="transfer full" translator_argus="NULL" comment="The newly cloned #ICalStrArray with the same value as the @array"/>
-		<comment xml:space="preserve">Creates a deep copy of #ICalStrArray with the same properties as the @array.</comment>
-	</method>
-	<method name="i_cal_strarray_free" corresponds="icalstrarray_free" annotation="skip" kind="destructor" since="4.0">
-		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray to be freed"/>
-		<comment xml:space="preserve">Frees the #ICalStrArray.</comment>
-	</method>
-	<method name="i_cal_strarray_remove_element_at" corresponds="icalstrarray_remove_element_at" kind="other" since="4.0">
-		<parameter type="ICalStrArray *" name="array"  comment="The #ICalStrArray to be modified"/>
-		<parameter type="gint" name="position" comment="The position in which the element will be removed from the array"/>
-		<comment xml:space="preserve">Removes the element at the @position from the array.</comment>
-	</method>
-	<method name="i_cal_strarray_element_at" corresponds="icalstrarray_element_at" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_str_array_get_element_at" corresponds="icalstrarray_element_at" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray to be queried"/>
-		<parameter type="gint" name="position" comment="The position the target element is located"/>
+		<parameter type="gsize" name="position" comment="The position the target element is located"/>
 		<returns type="const gchar *" annotation="transfer none, nullable" comment="The element located at the @position in the @array"/>
 		<comment xml:space="preserve">Gets the element located in the @position in the @array. NULL if position if out of bound.</comment>
 	</method>
-	<method name="i_cal_strarray_sort" corresponds="icalstrarray_sort" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_str_array_size" corresponds="icalstrarray_size" kind="other" since="4.0">
+		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray"/>
+		<returns type="gsize" error_return_value="((gsize)-1)" comment="The size of current array."/>
+		<comment>Gets the size of the array.</comment>
+	</method>
+	<method name="i_cal_str_array_find" corresponds="icalstrarray_find" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray"/>
+		<parameter type="const gchar *" name="value" comment="The value to search for"/>
+		<returns type="gsize" error_return_value="((gsize)-1)" comment="The index of the value in the @array, or an index out of bounds, if not found."/>
+		<comment xml:space="preserve">Searches for a value in the @array and returns its first index.</comment>
+	</method>
+	<method name="i_cal_str_array_append" corresponds="icalstrarray_append" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray"/>
+		<parameter type="const gchar *" name="value" comment="The value to append"/>
+		<comment xml:space="preserve">Appends the @value into the @array, not checking for duplicates. See also i_cal_str_array_add().</comment>
+	</method>
+	<method name="i_cal_str_array_add" corresponds="icalstrarray_add" annotation="skip" kind="other" since="4.0">
+		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray"/>
+		<parameter type="const gchar *" name="value" comment="The value to add"/>
+		<comment xml:space="preserve">Adds the @value into the @array, omitting duplicates. See also i_cal_str_array_append().</comment>
+	</method>
+	<method name="i_cal_str_array_remove_element_at" corresponds="icalstrarray_remove_element_at" kind="other" since="4.0">
+		<parameter type="ICalStrArray *" name="array"  comment="The #ICalStrArray to be modified"/>
+		<parameter type="gsize" name="position" comment="The position in which the element will be removed from the array"/>
+		<comment xml:space="preserve">Removes the element at the @position from the @array.</comment>
+	</method>
+	<method name="i_cal_str_array_remove" corresponds="icalstrarray_remove" kind="other" since="4.0">
+		<parameter type="ICalStrArray *" name="array"  comment="The #ICalStrArray to be modified"/>
+		<parameter type="const gchar *" name="value" comment="The value to remove."/>
+		<comment xml:space="preserve">Removes all the occurrences of the @value in the @array.</comment>
+	</method>
+	<method name="i_cal_str_array_free" corresponds="icalstrarray_free" annotation="skip" kind="destructor" since="4.0">
+		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray to be freed"/>
+		<comment xml:space="preserve">Frees the #ICalStrArray.</comment>
+	</method>
+	<method name="i_cal_str_array_sort" corresponds="icalstrarray_sort" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalStrArray *" name="array" comment="The #ICalStrArray to be sorted"/>
+	</method>
+	<method name="i_cal_str_array_clone" corresponds="icalstrarray_clone" kind="clone" since="4.0">
+		<parameter type="ICalStrArray *" name="array" annotation="in" comment="The #ICalStrArray to be cloned"/>
+		<returns type="ICalStrArray *" annotation="transfer full" translator_argus="NULL" comment="The newly cloned #ICalStrArray with the same value as the @array"/>
+		<comment xml:space="preserve">Creates a deep copy of #ICalStrArray with the same properties as the @array.</comment>
 	</method>
 </structure>


### PR DESCRIPTION
They are needed to be able to work with those arrays.

----

I also reordered the definitions to be the same as in the corresponding header files, which makes it much easier to verify none is missing.