### PR TITLE
libical-glib: Add checker for API completeness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure project
         run: |
           mkdir build
-          cmake -B build --warn-uninitialized -Werror=dev -G Ninja -DLIBICAL_DEVMODE_MEMORY_CONSISTENCY=False -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DLIBICAL_DEVMODE=True -DLIBICAL_GLIB_BUILD_DOCS=True -DLIBICAL_GLIB=True -DGOBJECT_INTROSPECTION=True -DLIBICAL_GLIB_VAPI=True -DLIBICAL_BUILD_TESTING_BIGFUZZ=True
+          cmake -B build --warn-uninitialized -Werror=dev -G Ninja -DLIBICAL_DEVMODE_MEMORY_CONSISTENCY=False -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DLIBICAL_DEVMODE=True -DLIBICAL_GLIB_BUILD_DOCS=True -DLIBICAL_GLIB=True -DGOBJECT_INTROSPECTION=True -DLIBICAL_GLIB_VAPI=True -DLIBICAL_GLIB_CHECK_API_FILES=True -DLIBICAL_BUILD_TESTING_BIGFUZZ=True
       - name: Build project
         run: cmake --build build
       - name: Test project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@
 #  Requires gi-docgen, GOBJECT_INTROSPECTION and LIBICAL_BUILD_DOCS options to be true.
 #  Default=true (build libical-glib developer documentation)
 #
+# -DLIBICAL_GLIB_CHECK_API_FILES=[true|false]
+#  Set to check whether API files for the libical-glib contain all symbols exported
+#  in the corresponding header files; requires ICAL_GLIB to be set to True
+#  Default=false (always true if LIBICAL_DEVMODE is on)
+#
 # -DLIBICAL_ENABLE_MSVC_32BIT_TIME_T=[true|false]
 #  Set to build using a 32bit time_t (ignored unless building with MSVC on Windows)
 #  Default=false (use the default size of time_t)
@@ -747,6 +752,11 @@ if(LIBICAL_GLIB)
       "Alternatively, disable the libical-glib build (by passing -DLIBICAL_GLIB=False to cmake)."
     )
   endif()
+endif()
+libical_option(LIBICAL_GLIB_CHECK_API_FILES "Check libical-glib API files for completeness." False)
+# Always check the API files in developer-mode (when libical-glib is enabled)
+if(LIBICAL_DEVMODE)
+  set(LIBICAL_GLIB_CHECK_API_FILES True)
 endif()
 # LIBICAL_GLIB_BUILD_DOCS might be disabled later by some devmode options
 libical_deprecated_option(ICAL_GLIB_BUILD_DOCS LIBICAL_GLIB_BUILD_DOCS "Build libical-glib documentation" True)

--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(
   ical-glib-src-generator
   tools/generator.c
   tools/generator.h
+  tools/header-parser.c
+  tools/header-parser.h
   tools/xml-parser.c
   tools/xml-parser.h
 )
@@ -182,6 +184,17 @@ if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
       -DLIBICAL_GLIB_COMPILATION
   )
   target_link_libraries(ical-glib-static ${GLIB_LIBRARIES})
+endif()
+
+if(LIBICAL_GLIB_CHECK_API_FILES)
+  add_custom_command(
+    TARGET ical-glib
+    POST_BUILD
+    COMMAND
+      ${ical-glib-src-generator_EXE} "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${CMAKE_CURRENT_SOURCE_DIR}/api"
+      "--check-api-files" "${CMAKE_CURRENT_BINARY_DIR}/../libical/ical.h" "LIBICAL_ICAL_EXPORT"
+    COMMENT "Check the libical-glib API files for completeness"
+  )
 endif()
 
 include(CheckCCompilerFlag)

--- a/src/libical-glib/api/i-cal-array.xml
+++ b/src/libical-glib/api/i-cal-array.xml
@@ -5,8 +5,11 @@
 
 
 -->
- <structure namespace="ICal" name="Array" native="icalarray" is_possible_global="true" destroy_func="icalarray_free">
-	<method name="i_cal_array_size" corresponds="CUSTOM" kind="other" since="1.0">
+<structure namespace="ICal" name="Array" native="icalarray" is_possible_global="true" destroy_func="icalarray_free">
+    <skip>icalarray_new</skip>
+    <skip>icalarray_append</skip>
+    <skip>icalarray_set_element_at</skip>
+    <method name="i_cal_array_size" corresponds="custom" kind="custom" since="1.0">
 		<parameter type="ICalArray *" name="array" comment="The #ICalArray"/>
 		<returns type="gint" comment="The size of current array."/>
 		<comment>Gets the size of the array.</comment>
@@ -49,7 +52,7 @@
         <returns type="GObject *" annotation="transfer none, nullable" comment="The element located at the @position in the @array"/>
         <comment xml:space="preserve">Gets the element located in the @position in the @array. NULL if position if out of bound.</comment>
     </method>
-    <method name="i_cal_array_sort" corresponds="CUSTOM" annotation="skip" kind="others" since="1.0">
+    <method name="i_cal_array_sort" corresponds="icalarray_sort" annotation="skip" kind="custom" since="1.0">
         <parameter type="ICalArray *" name="array" comment="The #ICalArray to be sorted"/>
         <parameter type="gint (*compare)" name="(const void *, const void *)" comment="FULL: @compare: The compare function"/>
         <comment xml:space="preserve">Does not work right now. Sorts the @array using the sort function @compare.</comment>

--- a/src/libical-glib/api/i-cal-attach.xml
+++ b/src/libical-glib/api/i-cal-attach.xml
@@ -11,7 +11,7 @@
         <returns type="ICalAttach *" annotation="transfer full" comment="The newly created #ICalAttach from the @url" />
         <comment xml:space="preserve">Creates a new #ICalAttach from the url.</comment>
     </method>
-    <method name="i_cal_attach_new_from_data" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_attach_new_from_data" corresponds="icalattach_new_from_data" kind="custom" since="1.0">
         <parameter type="const gchar *" name="data" comment="The data used to create the #ICalAttach"/>
         <parameter type="GFunc" name="free_fn" translator="(icalattach_free_fn_t)" annotation="scope call, nullable" comment="The function used to free the data when the create #ICalAttach is destroyed"/>
         <parameter type="void *" name="free_fn_data" annotation="nullable" comment="The userdata used for the free function @free_fn"/>
@@ -31,7 +31,7 @@ static void unref_g_bytes(char *data, void *user_data)
 
     g_bytes_unref(bytes);
 }</declaration>
-    <method name="i_cal_attach_new_from_bytes" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_attach_new_from_bytes" corresponds="icalattach_new_from_data" kind="custom" since="1.0">
         <parameter type="GBytes *" annotation="transfer full" name="bytes" comment="The #GBytes holding the data used to create the #ICalAttach"/>
         <returns type="ICalAttach *" annotation="transfer full" comment="The newly created #ICalAttach" />
         <comment xml:space="preserve">Creates a new #ICalAttach from the data in bytes. Takes a reference of @bytes, increase the reference before calling this function if you with to use it afterward. The stored bytes should be already encoded with used encoding (like base64).</comment>
@@ -57,7 +57,7 @@ static void unref_g_bytes(char *data, void *user_data)
         <returns type="const gchar *" annotation="nullable, transfer none" comment="The url component of the @attach. %NULL if it is built from data or there is an error." />
         <comment xml:space="preserve">Gets the url, if the #ICalAttach is built from the url.</comment>
     </method>
-    <method name="i_cal_attach_get_data" corresponds="CUSTOM" kind="others" since="1.0">
+    <method name="i_cal_attach_get_data" corresponds="icalattach_get_data" kind="custom" since="1.0">
         <parameter type="ICalAttach *" name="attach" comment="The #ICalAttach to be queried"/>
         <returns type="const gchar *" annotation="nullable, transfer none" comment="The data component of the @attach. %NULL if it is built from url or there is an error." />
         <comment xml:space="preserve">Gets the data, if the #ICalAttach is built from the data.</comment>

--- a/src/libical-glib/api/i-cal-comp-iter.xml
+++ b/src/libical-glib/api/i-cal-comp-iter.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="CompIter" native="struct icalcompiter" is_bare="true" default_native="i_cal_comp_iter_new_default ()">
-        <method name="i_cal_comp_iter_new_default" corresponds="CUSTOM" kind="private" since="1.0" annotation="skip">
+        <method name="i_cal_comp_iter_new_default" corresponds="custom" kind="private" since="1.0" annotation="skip">
                 <returns type="struct icalcompiter" annotation="transfer none" comment="The newly created default native icalcompiter"/>
                 <custom>        icalcompiter compiter;
         compiter.iter = 0;

--- a/src/libical-glib/api/i-cal-component.xml
+++ b/src/libical-glib/api/i-cal-component.xml
@@ -6,6 +6,14 @@
 
 -->
 <structure namespace="ICal" name="Component" native="icalcomponent" destroy_func="icalcomponent_free" includes="libical-glib/i-cal-parameter.h">
+    <!-- write here any symbols to skip, which do not fit anywhere else -->
+    <skip>ICAL_CHECK_VERSION</skip>
+    <skip>icalpvl_*</skip>
+    <skip>icallangbind_*</skip>
+    <skip>sspm_*</skip>
+    <skip>enum sspm_*</skip>
+    <!-- follows symbols related to the icalcomponent itself -->
+    <skip>icalcomponent_vanew</skip>
     <method name="i_cal_component_new" corresponds="icalcomponent_new" kind="constructor" since="1.0">
         <parameter type="ICalComponentKind" name="kind" comment="The #ICalComponentKind"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
@@ -55,7 +63,7 @@
         <parameter type="ICalProperty *" name="property" translator_argus="component" comment="An #ICalProperty"/>
         <comment xml:space="preserve">Adds an #ICalProperty into #ICalComponent.</comment>
     </method>
-    <method name="i_cal_component_take_property" corresponds="CUSTOM" annotation="skip" since="1.0">
+    <method name="i_cal_component_take_property" corresponds="icalcomponent_add_property" annotation="skip" since="1.0">
         <parameter type="ICalComponent *" name="component" comment="An #ICalComponent"/>
         <parameter type="ICalProperty *" name="property" annotation="transfer full" comment="An #ICalProperty"/>
         <comment xml:space="preserve">Adds the @property into the @component and unrefs the @property.</comment>
@@ -121,7 +129,7 @@
         <parameter type="ICalComponent *" name="child" translator_argus="(GObject*) parent" comment="A child #ICalComponent"/>
         <comment xml:space="preserve">Adds a #ICalComponent into another #ICalComponent as a child component.</comment>
     </method>
-    <method name="i_cal_component_take_component" corresponds="CUSTOM" annotation="skip" since="1.0">
+    <method name="i_cal_component_take_component" corresponds="icalcomponent_add_component" annotation="skip" since="1.0">
         <parameter type="ICalComponent *" name="parent" comment="A #ICalComponent"/>
         <parameter type="ICalComponent *" name="child" annotation="transfer full" comment="A child #ICalComponent"/>
         <comment xml:space="preserve">Adds the @child into the @parent as a child component and unrefs the @child.</comment>
@@ -174,7 +182,7 @@
         <returns type="ICalComponent *" annotation="transfer full, nullable" translator_argus="(GObject *)component" comment="The next #ICalComponent."/>
         <comment xml:space="preserve">Gets the next #ICalComponent with specific kind in #ICalComponent.</comment>
     </method>
-    <method name="i_cal_component_begin_component" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_component_begin_component" corresponds="icalcomponent_begin_component" since="1.0">
         <parameter type="ICalComponent *" name="component" comment="A #ICalComponent"/>
         <parameter type="ICalComponentKind" name="kind" comment="A #ICalComponentKind"/>
         <returns type="ICalCompIter *" annotation="transfer full" comment="A #ICalCompIter"/>
@@ -191,7 +199,7 @@
 
     return iter;</custom>
     </method>
-    <method name="i_cal_component_end_component" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_component_end_component" corresponds="icalcomponent_end_component" since="1.0">
         <parameter type="ICalComponent *" name="component" comment="A #ICalComponent"/>
         <parameter type="ICalComponentKind" name="kind" comment="A #ICalComponentKind"/>
         <returns type="ICalCompIter *" annotation="transfer full" comment="A #ICalCompIter"/>
@@ -207,7 +215,7 @@
 
     return iter;</custom>
     </method>
-    <method name="i_cal_comp_iter_next" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_comp_iter_next" corresponds="icalcompiter_next" since="1.0">
         <parameter type="ICalCompIter *" name="i" native_op="POINTER" comment="A #ICalCompIter"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="A #ICalComponent"/>
         <comment xml:space="preserve">Gets the next #ICalComponent pointed by #ICalCompIter.</comment>
@@ -224,7 +232,7 @@
 
     return comp;</custom>
     </method>
-    <method name="i_cal_comp_iter_prior" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_comp_iter_prior" corresponds="icalcompiter_prior" since="1.0">
         <parameter type="ICalCompIter *" name="i" native_op="POINTER" comment="A #ICalCompIter"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="A #ICalComponent"/>
         <comment xml:space="preserve">Gets the prior #ICalComponent pointed by #ICalCompIter.</comment>
@@ -241,7 +249,7 @@
 
     return comp;</custom>
     </method>
-    <method name="i_cal_comp_iter_deref" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_comp_iter_deref" corresponds="icalcompiter_deref" since="1.0">
         <parameter type="ICalCompIter *" name="i" native_op="POINTER" comment="A #ICalCompIter"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="A #ICalComponent"/>
         <comment xml:space="preserve">Gets the current #ICalComponent pointed by #ICalCompIter.</comment>
@@ -258,7 +266,7 @@
 
     return comp;</custom>
     </method>
-    <method name="i_cal_component_begin_property" corresponds="CUSTOM" since="4.0">
+    <method name="i_cal_component_begin_property" corresponds="icalcomponent_begin_property" since="4.0">
         <parameter type="ICalComponent *" name="component" comment="A #ICalComponent"/>
         <parameter type="ICalPropertyKind" name="kind" comment="A #ICalPropertyKind"/>
         <returns type="ICalPropIter *" annotation="transfer full" comment="A #ICalPropIter"/>
@@ -275,7 +283,7 @@
 
     return iter;</custom>
     </method>
-    <method name="i_cal_prop_iter_next" corresponds="CUSTOM" since="4.0">
+    <method name="i_cal_prop_iter_next" corresponds="icalpropiter_next" since="4.0">
         <parameter type="ICalPropIter *" name="i" native_op="POINTER" comment="A #ICalPropIter"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="A #ICalProperty"/>
         <comment xml:space="preserve">Gets the next #ICalProperty pointed by #ICalPropIter.</comment>
@@ -292,7 +300,7 @@
 
     return prop;</custom>
     </method>
-    <method name="i_cal_prop_iter_deref" corresponds="CUSTOM" since="4.0">
+    <method name="i_cal_prop_iter_deref" corresponds="icalpropiter_deref" since="4.0">
         <parameter type="ICalPropIter *" name="i" native_op="POINTER" comment="A #ICalPropIter"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="A #ICalProperty"/>
         <comment xml:space="preserve">Gets the current #ICalProperty pointed by #ICalPropIter.</comment>
@@ -521,7 +529,7 @@ static void foreach_tzid_cb(icalparameter *in_param, void *user_data)
     i_cal_object_steal_native((ICalObject *) param);
     g_object_unref(param);
 }</declaration>
-    <method name="i_cal_component_foreach_tzid" corresponds="CUSTOM" kind="other" since="3.0.5">
+    <method name="i_cal_component_foreach_tzid" corresponds="icalcomponent_foreach_tzid" kind="other" since="3.0.5">
         <parameter type="ICalComponent *" name="comp" comment="The #ICalComponent to be queried"/>
         <parameter type="ICalComponentForeachTZIDFunc" name="callback" annotation="scope call,closure user_data" comment="The callback function"/>
         <parameter type="gpointer" name="user_data" annotation="nullable" comment="The user data for callback function"/>
@@ -561,7 +569,7 @@ static void foreach_recurrence_cb(const icalcomponent *in_comp, const struct ica
     (*(data->callback))(data->comp, span, data->user_data);
     g_object_unref(span);
 }</declaration>
-    <method name="i_cal_component_foreach_recurrence" corresponds="CUSTOM" kind="other" since="3.0.5">
+    <method name="i_cal_component_foreach_recurrence" corresponds="icalcomponent_foreach_recurrence" kind="other" since="3.0.5">
         <parameter type="ICalComponent *" name="comp" comment="The #ICalComponent to be queried"/>
         <parameter type="ICalTime *" name="start" comment="Ignore timespans before this"/>
         <parameter type="ICalTime *" name="end" comment="Ignore timespans after this"/>
@@ -686,5 +694,24 @@ static void foreach_recurrence_cb(const icalcomponent *in_comp, const struct ica
     <method name="i_cal_component_new_vresource" corresponds="icalcomponent_new_vresource" kind="constructor" since="4.0">
         <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
         <comment xml:space="preserve">Creates a #ICalComponent of type %I_CAL_VRESOURCE_COMPONENT.</comment>
+    </method>
+    <method name="i_cal_component_get_component_name" corresponds="icalcomponent_get_component_name_r" since="4.0">
+        <parameter type="const ICalComponent *" name="component" comment="an #ICalComponent"/>
+        <returns type="gchar *" annotation="transfer full" comment="name of the @component" translator="i_cal_memory_str_to_glib"/>
+        <comment xml:space="preserve">Returns the name of the @component as string.</comment>
+    </method>
+    <method name="i_cal_component_get_x_name" corresponds="icalcomponent_get_x_name" since="4.0">
+        <parameter type="const ICalComponent *" name="component" comment="an #ICalComponent"/>
+        <returns type="const gchar *" annotation="transfer full,nullable" comment="X (custom) name of the @component, or %NULL, when it's not a X component"/>
+        <comment xml:space="preserve">Returns the X (custom) name of the @component as string, or %NULL.</comment>
+    </method>
+    <method name="i_cal_component_set_x_name" corresponds="icalcomponent_set_x_name" since="4.0">
+        <parameter type="ICalComponent *" name="component" comment="an #ICalComponent"/>
+        <parameter type="const gchar *" name="xname" comment="an X (custom) name for the @component"/>
+        <comment xml:space="preserve">Sets an X (custom) name of the @component.</comment>
+    </method>
+    <method name="i_cal_component_normalize" corresponds="icalcomponent_normalize" since="4.0">
+        <parameter type="ICalComponent *" name="component" comment="an #ICalComponent"/>
+        <comment xml:space="preserve">Normalizes (reorders and sorts the properties) the @component.</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-datetimeperiod.xml
+++ b/src/libical-glib/api/i-cal-datetimeperiod.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="Datetimeperiod" native="struct icaldatetimeperiodtype" is_bare="true" default_native="i_cal_datetimeperiod_new_default ()" includes="libical-glib/i-cal-time.h, libical-glib/i-cal-period.h">
-	<method name="i_cal_datetimeperiod_new_default" corresponds="CUSTOM" annotation="skip" kind="private" since="1.0">
+    <method name="i_cal_datetimeperiod_new_default" corresponds="none" annotation="skip" kind="private" since="1.0">
         <returns type="struct icaldatetimeperiodtype" annotation="transfer full" comment="The newly created #ICalDatetimeperiod" />
         <comment xml:space="preserve">Creates a new default #ICalDatetimeperiod.</comment>
         <custom>	struct icaldatetimeperiodtype datetimeperiodtype;
@@ -14,19 +14,19 @@
 	datetimeperiodtype.period = icalperiodtype_null_period ();
 	return datetimeperiodtype;</custom>
     </method>
-    <method name="i_cal_datetimeperiod_new" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_datetimeperiod_new" corresponds="none" kind="constructor" since="1.0">
         <returns type="ICalDatetimeperiod *" annotation="transfer full" comment="The newly created #ICalDatetimeperiod." />
         <comment xml:space="preserve">Creates a new #ICalDatetimeperiod.</comment>
         <custom>	return i_cal_datetimeperiod_new_full(i_cal_datetimeperiod_new_default());</custom>
     </method>
-    <method name="i_cal_datetimeperiod_get_time" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_datetimeperiod_get_time" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalDatetimeperiod *" name="dtp" comment="The #ICalDatetimeperiod to be queried"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The time attribute of @dtp."/>
         <comment>Gets the time attribute of #ICalDatetimeperiod.</comment>
         <custom>	g_return_val_if_fail (dtp != NULL &amp;&amp; I_CAL_IS_DATETIMEPERIOD (dtp), NULL);
 	return i_cal_time_new_full (((struct icaldatetimeperiodtype *)i_cal_object_get_native ((ICalObject *)dtp))->time);</custom>
     </method>
-    <method name="i_cal_datetimeperiod_set_time" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_datetimeperiod_set_time" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDatetimeperiod *" name="dtp" comment="The #ICalDatetimeperiod to be set"/>
         <parameter type="ICalTime *" name="time" comment="The time attribute of @dtp"/>
         <comment>Sets the time attribute of #ICalDatetimeperiod.</comment>
@@ -34,14 +34,14 @@
 	g_return_if_fail (time != NULL &amp;&amp; I_CAL_IS_TIME(time));
 	((struct icaldatetimeperiodtype *)i_cal_object_get_native ((ICalObject *)dtp))->time = *(struct icaltimetype *)i_cal_object_get_native ((ICalObject *)time);</custom>
     </method>
-    <method name="i_cal_datetimeperiod_get_period" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_datetimeperiod_get_period" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalDatetimeperiod *" name="dtp" comment="The #ICalDatetimeperiod to be queried"/>
         <returns type="ICalPeriod *" annotation="transfer full" comment="The period attribute of @dtp."/>
         <comment>Gets the period attribute of #ICalDatetimeperiod.</comment>
         <custom>	g_return_val_if_fail (dtp != NULL &amp;&amp; I_CAL_IS_DATETIMEPERIOD (dtp), NULL);
 	return i_cal_period_new_full (((struct icaldatetimeperiodtype *)i_cal_object_get_native ((ICalObject *)dtp))->period);</custom>
     </method>
-    <method name="i_cal_datetimeperiod_set_period" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_datetimeperiod_set_period" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDatetimeperiod *" name="dtp" comment="The #ICalDatetimeperiod to be set"/>
         <parameter type="ICalPeriod *" name="period" comment="The period attribute of @dtp"/>
         <comment>Sets the period attribute of #ICalDatetimeperiod.</comment>

--- a/src/libical-glib/api/i-cal-derived-parameter.xml
+++ b/src/libical-glib/api/i-cal-derived-parameter.xml
@@ -6,6 +6,7 @@
 
 -->
 <structure namespace="ICal" name="DerivedParameter">
+    <skip>icalparameter_vanew_*</skip>
     <enum name="ICalParameterKind" native_name="icalparameter_kind" default_native="I_CAL_NO_PARAMETER">
         <element name="ICAL_ANY_PARAMETER"/>
         <element name="ICAL_ACTIONPARAM_PARAMETER"/>
@@ -272,6 +273,16 @@
         <element name="ICAL_XLICERRORTYPE_VCALPROPPARSEERROR"/>
         <element name="ICAL_XLICERRORTYPE_NONE"/>
     </enum>
+    <method name="i_cal_parameter_enum_to_string" corresponds="icalparameter_enum_to_string" kind="other" since="4.0">
+        <parameter type="gint" name="e" comment="an enum numeric value"/>
+        <returns type="const gchar *" comment="string representation of the enum value @e." />
+        <comment xml:space="preserve">Converts an integer representation of a parameter enum to a string.</comment>
+    </method>
+    <method name="i_cal_parameter_enum_from_string" corresponds="icalparameter_string_to_enum" kind="other" since="4.0">
+        <parameter type="const gchar *" name="str" comment="a string enum value"/>
+        <returns type="gint" comment="an integer representation of the string enum value @str." />
+        <comment xml:space="preserve">Converts a string representation of a parameter enum to a its numeric value.</comment>
+    </method>
     <method name="i_cal_parameter_new_actionparam" corresponds="icalparameter_new_actionparam" kind="constructor" since="1.0">
         <parameter type="ICalParameterAction" name="v" comment="The type of #ICalParameter to be created"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
@@ -367,6 +378,27 @@
         <parameter type="ICalStrArray *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
     </method>
+    <method name="i_cal_parameter_get_delegatedfrom_size" corresponds="icalparameter_get_delegatedfrom_size" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <returns type="gsize" error_return_value="0" comment="Number of elements" />
+        <comment xml:space="preserve">Returns number of elements of the DELEGATED-FROM parameter</comment>
+    </method>
+    <method name="i_cal_parameter_get_delegatedfrom_nth" corresponds="icalparameter_get_delegatedfrom_nth" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <parameter type="gsize" name="position" comment="the position of an element"/>
+        <returns type="const gchar *" annotation="nullable" comment="The n-th element, or %NULL, when out of bounds" />
+        <comment xml:space="preserve">Returns the n-th element of the DELEGATED-FROM parameter</comment>
+    </method>
+    <method name="i_cal_parameter_add_delegatedfrom" corresponds="icalparameter_add_delegatedfrom" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment xml:space="preserve">Adds a DELEGATED-FROM value to the @param</comment>
+    </method>
+    <method name="i_cal_parameter_remove_delegatedfrom" corresponds="icalparameter_remove_delegatedfrom" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment xml:space="preserve">Removes a DELEGATED-FROM @v value from the @param</comment>
+    </method>
     <method name="i_cal_parameter_new_delegatedto" corresponds="icalparameter_new_delegatedto" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The string used to create the new #ICalParameter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
@@ -386,6 +418,27 @@
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
         <parameter type="ICalStrArray *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_get_delegatedto_size" corresponds="icalparameter_get_delegatedto_size" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <returns type="gsize" error_return_value="0" comment="Number of elements" />
+        <comment xml:space="preserve">Returns number of elements of the DELEGATED-TO parameter</comment>
+    </method>
+    <method name="i_cal_parameter_get_delegatedto_nth" corresponds="icalparameter_get_delegatedto_nth" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <parameter type="gsize" name="position" comment="the position of the element"/>
+        <returns type="const gchar *" annotation="nullable" comment="The n-th element, or %NULL, when out of bounds" />
+        <comment xml:space="preserve">Returns the n-th element of the DELEGATED-TO parameter</comment>
+    </method>
+    <method name="i_cal_parameter_add_delegatedto" corresponds="icalparameter_add_delegatedto" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment xml:space="preserve">Adds a DELEGATED-TO value to the @param</comment>
+    </method>
+    <method name="i_cal_parameter_remove_delegatedto" corresponds="icalparameter_remove_delegatedto" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment xml:space="preserve">Removes a DELEGATED-TO @v value from the @param</comment>
     </method>
     <method name="i_cal_parameter_new_derived" corresponds="icalparameter_new_derived" kind="constructor" since="4.0">
         <parameter type="ICalParameterDerived" name="v" comment="An initial value for the new #ICalParameter"/>
@@ -423,19 +476,67 @@
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_display_list" corresponds="icalparameter_new_display_list" kind="constructor" since="4.0">
-        <parameter type="ICalEnumArray *" name="value" comment="The #ICalEnumArray element value of the new #ICalParameter"/>
+        <parameter type="const ICalEnumArray *" name="value" comment="The #ICalEnumArray element value of the new #ICalParameter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter" />
-        <comment xml:space="preserve"></comment>
+        <comment xml:space="preserve">Note: this uses a copy of the array, not the one stored in the @value</comment>
+        <custom>    icalenumarray *val;
+    g_return_val_if_fail(value != NULL, NULL);
+    val = (icalenumarray *)i_cal_object_get_native((ICalObject *)value);
+    if (val == NULL)
+        return NULL;
+    return i_cal_parameter_new_full(icalparameter_new_display_list(icalenumarray_clone(val)), NULL);</custom>
     </method>
     <method name="i_cal_parameter_get_display" corresponds="icalparameter_get_display" kind="get" since="4.0">
         <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
         <returns type="ICalEnumArray *" annotation="transfer full" comment="The #ICalEnumArray value of the @param"/>
-        <comment xml:space="preserve"></comment>
+        <comment xml:space="preserve">Note: this returns copy of the array, not the one stored in the @param</comment>
+	<custom>    icalenumarray *val;
+    g_return_val_if_fail(param != NULL, NULL);
+    val = icalparameter_get_display((icalparameter *)i_cal_object_get_native((ICalObject *)param));
+    if (val == NULL)
+        return NULL;
+    return i_cal_enum_array_new_full(icalenumarray_clone(val), NULL);</custom>
     </method>
     <method name="i_cal_parameter_set_display" corresponds="icalparameter_set_display" kind="set" since="4.0">
         <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
-        <parameter type="ICalEnumArray *" name="value" comment="The #ICalEnumArray to set into the @param"/>
+        <parameter type="const ICalEnumArray *" name="value" comment="The #ICalEnumArray to set into the @param"/>
+        <comment xml:space="preserve">Note: this uses a copy of the array, not the one stored in the @value</comment>
+	<custom>    g_return_if_fail(param != NULL);
+    icalparameter_set_display((icalparameter *)i_cal_object_get_native((ICalObject *)param),
+        icalenumarray_clone((icalenumarray *)i_cal_object_get_native((ICalObject *)value)));</custom>
+    </method>
+    <method name="i_cal_parameter_get_display_size" corresponds="icalparameter_get_display_size" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <returns type="gsize" error_return_value="0" comment="Number of elements" />
+        <comment xml:space="preserve">Returns number of elements of the DISPLAY parameter</comment>
+    </method>
+    <method name="i_cal_parameter_get_display_nth" corresponds="icalparameter_get_display_nth" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <parameter type="gsize" name="position" comment="the position of the element"/>
+        <returns type="ICalParameterDisplay" comment="The n-th element" />
+        <comment xml:space="preserve">Returns the n-th element of the DISPLAY parameter</comment>
+    </method>
+    <method name="i_cal_parameter_add_display" corresponds="icalparameter_add_display" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="ICalParameterDisplay" name="value" comment="an #ICalParameterDisplay"/>
+        <parameter type="const gchar *" name="x_value" annotation="nullable" comment="An X name, or %NULL; when set, the @value should be I_CAL_DISPLAY_X"/>
         <comment xml:space="preserve"></comment>
+        <custom>    icalenumarray_element elem = { 0, };
+    g_return_if_fail(param != NULL);
+    elem.val = value;
+    elem.xvalue = x_value;
+    icalparameter_add_display((icalparameter *)i_cal_object_get_native((ICalObject *)param), &amp;elem);</custom>
+    </method>
+    <method name="i_cal_parameter_remove_display" corresponds="icalparameter_remove_display" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="ICalParameterDisplay" name="value" comment="an #ICalParameterDisplay"/>
+        <parameter type="const gchar *" name="x_value" annotation="nullable" comment="An X name, or %NULL; when set, the @value should be I_CAL_DISPLAY_X"/>
+        <comment xml:space="preserve"></comment>
+        <custom>    icalenumarray_element elem = { 0, };
+    g_return_if_fail(param != NULL);
+    elem.val = value;
+    elem.xvalue = x_value;
+    icalparameter_remove_display((icalparameter *)i_cal_object_get_native((ICalObject *)param), &amp;elem);</custom>
     </method>
     <method name="i_cal_parameter_new_email" corresponds="icalparameter_new_email" kind="constructor" since="3.0.15">
         <parameter type="const gchar *" name="value" comment="The string value of the new #ICalParameter"/>
@@ -510,12 +611,54 @@
     <method name="i_cal_parameter_get_feature" corresponds="icalparameter_get_feature" kind="get" since="4.0">
         <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
         <returns type="ICalEnumArray *" annotation="transfer full" comment="The #ICalEnumArray value of the @param"/>
-        <comment xml:space="preserve"></comment>
+        <comment xml:space="preserve">Note: this returns copy of the array, not the one stored in the @param</comment>
+	<custom>    icalenumarray *val;
+    g_return_val_if_fail(param != NULL, NULL);
+    val = icalparameter_get_feature((icalparameter *)i_cal_object_get_native((ICalObject *)param));
+    if (val == NULL)
+        return NULL;
+    return i_cal_enum_array_new_full(icalenumarray_clone(val), NULL);</custom>
     </method>
     <method name="i_cal_parameter_set_feature" corresponds="icalparameter_set_feature" kind="set" since="4.0">
         <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
-        <parameter type="ICalEnumArray *" name="value" comment="The #ICalEnumArray to set into the @param"/>
+        <parameter type="const ICalEnumArray *" name="value" comment="The #ICalEnumArray to set into the @param"/>
+        <comment xml:space="preserve">Note: this uses a copy of the array, not the one stored in the @value</comment>
+	<custom>    g_return_if_fail(param != NULL);
+    icalparameter_set_feature((icalparameter *)i_cal_object_get_native((ICalObject *)param),
+        icalenumarray_clone((icalenumarray *)i_cal_object_get_native((ICalObject *)value)));</custom>
+    </method>
+    <method name="i_cal_parameter_get_feature_size" corresponds="icalparameter_get_feature_size" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <returns type="gsize" error_return_value="0" comment="Number of elements" />
+        <comment xml:space="preserve">Returns number of elements of the FEATURE parameter</comment>
+    </method>
+    <method name="i_cal_parameter_get_feature_nth" corresponds="icalparameter_get_feature_nth" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <parameter type="gsize" name="position" comment="the position of the element"/>
+        <returns type="ICalParameterFeature" comment="The n-th element" />
+        <comment xml:space="preserve">Returns the n-th element of the FEATURE parameter</comment>
+    </method>
+    <method name="i_cal_parameter_add_feature" corresponds="icalparameter_add_feature" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="ICalParameterFeature" name="value" comment="an #ICalParameterFeature"/>
+        <parameter type="const gchar *" name="x_value" annotation="nullable" comment="An X name, or %NULL; when set, the @value should be I_CAL_FEATURE_X"/>
         <comment xml:space="preserve"></comment>
+        <custom>    icalenumarray_element elem = { 0, };
+    g_return_if_fail(param != NULL);
+    elem.val = value;
+    elem.xvalue = x_value;
+    icalparameter_add_feature((icalparameter *)i_cal_object_get_native((ICalObject *)param), &amp;elem);</custom>
+    </method>
+    <method name="i_cal_parameter_remove_feature" corresponds="icalparameter_remove_feature" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="ICalParameterFeature" name="value" comment="an #ICalParameterFeature"/>
+        <parameter type="const gchar *" name="x_value" annotation="nullable" comment="An X name, or %NULL; when set, the @value should be I_CAL_FEATURE_X"/>
+        <comment xml:space="preserve"></comment>
+        <custom>    icalenumarray_element elem = { 0, };
+    g_return_if_fail(param != NULL);
+    elem.val = value;
+    elem.xvalue = x_value;
+    icalparameter_remove_feature((icalparameter *)i_cal_object_get_native((ICalObject *)param), &amp;elem);</custom>
     </method>
     <method name="i_cal_parameter_new_filename" corresponds="icalparameter_new_filename" kind="constructor" since="2.0">
         <parameter type="const gchar *" name="v" comment="The string used to create the new #ICalParameter"/>
@@ -546,6 +689,21 @@
         <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
         <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_new_gap" corresponds="icalparameter_new_gap" kind="constructor" since="4.0">
+        <parameter type="const ICalDuration *" name="v" comment="an #ICalDuration"/>
+        <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
+        <comment xml:space="preserve">Creates a new GP parameter with value @v</comment>
+    </method>
+    <method name="i_cal_parameter_get_gap" corresponds="icalparameter_get_gap" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="an #ICalParameter"/>
+        <returns type="ICalDuration *" annotation="transfer full,nullable" comment="a GAP value of the @param, or %NULL, when it's not a GAP parameter" />
+        <comment xml:space="preserve">Gets a value of a GAP parameter.</comment>
+    </method>
+    <method name="i_cal_parameter_set_gap" corresponds="icalparameter_set_gap" kind="set" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="an #ICalParameter"/>
+        <parameter type="const ICalDuration *" name="v" comment="an #ICalDuration value"/>
+        <comment xml:space="preserve">Set a GAP parameter value</comment>
     </method>
     <method name="i_cal_parameter_new_iana" corresponds="icalparameter_new_iana" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The string used to create the new #ICalParameter"/>
@@ -622,6 +780,21 @@
         <parameter type="const gchar *" name="v" comment="The string used to set into the @value"/>
         <comment xml:space="preserve"></comment>
     </method>
+    <method name="i_cal_parameter_new_linkrel" corresponds="icalparameter_new_linkrel" kind="constructor" since="4.0">
+        <parameter type="const gchar *" name="v" comment="The string used to create a LINKREL #ICalParameter"/>
+        <returns type="ICalParameter *" annotation="transfer full" comment="a newly created LINKREL #ICalParameter." />
+        <comment xml:space="preserve">Creates a new LINKREL parameter with value @v</comment>
+    </method>
+    <method name="i_cal_parameter_get_linkrel" corresponds="icalparameter_get_linkrel" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="an #ICalParameter"/>
+        <returns type="const gchar *" annotation="nullable" comment="a value of the LINKREL @param, or %NULL when of other kind" />
+        <comment xml:space="preserve">Gets a value of a LINKREL parameter</comment>
+    </method>
+    <method name="i_cal_parameter_set_linkrel" corresponds="icalparameter_set_linkrel" kind="set" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="an #ICalParameter"/>
+        <parameter type="const gchar *" name="v" comment="The string LINKREL value to set"/>
+        <comment xml:space="preserve">Sets a value to the LINKREL parameter @param</comment>
+    </method>
     <method name="i_cal_parameter_new_local" corresponds="icalparameter_new_local" kind="constructor" since="1.0">
         <parameter type="ICalParameterLocal" name="v" comment="The type of #ICalParameter to be created"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
@@ -673,18 +846,54 @@
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_member_list" corresponds="icalparameter_new_member_list" kind="constructor" since="4.0">
-        <parameter type="ICalStrArray *" name="v" comment="The string array used to create the new #ICalParameter"/>
+        <parameter type="const ICalStrArray *" name="v" annotation="transfer none" comment="The string array used to create the new #ICalParameter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="The newly created #ICalParameter." />
-        <comment xml:space="preserve"></comment>
+        <comment xml:space="preserve">Note: this uses a copy of the string array, not the one stored in the @v</comment>
+        <custom>    icalstrarray *val;
+    g_return_val_if_fail(v != NULL, NULL);
+    val = (icalstrarray *)i_cal_object_get_native ((ICalObject *)v);
+    if (val == NULL)
+        return NULL;
+    return i_cal_parameter_new_full(icalparameter_new_member_list(icalstrarray_clone(val)), NULL);</custom>
     </method>
     <method name="i_cal_parameter_get_member" corresponds="icalparameter_get_member" kind="get" since="4.0">
-        <parameter type="const ICalParameter *" name="value" comment="The #ICalParameter to be queried"/>
-        <returns type="ICalStrArray *" annotation="transfer full" comment="The property of the @value" />
-        <comment xml:space="preserve"></comment>
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <returns type="ICalStrArray *" annotation="transfer full" comment="The property of the @param" />
+        <comment xml:space="preserve">Note: this returns copy of the string array, not the one stored in the @param</comment>
+        <custom>    icalstrarray *val;
+    g_return_val_if_fail(param != NULL, NULL);
+    val = icalparameter_get_member((icalparameter *)i_cal_object_get_native ((ICalObject *)param));
+    if (val == NULL)
+        return NULL;
+    return i_cal_str_array_new_full(icalstrarray_clone(val), NULL);</custom>
     </method>
     <method name="i_cal_parameter_set_member" corresponds="icalparameter_set_member" kind="set" since="4.0">
-        <parameter type="ICalParameter *" name="value" comment="The #ICalParameter to be set"/>
-        <parameter type="ICalStrArray *" name="v" comment="The string used to set into the @value"/>
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const ICalStrArray *" name="v" comment="The string used to set into the @param"/>
+        <comment xml:space="preserve">Note: this uses a copy of the string array, not the one stored in the @v</comment>
+        <custom>    g_return_if_fail(param != NULL);
+    icalparameter_set_member((icalparameter *)i_cal_object_get_native ((ICalObject *)param),
+        icalstrarray_clone((icalstrarray *)i_cal_object_get_native ((ICalObject *)v)));</custom>
+    </method>
+    <method name="i_cal_parameter_get_member_size" corresponds="icalparameter_get_member_size" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <returns type="gsize" error_return_value="0" comment="Number of MEMBER elements in the @param"/>
+        <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_get_member_nth" corresponds="icalparameter_get_member_nth" kind="get" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="The #ICalParameter to be queried"/>
+        <parameter type="gsize" name="position" comment="Position of the MEMBER item to get"/>
+        <returns type="const gchar *" annotation="nullable" comment="n-th item of the MEMBER @param" />
+        <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_add_member" corresponds="icalparameter_add_member" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const gchar *" name="member" comment="The string used to add into the @param"/>
+        <comment xml:space="preserve"></comment>
+    </method>
+    <method name="i_cal_parameter_remove_member" corresponds="icalparameter_remove_member" kind="other" since="4.0">
+        <parameter type="ICalParameter *" name="param" comment="The #ICalParameter to be set"/>
+        <parameter type="const gchar *" name="member" comment="The string used to remove from the @param"/>
         <comment xml:space="preserve"></comment>
     </method>
     <method name="i_cal_parameter_new_modified" corresponds="icalparameter_new_modified" kind="constructor" since="2.0">

--- a/src/libical-glib/api/i-cal-derived-property.xml
+++ b/src/libical-glib/api/i-cal-derived-property.xml
@@ -6,6 +6,7 @@
 
 -->
 <structure namespace="ICal" name="DerivedProperty">
+    <skip>icalproperty_vanew_*</skip>
     <enum name="ICalPropertyKind" native_name="icalproperty_kind" default_native="I_CAL_NO_PROPERTY">
         <element name="ICAL_ANY_PROPERTY"/>
         <element name="ICAL_ACCEPTRESPONSE_PROPERTY"/>
@@ -203,7 +204,7 @@
         <returns type="const gchar *" annotation="transfer none" comment="Get the allowconflict of #ICalProperty."/>
         <comment>Gets the allowconflict of #ICalProperty.</comment>
     </method>
-    <method name="i_cal_property_new_attach" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_property_new_attach" corresponds="icalproperty_new_attach" kind="constructor" since="1.0">
         <parameter type="ICalAttach *" name="v" comment="The #ICalAttach"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty"/>
         <comment xml:space="preserve">Creates a new #ICalProperty.</comment>
@@ -373,18 +374,18 @@
         <comment>Gets the categories of #ICalProperty.</comment>
     </method>
     <method name="i_cal_property_new_class" corresponds="icalproperty_new_class" kind="constructor" since="1.0">
-        <parameter type="ICalProperty_Class" name="v" comment="The class"/>
+        <parameter type="ICalPropertyClassenum" name="v" comment="The class"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty"/>
         <comment xml:space="preserve">Creates a new #ICalProperty.</comment>
     </method>
     <method name="i_cal_property_set_class" corresponds="icalproperty_set_class" kind="set" since="1.0">
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be set"/>
-        <parameter type="ICalProperty_Class" name="v" comment="The class"/>
+        <parameter type="ICalPropertyClassenum" name="v" comment="The class"/>
         <comment>Sets the class for the #ICalProperty.</comment>
     </method>
     <method name="i_cal_property_get_class" corresponds="icalproperty_get_class" kind="get" since="1.0">
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
-        <returns type="ICalProperty_Class" comment="Get the class of #ICalProperty."/>
+        <returns type="ICalPropertyClassenum" comment="Get the class of #ICalProperty."/>
         <comment>Gets the class of #ICalProperty.</comment>
     </method>
     <method name="i_cal_property_new_cmd" corresponds="icalproperty_new_cmd" kind="constructor" since="1.0">
@@ -461,6 +462,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="const gchar *" annotation="transfer none" comment="Get the components of #ICalProperty."/>
         <comment>Gets the components of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_concept" corresponds="icalproperty_new_concept" kind="constructor" since="4.0">
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty"/>
+        <comment xml:space="preserve">Creates a new CONCEPT #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_set_concept" corresponds="icalproperty_set_concept" kind="set" since="4.0">
+        <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment>Sets the value of the CONCEPT @prop.</comment>
+    </method>
+    <method name="i_cal_property_get_concept" corresponds="icalproperty_get_concept" kind="get" since="4.0">
+        <parameter type="const ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
+        <returns type="const gchar *" annotation="transfer none" comment="the value of the CONCEPT @prop."/>
+        <comment>Gets the value of the CONCEPT @prop.</comment>
     </method>
     <method name="i_cal_property_new_conference" corresponds="icalproperty_new_conference" kind="constructor" since="4.0">
         <parameter type="const gchar *" name="v" comment="An initial value for the new #ICalProperty"/>
@@ -837,7 +853,7 @@
         <returns type="const gchar *" annotation="transfer none" comment="Get the grant of #ICalProperty."/>
         <comment>Gets the grant of #ICalProperty.</comment>
     </method>
-    <method name="i_cal_property_new_image" corresponds="CUSTOM" kind="constructor" since="4.0">
+    <method name="i_cal_property_new_image" corresponds="icalproperty_new_image" kind="constructor" since="4.0">
         <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="An initial value for the new #ICalProperty"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
         <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_IMAGE_PROPERTY holding value @v of type #ICalAttach</comment>
@@ -885,6 +901,21 @@
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
         <returns type="ICalTime *" annotation="transfer full" comment="Get the lastmodified time of #ICalProperty."/>
         <comment>Gets the lastmodified time of #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_new_link" corresponds="icalproperty_new_link" kind="constructor" since="4.0">
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty"/>
+        <comment xml:space="preserve">Creates a new LINK #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_set_link" corresponds="icalproperty_set_link" kind="set" since="4.0">
+        <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment>Sets the value of the LINK @prop.</comment>
+    </method>
+    <method name="i_cal_property_get_link" corresponds="icalproperty_get_link" kind="get" since="4.0">
+        <parameter type="const ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
+        <returns type="const gchar *" annotation="transfer none" comment="the value of the LINK @prop"/>
+        <comment>Gets the value of the LINK @prop.</comment>
     </method>
     <method name="i_cal_property_new_location" corresponds="icalproperty_new_location" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="v" comment="The location"/>
@@ -1441,6 +1472,21 @@
         <returns type="ICalTime *" annotation="transfer full" comment="Get the recurrenceid time of #ICalProperty."/>
         <comment>Gets the recurrenceid time of #ICalProperty.</comment>
     </method>
+    <method name="i_cal_property_new_refid" corresponds="icalproperty_new_refid" kind="constructor" since="4.0">
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty"/>
+        <comment xml:space="preserve">Creates a new REFID #ICalProperty.</comment>
+    </method>
+    <method name="i_cal_property_set_refid" corresponds="icalproperty_set_refid" kind="set" since="4.0">
+        <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be set"/>
+        <parameter type="const gchar *" name="v" comment="the value"/>
+        <comment>Sets the value of the REFID @prop.</comment>
+    </method>
+    <method name="i_cal_property_get_refid" corresponds="icalproperty_get_refid" kind="get" since="4.0">
+        <parameter type="const ICalProperty *" name="prop" comment="The #ICalProperty to be queried"/>
+        <returns type="const gchar *" annotation="transfer none" comment="the value of the REFID @prop"/>
+        <comment>Gets the value of the REFID @prop.</comment>
+    </method>
     <method name="i_cal_property_new_refreshinterval" corresponds="icalproperty_new_refreshinterval" kind="constructor" since="4.0">
         <parameter type="ICalDuration *" name="v" comment="An initial value for the new #ICalProperty"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
@@ -1681,7 +1727,7 @@
         <returns type="const gchar *" annotation="transfer none" comment="Get the storesexpanded of #ICalProperty."/>
         <comment>Gets the storesexpanded of #ICalProperty.</comment>
     </method>
-    <method name="i_cal_property_new_structureddata" corresponds="CUSTOM" kind="constructor" since="4.0">
+    <method name="i_cal_property_new_structureddata" corresponds="icalproperty_new_structureddata" kind="constructor" since="4.0">
         <parameter type="ICalAttach *" name="v" annotation="transfer none" comment="An initial value for the new #ICalProperty"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty." />
         <comment xml:space="preserve">Creates a new #ICalProperty of kind %I_CAL_STRUCTUREDDATA_PROPERTY holding value @v of type #ICalAttach</comment>

--- a/src/libical-glib/api/i-cal-derived-value.xml
+++ b/src/libical-glib/api/i-cal-derived-value.xml
@@ -6,6 +6,7 @@
 
 -->
 <structure namespace="ICal" name="DerivedValue">
+	<skip>icalvalue_vanew_*</skip>
 	<enum name="ICalValueKind" native_name="icalvalue_kind" default_native="I_CAL_NO_VALUE">
 	    <element name="ICAL_ANY_VALUE"/>
 	    <element name="ICAL_ACTION_VALUE"/>
@@ -74,7 +75,7 @@
 	    <element name="ICAL_CARLEVEL_CARFULL1"/>
 	    <element name="ICAL_CARLEVEL_NONE"/>
 	</enum>
-	<enum name="ICalProperty_Class" native_name="icalproperty_class" default_native="I_CAL_CLASS_NONE">
+	<enum name="ICalPropertyClassenum" native_name="icalproperty_class" default_native="I_CAL_CLASS_NONE">
 	    <element name="ICAL_CLASS_X"/>
 	    <element name="ICAL_CLASS_PUBLIC"/>
 	    <element name="ICAL_CLASS_PRIVATE"/>
@@ -624,6 +625,21 @@
 		<returns type="gint" comment="The integer within #ICalValue"/>
 		<comment>Gets the integer of #ICalValue.</comment>
 	</method>
+	<method name="i_cal_value_set_uid" corresponds="icalvalue_set_uid" kind="set" since="4.0">
+		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>
+		<parameter type="const gchar *" name="v" comment="The UID value"/>
+		<comment>Sets the UID in the #ICalValue.</comment>
+	</method>
+	<method name="i_cal_value_new_uid" corresponds="icalvalue_new_uid" kind="constructor" since="4.0">
+		<parameter type="const gchar *" name="v" comment="The UID value"/>
+		<returns type="ICalValue *" annotation="transfer full" comment="The newly created #ICalValue."/>
+		<comment>Creates a new #ICalValue with the type UID.</comment>
+	</method>
+	<method name="i_cal_value_get_uid" corresponds="icalvalue_get_uid" kind="get" since="4.0">
+		<parameter type="ICalValue *" name="value" comment="The #ICalValue to be queried"/>
+		<returns type="const gchar *" annotation="nullable, transfer none" comment="The UID within #ICalValue"/>
+		<comment>Gets the UID of #ICalValue.</comment>
+	</method>
 	<method name="i_cal_value_set_uri" corresponds="icalvalue_set_uri" kind="set" since="1.0">
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>
 		<parameter type="const gchar *" name="v" comment="The uri value"/>
@@ -641,17 +657,17 @@
 	</method>
 	<method name="i_cal_value_set_class" corresponds="icalvalue_set_class" kind="set" since="1.0">
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>
-		<parameter type="ICalProperty_Class" name="v" comment="The class value"/>
+		<parameter type="ICalPropertyClassenum" name="v" comment="The class value"/>
 		<comment>Sets the class in the #ICalValue.</comment>
 	</method>
 	<method name="i_cal_value_new_class" corresponds="icalvalue_new_class" kind="constructor" since="1.0">
-		<parameter type="ICalProperty_Class" name="v" comment="The class value"/>
+		<parameter type="ICalPropertyClassenum" name="v" comment="The class value"/>
 		<returns type="ICalValue *" annotation="transfer full" comment="The newly created #ICalValue."/>
 		<comment>Creates a new #ICalValue with the type class.</comment>
 	</method>
 	<method name="i_cal_value_get_class" corresponds="icalvalue_get_class" kind="get" since="1.0">
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue to be queried"/>
-		<returns type="ICalProperty_Class" comment="The class within #ICalValue"/>
+		<returns type="ICalPropertyClassenum" comment="The class within #ICalValue"/>
 		<comment>Gets the class of #ICalValue.</comment>
 	</method>
 	<method name="i_cal_value_set_float" corresponds="icalvalue_set_float" kind="set" since="1.0">
@@ -803,5 +819,20 @@
 		<parameter type="ICalValue *" name="value" comment="The #ICalValue to be queried"/>
 		<returns type="ICalPropertyCarlevel" comment="The carlevel within #ICalValue"/>
 		<comment>Gets the carlevel of #ICalValue.</comment>
+	</method>
+	<method name="i_cal_value_set_xmlreference" corresponds="icalvalue_set_xmlreference" kind="set" since="4.0">
+		<parameter type="ICalValue *" name="value" comment="The #ICalValue"/>
+		<parameter type="const gchar *" name="v" comment="The XMLREFERENCE value"/>
+		<comment>Sets the XMLREFERENCE in the #ICalValue.</comment>
+	</method>
+	<method name="i_cal_value_new_xmlreference" corresponds="icalvalue_new_xmlreference" kind="constructor" since="4.0">
+		<parameter type="const gchar *" name="v" comment="The XMLREFERENCE value"/>
+		<returns type="ICalValue *" annotation="transfer full" comment="The newly created #ICalValue."/>
+		<comment>Creates a new #ICalValue with the type XMLREFERENCE.</comment>
+	</method>
+	<method name="i_cal_value_get_xmlreference" corresponds="icalvalue_get_xmlreference" kind="get" since="4.0">
+		<parameter type="ICalValue *" name="value" comment="The #ICalValue to be queried"/>
+		<returns type="const gchar *" annotation="nullable, transfer none" comment="The XMLREFERENCE within #ICalValue"/>
+		<comment>Gets the XMLREFERENCE of #ICalValue.</comment>
 	</method>
 </structure>

--- a/src/libical-glib/api/i-cal-duration.xml
+++ b/src/libical-glib/api/i-cal-duration.xml
@@ -6,84 +6,84 @@
 
 -->
 <structure namespace="ICal" name="Duration" native="struct icaldurationtype" is_bare="true" default_native="icaldurationtype_null_duration()">
-    <method name="i_cal_duration_is_neg" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_duration_is_neg" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
         <returns type="gboolean" comment="The is_neg." />
         <comment xml:space="preserve">Gets the is_neg of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
 	return (((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->is_neg) ? TRUE : FALSE;</custom>
     </method>
-    <method name="i_cal_duration_set_is_neg" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_duration_set_is_neg" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="gboolean" name="is_neg" comment="The is_neg"/>
         <comment>Sets the is_neg of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
 	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->is_neg = is_neg ? 1 : 0;</custom>
     </method>
-    <method name="i_cal_duration_get_days" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_duration_get_days" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
         <returns type="guint" comment="The days." />
         <comment xml:space="preserve">Gets the days of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
 	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->days;</custom>
     </method>
-    <method name="i_cal_duration_set_days" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_duration_set_days" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="days" comment="The days"/>
         <comment>Sets the days of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
 	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->days = days;</custom>
     </method>
-    <method name="i_cal_duration_get_weeks" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_duration_get_weeks" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
         <returns type="guint" comment="The weeks." />
         <comment xml:space="preserve">Gets the weeks of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
 	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->weeks;</custom>
     </method>
-    <method name="i_cal_duration_set_weeks" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_duration_set_weeks" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="weeks" comment="The weeks"/>
         <comment>Sets the weeks of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
 	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->weeks = weeks;</custom>
     </method>
-    <method name="i_cal_duration_get_hours" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_duration_get_hours" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
         <returns type="guint" comment="The hours." />
         <comment xml:space="preserve">Gets the hours of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
 	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->hours;</custom>
     </method>
-    <method name="i_cal_duration_set_hours" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_duration_set_hours" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="hours" comment="The hours"/>
         <comment>Sets the hours of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
 	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->hours = hours;</custom>
     </method>
-    <method name="i_cal_duration_get_minutes" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_duration_get_minutes" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
         <returns type="guint" comment="The minutes." />
         <comment xml:space="preserve">Gets the minutes of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
 	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->minutes;</custom>
     </method>
-    <method name="i_cal_duration_set_minutes" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_duration_set_minutes" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="minutes" comment="The minutes"/>
         <comment>Sets the minutes of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
 	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->minutes = minutes;</custom>
     </method>
-    <method name="i_cal_duration_get_seconds" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_duration_get_seconds" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
         <returns type="guint" comment="The seconds." />
         <comment xml:space="preserve">Gets the seconds of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
 	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->seconds;</custom>
     </method>
-    <method name="i_cal_duration_set_seconds" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_duration_set_seconds" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="seconds" comment="The seconds"/>
         <comment>Sets the seconds of #ICalDuration.</comment>

--- a/src/libical-glib/api/i-cal-enum-array.xml
+++ b/src/libical-glib/api/i-cal-enum-array.xml
@@ -10,7 +10,57 @@
 		<returns type="ICalEnumArray *" annotation="transfer full" comment="a new #ICalEnumArray."/>
 		<comment>Creates a new #ICalEnumArray.</comment>
 	</method>
-	<method name="i_cal_enum_array_get_value_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enumarray_clone" corresponds="icalenumarray_clone" kind="clone" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" annotation="in" comment="The #ICalEnumArray to be cloned"/>
+		<returns type="ICalEnumArray *" annotation="transfer full" translator_argus="NULL" comment="The newly cloned #ICalEnumArray with the same value as the @array"/>
+		<comment xml:space="preserve">Creates a deep copy of #ICalEnumArray with the same properties as the @array.</comment>
+	</method>
+	<method name="i_cal_enumarray_free" corresponds="icalenumarray_free" annotation="skip" kind="destructor" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be freed"/>
+		<comment xml:space="preserve">Frees the #ICalEnumArray.</comment>
+	</method>
+	<method name="i_cal_enum_array_element_append_value" corresponds="icalenumarray_append" annotation="skip" kind="custom" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to append"/>
+		<comment xml:space="preserve">Appends an integer value to the @array. See also i_cal_enum_array_element_add_value(), i_cal_enum_array_element_append_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_element_append_x_value" corresponds="icalenumarray_append" annotation="skip" kind="custom" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
+		<comment xml:space="preserve">Appends an X (custom) value to the @array. See also i_cal_enum_array_element_add_x_value(), i_cal_enum_array_element_append_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_element_add_value" corresponds="icalenumarray_add" annotation="skip" kind="custom" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="gint" name="value" comment="The integer value to append"/>
+		<comment xml:space="preserve">Adds an integer value to the @array, omitting duplicates. See also i_cal_enum_array_element_append_value(), i_cal_enum_array_element_add_x_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.val = value;
+    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enum_array_element_add_x_value" corresponds="icalenumarray_add" annotation="skip" kind="custom" since="4.0">
+		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
+		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
+		<comment xml:space="preserve">Adds an X (custom) value to the @array, omitting duplicates. See also i_cal_enum_array_element_append_x_value(), i_cal_enum_array_element_add_value()</comment>
+		<custom>    icalenumarray_element elem = { 0 };
+    g_return_if_fail(I_CAL_IS_ENUM_ARRAY(array));
+    elem.xvalue = xvalue;
+    icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
+	</method>
+	<method name="i_cal_enumarray_remove_element_at" corresponds="icalenumarray_remove_element_at" kind="custom" since="4.0">
+		<parameter type="ICalEnumArray *" name="array"  comment="The #ICalEnumArray to be modified"/>
+		<parameter type="gint" name="position" comment="The position in which the element will be removed from the array"/>
+		<comment xml:space="preserve">Removes the element at the @position from the array.</comment>
+	</method>
+	<method name="i_cal_enum_array_element_get_value_at" corresponds="icalenumarray_element_at" annotation="skip" kind="other" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be queried"/>
 		<parameter type="gsize" name="position" comment="The position the target element is located"/>
 		<returns type="gint" comment="The element integer value located at the @position in the @array"/>
@@ -22,7 +72,7 @@
         return 0;
     return elem->val;</custom>
 	</method>
-	<method name="i_cal_enum_array_get_xvalue_at" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_element_get_xvalue_at" corresponds="icalenumarray_element_at" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray to be queried"/>
 		<parameter type="gsize" name="position" comment="The position the target element is located"/>
 		<returns type="const gchar *" annotation="transfer none,nullable" comment="The element X value located at the @position in the @array"/>
@@ -39,7 +89,7 @@
 		<returns type="gsize" error_return_value="((gsize)-1)" comment="The size of current array."/>
 		<comment>Gets the size of the array.</comment>
 	</method>
-	<method name="i_cal_enum_array_find_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_find_value" corresponds="icalenumarray_find" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="gint" name="value" comment="The integer value to search for"/>
 		<returns type="gsize" error_return_value="((gsize)-1)" comment="The index of the value in the @array, or an index out of bounds, if not found."/>
@@ -49,7 +99,7 @@
     elem.val = value;
     return icalenumarray_find((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
 	</method>
-	<method name="i_cal_enum_array_find_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_find_x_value" corresponds="icalenumarray_find" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to search for"/>
 		<returns type="gsize" error_return_value="((gsize)-1)" comment="The index of the value in the @array, or an index out of bounds, if not found."/>
@@ -59,7 +109,7 @@
     elem.xvalue = xvalue;
     return icalenumarray_find((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
 	</method>
-	<method name="i_cal_enum_array_append_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_append_value" corresponds="icalenumarray_append" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="gint" name="value" comment="The integer value to append"/>
 		<comment xml:space="preserve">Appends an integer value to the @array. See also i_cal_enum_array_add_value(), i_cal_enum_array_append_x_value()</comment>
@@ -68,7 +118,7 @@
     elem.val = value;
     icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
 	</method>
-	<method name="i_cal_enum_array_append_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_append_x_value" corresponds="icalenumarray_append" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
 		<comment xml:space="preserve">Appends an X (custom) value to the @array. See also i_cal_enum_array_add_x_value(), i_cal_enum_array_append_value()</comment>
@@ -77,7 +127,7 @@
     elem.xvalue = xvalue;
     icalenumarray_append((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
 	</method>
-	<method name="i_cal_enum_array_add_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_add_value" corresponds="icalenumarray_add" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="gint" name="value" comment="The integer value to append"/>
 		<comment xml:space="preserve">Adds an integer value to the @array, omitting duplicates. See also i_cal_enum_array_append_value(), i_cal_enum_array_add_x_value()</comment>
@@ -86,7 +136,7 @@
     elem.val = value;
     icalenumarray_add((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
 	</method>
-	<method name="i_cal_enum_array_add_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_add_x_value" corresponds="icalenumarray_add" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to append"/>
 		<comment xml:space="preserve">Adds an X (custom) value to the @array, omitting duplicates. See also i_cal_enum_array_append_x_value(), i_cal_enum_array_add_value()</comment>
@@ -100,7 +150,7 @@
 		<parameter type="gsize" name="position" comment="The position in which the element will be removed from the array"/>
 		<comment xml:space="preserve">Removes the element at the @position from the array.</comment>
 	</method>
-	<method name="i_cal_enum_array_remove_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_remove_value" corresponds="icalenumarray_remove" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="gint" name="value" comment="The integer value to remove"/>
 		<comment xml:space="preserve">Removes all occurrences of an integer value from the @array. See also i_cal_enum_array_remove_x_value()</comment>
@@ -109,7 +159,7 @@
     elem.val = value;
     icalenumarray_remove((icalenumarray *)i_cal_object_get_native((ICalObject *)array), &amp;elem);</custom>
 	</method>
-	<method name="i_cal_enum_array_remove_x_value" corresponds="CUSTOM" annotation="skip" kind="other" since="4.0">
+	<method name="i_cal_enum_array_remove_x_value" corresponds="icalenumarray_remove" annotation="skip" kind="custom" since="4.0">
 		<parameter type="ICalEnumArray *" name="array" comment="The #ICalEnumArray"/>
 		<parameter type="const gchar *" name="xvalue" comment="The X (custom) value to remove"/>
 		<comment xml:space="preserve">Removes all occurrences of an X (custom) value from the @array. See also i_cal_enum_array_remove_value()</comment>

--- a/src/libical-glib/api/i-cal-enums.xml
+++ b/src/libical-glib/api/i-cal-enums.xml
@@ -6,6 +6,27 @@
 
 -->
 <structure namespace="ICal" name="Enums">
+    <skip>icalenum_property_kind_to_string</skip>
+    <skip>icalenum_string_to_property_kind</skip>
+    <skip>icalenum_property_kind_to_value_kind</skip>
+    <skip>icalenum_method_to_string</skip>
+    <skip>icalenum_string_to_method</skip>
+    <skip>icalenum_status_to_string</skip>
+    <skip>icalenum_string_to_status</skip>
+    <skip>icalenum_string_to_value_kind</skip>
+    <skip>icalenum_value_kind_to_string</skip>
+    <skip>icalenum_component_kind_to_string</skip>
+    <skip>icalenum_string_to_component_kind</skip>
+    <skip>icalenum_action_to_string</skip>
+    <skip>icalenum_string_to_action</skip>
+    <skip>icalenum_transp_to_string</skip>
+    <skip>icalenum_string_to_transp</skip>
+    <skip>icalenum_class_to_string</skip>
+    <skip>icalenum_string_to_class</skip>
+    <skip>icalenum_participanttype_to_string</skip>
+    <skip>icalenum_string_to_participanttype</skip>
+    <skip>icalenum_resourcetype_to_string</skip>
+    <skip>icalenum_string_to_resourcetype</skip>
     <enum name="ICalComponentKind" native_name="icalcomponent_kind" default_native="I_CAL_NO_COMPONENT">
         <element name="ICAL_NO_COMPONENT"/>
         <element name="ICAL_ANY_COMPONENT"/>
@@ -84,7 +105,7 @@
         <element name="ICAL_5_2_NOSERVICE_STATUS"/>
         <element name="ICAL_5_3_NOSCHED_STATUS"/>
         <element name="ICAL_6_1_CONTAINER_NOT_FOUND"/>
-		<element name="ICAL_9_0_UNRECOGNIZED_COMMAND"/>
+	<element name="ICAL_9_0_UNRECOGNIZED_COMMAND"/>
     </enum>
     <method name="i_cal_request_status_desc" corresponds="icalenum_reqstat_desc" since="1.0">
         <parameter type="ICalRequestStatus" name="stat" comment="The #ICalRequestStatus to be translated"/>

--- a/src/libical-glib/api/i-cal-error.xml
+++ b/src/libical-glib/api/i-cal-error.xml
@@ -6,6 +6,17 @@
 
 -->
 <structure namespace="ICal" name="Error">
+    <skip>icalerror_assert</skip>
+    <skip>icalerror_check_arg</skip>
+    <skip>icalerror_check_arg_re</skip>
+    <skip>icalerror_check_arg_rv</skip>
+    <skip>icalerror_check_arg_rx</skip>
+    <skip>icalerror_check_arg_rz</skip>
+    <skip>icalerror_check_component_type</skip>
+    <skip>icalerror_check_parameter_type</skip>
+    <skip>icalerror_check_property_type</skip>
+    <skip>icalerror_check_value_type</skip>
+    <skip>icalerror_warn</skip>
     <enum name="ICalErrorEnum" native_name="icalerrorenum" default_native="I_CAL_UNKNOWN_ERROR">
         <element name="ICAL_NO_ERROR"/>
         <element name="ICAL_BADARG_ERROR"/>
@@ -67,5 +78,18 @@
         <parameter type="const gchar *" name="error" comment="The error to be restored"/>
         <parameter type="ICalErrorState" name="es" comment="The error state to be restored"/>
         <comment xml:space="preserve">Restores the error to specified state.</comment>
+    </method>
+    <method name="i_cal_error_error_from_string" corresponds="icalerror_error_from_string" since="4.0">
+        <parameter type="const gchar *" name="str" comment="The error name string"/>
+        <returns type="ICalErrorEnum" comment="An #ICalErrorEnum representation of the error @str" />
+        <comment xml:space="preserve">Reads an error from a string.</comment>
+    </method>
+    <method name="i_cal_error_get_errors_are_fatal" corresponds="icalerror_get_errors_are_fatal" since="4.0">
+        <returns type="gboolean" comment="whether errors are fatal" />
+        <comment xml:space="preserve">Determine whether errors are fatal.</comment>
+    </method>
+    <method name="i_cal_error_set_errors_are_fatal" corresponds="icalerror_set_errors_are_fatal" since="4.0">
+        <parameter type="gboolean" name="value" comment="value to set"/>
+        <comment xml:space="preserve">Sets whether errors are fatal, that is, whether libical aborts after any processing reports an error.</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-geo.xml
+++ b/src/libical-glib/api/i-cal-geo.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="Geo" native="struct icalgeotype" is_bare="true" default_native="i_cal_geo_new_default ()">
-    <method name="i_cal_geo_new_default" corresponds="CUSTOM" annotation="skip" kind="private" since="1.0">
+    <method name="i_cal_geo_new_default" corresponds="none" annotation="skip" kind="private" since="1.0">
         <returns type="struct icalgeotype" annotation="transfer full" comment="The newly created #ICalGeo" />
         <comment xml:space="preserve">Creates a new default #ICalGeo.</comment>
         <custom>	struct icalgeotype geotype;
@@ -14,7 +14,7 @@
   memset(geotype.lon, 0, ICAL_GEO_LEN);
 	return geotype;</custom>
     </method>
-    <method name="i_cal_geo_new" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_geo_new" corresponds="none" kind="constructor" since="1.0">
         <parameter type="gdouble" name="lat" comment="Latitude"/>
         <parameter type="gdouble" name="lon" comment="Longitude"/>
         <returns type="ICalGeo *" annotation="transfer full" comment="The newly created #ICalGeo." />
@@ -26,7 +26,7 @@
 
     return i_cal_geo_new_full(geo);</custom>
     </method>
-    <method name="i_cal_geo_clone" corresponds="CUSTOM" kind="clone" since="1.0">
+    <method name="i_cal_geo_clone" corresponds="none" kind="clone" since="1.0">
         <parameter type="const ICalGeo *" name="geo" comment="The #ICalGeo to clone"/>
         <returns type="ICalGeo *" annotation="transfer full" comment="The newly created #ICalGeo, copy of @geo." />
         <comment xml:space="preserve">Creates a new #ICalGeo, copy of @geo.</comment>
@@ -39,7 +39,7 @@
 
     return i_cal_geo_new_full(*src);</custom>
     </method>
-    <method name="i_cal_geo_get_lat" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_geo_get_lat" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalGeo *" name="geo" comment="The #ICalGeo to be queried"/>
         <returns type="gdouble" comment="The latitude." />
         <comment xml:space="preserve">Gets the latitude of #ICalGeo.</comment>
@@ -48,7 +48,7 @@
     native = (struct icalgeotype *)i_cal_object_get_native ((ICalObject *)geo);
     return g_ascii_strtod(native->lat, NULL);</custom>
     </method>
-    <method name="i_cal_geo_set_lat" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_geo_set_lat" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalGeo *" name="geo" comment="The #ICalGeo to be set"/>
         <parameter type="gdouble" name="lat" comment="The latitude"/>
         <comment>Sets the latitude of #ICalGeo.</comment>
@@ -57,7 +57,7 @@
     native = (struct icalgeotype *)i_cal_object_get_native ((ICalObject *)geo);
     g_ascii_dtostr(native->lat, ICAL_GEO_LEN, lat);</custom>
     </method>
-    <method name="i_cal_geo_get_lon" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_geo_get_lon" corresponds="none" kind="get" since="1.0">
 	<parameter type="ICalGeo *" name="geo" comment="The #ICalGeo to be queried"/>
         <returns type="gdouble" comment="The longitude." />
         <comment xml:space="preserve">Gets the longitude of #ICalGeo.</comment>
@@ -66,7 +66,7 @@
     native = (struct icalgeotype *)i_cal_object_get_native ((ICalObject *)geo);
     return g_ascii_strtod(native->lon, NULL);</custom>
     </method>
-    <method name="i_cal_geo_set_lon" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_geo_set_lon" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalGeo *" name="geo" comment="The #ICalGeo to be set"/>
         <parameter type="gdouble" name="lon" comment="The longitude"/>
         <comment>Sets the longitude of #ICalGeo.</comment>

--- a/src/libical-glib/api/i-cal-memory.xml
+++ b/src/libical-glib/api/i-cal-memory.xml
@@ -6,6 +6,8 @@
 
 -->
 <structure namespace="ICal" name="Memory">
+    <skip>icalmemory_get_mem_alloc_funcs</skip>
+    <skip>icalmemory_set_mem_alloc_funcs</skip>
     <method name="i_cal_memory_tmp_buffer" corresponds="icalmemory_tmp_buffer" since="1.0">
         <parameter type="size_t" name="size" comment="The size of the buffer to be created"/>
         <returns type="void *" annotation="transfer full" comment="The newly created buffer"/>
@@ -57,7 +59,7 @@
         <returns type="gchar *" annotation="transfer full" comment="The cloned string."/>
         <comment xml:space="preserve">A wrapper around strdup. Partly to trap calls to strdup, partly because in -ansi, gcc on Red Hat claims that strdup is undeclared.</comment>
     </method>
-    <method name="i_cal_memory_str_to_glib" corresponds="CUSTOM" annotation="skip" kind="private" since="1.0">
+    <method name="i_cal_memory_str_to_glib" corresponds="none" annotation="skip" kind="private" since="1.0">
         <parameter type="char *" annotation="transfer full, nullable" name="buffer" comment="The ical memory string to transform"/>
         <returns type="gchar *" annotation="transfer full, nullable" comment="The same string that can be freed with g_free"/>
         <comment xml:space="preserve">Transform a string allocated with icalmemory into one that can be freed with g_free.</comment>

--- a/src/libical-glib/api/i-cal-mime.xml
+++ b/src/libical-glib/api/i-cal-mime.xml
@@ -15,7 +15,7 @@
  * Returns: A #ICalComponent as a string
  */
 typedef gchar *(*ICalMimeParseFunc)(gchar *bytes, size_t size, gpointer user_data);</declaration>
-    <method name="i_cal_mime_parse" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_mime_parse" corresponds="icalmime_parse" kind="custom" since="1.0">
         <parameter type="ICalMimeParseFunc" name="func" annotation="scope call,closure user_data" comment="The parsing function"/>
         <parameter type="gpointer" name="user_data" comment="The date given to @func"/>
         <returns type="ICalComponent *" annotation="transfer full" comment="The parsed #ICalComponent"/>

--- a/src/libical-glib/api/i-cal-param-iter.xml
+++ b/src/libical-glib/api/i-cal-param-iter.xml
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 -->
 <structure namespace="ICal" name="ParamIter" native="struct icalparamiter" is_bare="true" default_native="i_cal_param_iter_new_default ()">
-        <method name="i_cal_param_iter_new_default" corresponds="CUSTOM" kind="private" since="1.0" annotation="skip">
+        <method name="i_cal_param_iter_new_default" corresponds="none" kind="private" since="1.0" annotation="skip">
                 <returns type="struct icalparamiter" annotation="transfer none" comment="The newly created default native icalparamiter"/>
                 <custom>        icalparamiter paramiter;
         paramiter.iter = 0;

--- a/src/libical-glib/api/i-cal-parameter.xml
+++ b/src/libical-glib/api/i-cal-parameter.xml
@@ -103,8 +103,23 @@
         <comment xml:space="preserve">Converts a string to the #ICalParameterKind.</comment>
     </method>
     <method name="i_cal_parameter_kind_is_valid" corresponds="icalparameter_kind_is_valid" since="3.0.5">
-        <parameter type="const ICalParameterKind" name="kind" comment="The #ICalPropertyKind"/>
+        <parameter type="ICalParameterKind" name="kind" comment="The #ICalParameterKind"/>
         <returns type="gboolean" comment="true if valid, false if not."/>
         <comment xml:space="preserve">Checks whether #ICalParameterKind is valid.</comment>
+    </method>
+    <method name="i_cal_parameter_kind_value_kind" corresponds="icalparameter_kind_value_kind" since="4.0">
+        <parameter type="ICalParameterKind" name="kind" comment="The #ICalParameterKind"/>
+        <parameter type="gboolean *" name="out_is_multivalued" annotation="out,optional" comment="location to store whether the parameter is multivalued, or %NULL to ignore"/>
+        <returns type="ICalValueKind" comment="an #ICalValueKind corresponding to the @kind"/>
+        <comment xml:space="preserve">Converts the @kind into an #ICalValueKind and optionally returns whether the @kind is a multivalued parameter.</comment>
+    </method>
+    <method name="i_cal_parameter_is_multivalued" corresponds="icalparameter_is_multivalued" since="4.0">
+        <parameter type="const ICalParameter *" name="param" comment="an #ICalParameter"/>
+        <returns type="gboolean" comment="whether the@param is a multivalued parameter"/>
+        <comment xml:space="preserve">Returns whether the @param is a multivalued parameter.</comment>
+    </method>
+    <method name="i_cal_parameter_decode_value" corresponds="icalparameter_decode_value" since="4.0">
+        <parameter type="gchar *" name="value" annotation="inout" comment="an #ICalParameter"/>
+        <comment xml:space="preserve">Converts the @value according to RFC 6868, changing the @value itself.</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-parser.xml
+++ b/src/libical-glib/api/i-cal-parser.xml
@@ -6,12 +6,19 @@
 
 -->
 <structure namespace="ICal" name="Parser" native="icalparser" destroy_func="icalparser_free">
+    <skip>icalparser_set_gen_data</skip>
+    <skip>icalparser_string_line_generator</skip>
     <enum name="ICalParserState" native_name="icalparser_state" default_native="I_CAL_PARSER_ERROR">
         <element name="ICALPARSER_ERROR"/>
         <element name="ICALPARSER_SUCCESS"/>
         <element name="ICALPARSER_BEGIN_COMP"/>
         <element name="ICALPARSER_END_COMP"/>
         <element name="ICALPARSER_IN_PROGRESS"/>
+    </enum>
+    <enum name="ICalParserCtrl" native_name="enum icalparser_ctrl" default_native="I_CAL_PARSER_CTRL_KEEP">
+        <element name="ICALPARSER_CTRL_KEEP"/>
+        <element name="ICALPARSER_CTRL_OMIT"/>
+        <element name="ICALPARSER_CTRL_ERROR"/>
     </enum>
     <declaration position="header">/**
  * ICalParserLineGenFunc:
@@ -46,7 +53,7 @@ typedef gchar *(*ICalParserLineGenFunc)(gchar *bytes, size_t size, gpointer user
         <parameter type="ICalParser *" name="parser" comment="The #ICalParser to be freed"/>
         <comment xml:space="preserve">Frees a #ICalParser.</comment>
     </method>
-    <method name="i_cal_parser_parse" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_parser_parse" corresponds="icalparser_parse" kind="custom" since="1.0">
         <parameter type="ICalParser *" name="parser" comment="The parser used to parse the string and output the #ICalComponent"/>
         <parameter type="ICalParserLineGenFunc" name="func" annotation="scope call,closure user_data" comment="The function used to parse"/>
         <parameter type="gpointer" name="user_data" comment="The data given to @func"/>
@@ -62,7 +69,7 @@ typedef gchar *(*ICalParserLineGenFunc)(gchar *bytes, size_t size, gpointer user
         <returns type="ICalComponent *" annotation="transfer full" comment="The #ICalComponent parsed from str."/>
         <comment xml:space="preserve">Parses the string into a #ICalComponent.</comment>
     </method>
-    <method name="i_cal_parser_get_line" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_parser_get_line" corresponds="icalparser_get_line" kind="custom" since="1.0">
         <parameter type="ICalParser *" name="parser" comment="The parser to be queried"/>
         <parameter type="ICalParserLineGenFunc" name="func" annotation="scope call,closure user_data" comment="A line generator function"/>
         <parameter type="gpointer" name="user_data" comment="The data given to @func"/>
@@ -76,5 +83,13 @@ typedef gchar *(*ICalParserLineGenFunc)(gchar *bytes, size_t size, gpointer user
 	linecopy = g_strdup(line);
 	i_cal_memory_free_buffer(line);
 	return linecopy;</custom>
+    </method>
+    <method name="i_cal_parser_get_ctrl" corresponds="icalparser_get_ctrl" kind="get" since="4.0">
+        <returns type="ICalParserCtrl" comment="Get the current parser setting how to handle CONTROL characters."/>
+        <comment xml:space="preserve">Gets the current parser setting how to handle CONTROL characters. @I_CAL_PARSER_CTRL_KEEP keeps CONTROL characters in content-line, @I_CAL_PARSER_CTRL_OMIT omits CONTROL characters from content-line and @I_CAL_PARSER_CTRL_ERROR inserts an X-LIC-ERROR instead of content-line</comment>
+    </method>
+    <method name="i_cal_parser_set_ctrl" corresponds="icalparser_set_ctrl" kind="set" since="4.0">
+        <parameter type="ICalParserCtrl" name="value" comment="an #ICalParserCtrl"/>
+        <comment xml:space="preserve">Sets the parser setting how to handle CONTROL characters. @I_CAL_PARSER_CTRL_KEEP keeps CONTROL characters in content-line, @I_CAL_PARSER_CTRL_OMIT omits CONTROL characters from content-line and @I_CAL_PARSER_CTRL_ERROR inserts an X-LIC-ERROR instead of content-line</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-period.xml
+++ b/src/libical-glib/api/i-cal-period.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="Period" native="struct icalperiodtype" is_bare="true" default_native="icalperiodtype_null_period ()">
-	<method name="i_cal_period_get_start" corresponds="CUSTOM" kind="get" since="1.0">
+	<method name="i_cal_period_get_start" corresponds="none" kind="get" since="1.0">
 		<parameter type="ICalPeriod *" name="period" comment="The #ICalPeriod to be queried"/>
 		<returns type="ICalTime *" annotation="transfer full" comment="The start of @period."/>
 		<comment>Gets the start time from an #ICalPeriod.</comment>
@@ -15,7 +15,7 @@
 
 	return i_cal_time_new_full ((* (struct icalperiodtype *)i_cal_object_get_native ((ICalObject *)period)).start);</custom>
 	</method>
-	<method name="i_cal_period_set_start" corresponds="CUSTOM" kind="set" since="1.0">
+	<method name="i_cal_period_set_start" corresponds="none" kind="set" since="1.0">
 		<parameter type="ICalPeriod *" name="period" comment="The #ICalPeriod to be set"/>
 		<parameter type="ICalTime *" name="start" comment="The start of @period"/>
 		<comment>Sets the start time of an #ICalPeriod.</comment>
@@ -28,7 +28,7 @@
 	periodtype = (struct icalperiodtype *)i_cal_object_get_native ((ICalObject *)period);
 	periodtype->start = * (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)start);</custom>
 	</method>
-	<method name="i_cal_period_get_end" corresponds="CUSTOM" kind="get" since="1.0">
+	<method name="i_cal_period_get_end" corresponds="none" kind="get" since="1.0">
 		<parameter type="ICalPeriod *" name="period" comment="The #ICalPeriod to be queried"/>
 		<returns type="ICalTime *" annotation="transfer full" comment="The end of @period."/>
 		<comment>Gets the end time from an #ICalPeriod.</comment>
@@ -37,7 +37,7 @@
 
 	return i_cal_time_new_full ((* (struct icalperiodtype *)i_cal_object_get_native ((ICalObject *)period)).end);</custom>
 	</method>
-	<method name="i_cal_period_set_end" corresponds="CUSTOM" kind="set" since="1.0">
+	<method name="i_cal_period_set_end" corresponds="none" kind="set" since="1.0">
 		<parameter type="ICalPeriod *" name="period" comment="The #ICalPeriod to be set"/>
 		<parameter type="ICalTime *" name="end" comment="The end of @period"/>
 		<comment>Sets the end time of an #ICalPeriod.</comment>
@@ -50,7 +50,7 @@
 	periodtype = (struct icalperiodtype *)i_cal_object_get_native ((ICalObject *)period);
 	periodtype->end = (* (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)end));</custom>
 	</method>
-	<method name="i_cal_period_get_duration" corresponds="CUSTOM" kind="get" since="1.0">
+	<method name="i_cal_period_get_duration" corresponds="none" kind="get" since="1.0">
 		<parameter type="ICalPeriod *" name="period" comment="The #ICalPeriod to be queried"/>
 		<returns type="ICalDuration *" annotation="transfer full" comment="The duration of @period."/>
 		<comment>Gets the duration from an #ICalPeriod.</comment>
@@ -59,7 +59,7 @@
 
 	return i_cal_duration_new_full ((* (struct icalperiodtype *)i_cal_object_get_native ((ICalObject *)period)).duration);</custom>
 	</method>
-	<method name="i_cal_period_set_duration" corresponds="CUSTOM" kind="set" since="1.0">
+	<method name="i_cal_period_set_duration" corresponds="none" kind="set" since="1.0">
 		<parameter type="ICalPeriod *" name="period" comment="The #ICalPeriod to be set"/>
 		<parameter type="ICalDuration *" name="duration" comment="The duration of @period"/>
 		<comment>Sets the duration of an #ICalPeriod.</comment>

--- a/src/libical-glib/api/i-cal-prop-iter.xml
+++ b/src/libical-glib/api/i-cal-prop-iter.xml
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 -->
 <structure namespace="ICal" name="PropIter" native="struct icalpropiter" is_bare="true" default_native="i_cal_prop_iter_new_default ()">
-        <method name="i_cal_prop_iter_new_default" corresponds="CUSTOM" kind="private" since="1.0" annotation="skip">
+        <method name="i_cal_prop_iter_new_default" corresponds="none" kind="private" since="1.0" annotation="skip">
                 <returns type="struct icalpropiter" annotation="transfer none" comment="The newly created default native icalpropiter"/>
                 <custom>        icalpropiter propiter;
         propiter.iter = 0;

--- a/src/libical-glib/api/i-cal-property.xml
+++ b/src/libical-glib/api/i-cal-property.xml
@@ -6,6 +6,8 @@
 
 -->
 <structure namespace="ICal" name="Property" native="icalproperty" destroy_func="icalproperty_free">
+    <skip>icalproperty_new_impl</skip>
+    <skip>icalproperty_add_parameters</skip>
     <method name="i_cal_property_new" corresponds="icalproperty_new" kind="constructor" since="1.0">
         <parameter type="ICalPropertyKind" name="kind" comment="The kind of #ICalProperty to be created"/>
         <returns type="ICalProperty *" annotation="transfer full" comment="The newly created #ICalProperty with the type @kind."/>
@@ -45,7 +47,7 @@
         <parameter type="ICalParameter *" name="parameter" annotation="transfer none" owner_op="prop" comment="The parameter to be added into @prop"/>
         <comment xml:space="preserve">Adds a #ICalParameter into the #ICalProperty. It behaves like set the copy of the #ICalParameter. Upon completion the native part of #ICalParameter will be set to NULL.</comment>
     </method>
-    <method name="i_cal_property_take_parameter" corresponds="CUSTOM" annotation="skip" since="1.0">
+    <method name="i_cal_property_take_parameter" corresponds="icalproperty_add_parameter" kind="custom" annotation="skip" since="1.0">
         <parameter type="ICalProperty *" name="prop" comment="The #ICalProperty to be set"/>
         <parameter type="ICalParameter *" name="parameter" annotation="transfer full" comment="The parameter to be added into @prop"/>
         <comment xml:space="preserve">Adds the @parameter into the @prop and free the @parameter.</comment>
@@ -109,7 +111,7 @@
         <parameter type="ICalValue *" name="value" owner_op="prop" comment="The #ICalValue will be set as the property of @prop"/>
         <comment xml:space="preserve">Sets the #ICalProperty with the #ICalValue.</comment>
     </method>
-    <method name="i_cal_property_take_value" corresponds="CUSTOM" annotation="skip" since="1.0">
+    <method name="i_cal_property_take_value" corresponds="icalproperty_set_value" kind="custom" annotation="skip" since="1.0">
         <parameter type="ICalProperty *" name="prop" comment="The target #ICalProperty"/>
         <parameter type="ICalValue *" name="value" annotation="transfer full" comment="The #ICalValue will be set as the property of @prop"/>
         <comment xml:space="preserve">Sets the @prop with the @value and unrefs the @value.</comment>
@@ -237,7 +239,11 @@
         <returns type="gboolean" comment="true if yes, false if not."/>
         <comment xml:space="preserve">Checks whether the enum belongs to the #ICalPropertyKind.</comment>
     </method>
-    <method name="i_cal_property_begin_parameter" corresponds="CUSTOM" since="4.0">
+    <method name="i_cal_property_normalize" corresponds="icalproperty_normalize" since="4.0">
+        <parameter type="ICalProperty *" name="prop" comment="an #ICalProperty"/>
+        <comment xml:space="preserve">Normalizes (reorders and sorts the parameters) the specified @prop.</comment>
+    </method>
+    <method name="i_cal_property_begin_parameter" corresponds="icalproperty_begin_parameter" kind="custom" since="4.0">
         <parameter type="ICalProperty *" name="prop" comment="A #ICalProperty"/>
         <parameter type="ICalParameterKind" name="kind" comment="A #ICalParameterKind"/>
         <returns type="ICalParamIter *" annotation="transfer full" comment="A #ICalParamIter"/>
@@ -254,7 +260,7 @@
 
     return iter;</custom>
     </method>
-    <method name="i_cal_param_iter_next" corresponds="CUSTOM" since="4.0">
+    <method name="i_cal_param_iter_next" corresponds="icalparamiter_next" kind="custom" since="4.0">
         <parameter type="ICalParamIter *" name="i" native_op="POINTER" comment="A #ICalParamIter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="A #ICalParameter"/>
         <comment xml:space="preserve">Gets the next #ICalParameter pointed by #ICalParamIter.</comment>
@@ -271,7 +277,7 @@
 
     return param;</custom>
     </method>
-    <method name="i_cal_param_iter_deref" corresponds="CUSTOM" since="4.0">
+    <method name="i_cal_param_iter_deref" corresponds="icalparamiter_deref" kind="custom" since="4.0">
         <parameter type="ICalParamIter *" name="i" native_op="POINTER" comment="A #ICalParamIter"/>
         <returns type="ICalParameter *" annotation="transfer full" comment="A #ICalParameter"/>
         <comment xml:space="preserve">Gets the current #ICalParameter pointed by #ICalParamIter.</comment>
@@ -287,5 +293,55 @@
     }
 
     return param;</custom>
+    </method>
+    <method name="i_cal_property_action_from_string" corresponds="icalproperty_string_to_action" since="4.0">
+        <parameter type="const gchar *" name="str" comment="A string"/>
+        <returns type="ICalPropertyAction" comment="The #ICalPropertyAction."/>
+        <comment xml:space="preserve">Converts the string to #ICalPropertyAction.</comment>
+    </method>
+    <method name="i_cal_property_action_to_string" corresponds="icalproperty_action_to_string" since="4.0">
+        <parameter type="ICalPropertyAction" name="value" comment="The #ICalPropertyAction"/>
+        <returns type="const gchar *" comment="The string representation of #ICalPropertyAction."/>
+        <comment xml:space="preserve">Converts the #ICalPropertyAction to string.</comment>
+    </method>
+    <method name="i_cal_property_transp_from_string" corresponds="icalproperty_string_to_transp" since="4.0">
+        <parameter type="const gchar *" name="str" comment="A string"/>
+        <returns type="ICalPropertyTransp" comment="The #ICalPropertyTransp."/>
+        <comment xml:space="preserve">Converts the string to #ICalPropertyTransp.</comment>
+    </method>
+    <method name="i_cal_property_transp_to_string" corresponds="icalproperty_transp_to_string" since="4.0">
+        <parameter type="ICalPropertyTransp" name="value" comment="The #ICalPropertyTransp"/>
+        <returns type="const gchar *" comment="The string representation of #ICalPropertyTransp."/>
+        <comment xml:space="preserve">Converts the #ICalPropertyTransp to string.</comment>
+    </method>
+    <method name="i_cal_property_classenum_from_string" corresponds="icalproperty_string_to_class" since="4.0">
+        <parameter type="const gchar *" name="str" comment="A string"/>
+        <returns type="ICalPropertyClassenum" comment="The #ICalPropertyClassenum."/>
+        <comment xml:space="preserve">Converts the string to #ICalPropertyClassenum.</comment>
+    </method>
+    <method name="i_cal_property_classenum_to_string" corresponds="icalproperty_class_to_string" since="4.0">
+        <parameter type="ICalPropertyClassenum" name="value" comment="The #ICalPropertyClassenum"/>
+        <returns type="const gchar *" comment="The string representation of #ICalPropertyClassenum."/>
+        <comment xml:space="preserve">Converts the #ICalPropertyClassenum to string.</comment>
+    </method>
+    <method name="i_cal_property_participanttype_from_string" corresponds="icalproperty_string_to_participanttype" since="4.0">
+        <parameter type="const gchar *" name="str" comment="A string"/>
+        <returns type="ICalPropertyParticipanttype" comment="The #ICalPropertyParticipanttype."/>
+        <comment xml:space="preserve">Converts the string to #ICalPropertyParticipanttype.</comment>
+    </method>
+    <method name="i_cal_property_participanttype_to_string" corresponds="icalproperty_participanttype_to_string" since="4.0">
+        <parameter type="ICalPropertyParticipanttype" name="value" comment="The #ICalPropertyParticipanttype"/>
+        <returns type="const gchar *" comment="The string representation of #ICalPropertyParticipanttype."/>
+        <comment xml:space="preserve">Converts the #ICalPropertyParticipanttype to string.</comment>
+    </method>
+    <method name="i_cal_property_resourcetype_from_string" corresponds="icalproperty_string_to_resourcetype" since="4.0">
+        <parameter type="const gchar *" name="str" comment="A string"/>
+        <returns type="ICalPropertyResourcetype" comment="The #ICalPropertyResourcetype."/>
+        <comment xml:space="preserve">Converts the string to #ICalPropertyResourcetype.</comment>
+    </method>
+    <method name="i_cal_property_resourcetype_to_string" corresponds="icalproperty_resourcetype_to_string" since="4.0">
+        <parameter type="ICalPropertyResourcetype" name="value" comment="The #ICalPropertyResourcetype"/>
+        <returns type="const gchar *" comment="The string representation of #ICalPropertyResourcetype."/>
+        <comment xml:space="preserve">Converts the #ICalPropertyResourcetype to string.</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-recur-iterator.xml
+++ b/src/libical-glib/api/i-cal-recur-iterator.xml
@@ -17,6 +17,11 @@
         <returns type="ICalTime *" annotation="transfer full" comment="The next occurrence according to this recurrence rule."/>
         <comment xml:space="preserve">Gets the next occurrence from an iterator.</comment>
     </method>
+    <method name="i_cal_recur_iterator_prev" corresponds="icalrecur_iterator_prev" since="4.0">
+        <parameter type="ICalRecurIterator *" name="iterator" comment="The iterator"/>
+        <returns type="ICalTime *" annotation="transfer full" comment="The previous occurrence according to this recurrence rule."/>
+        <comment xml:space="preserve">Gets the previous occurrence from an iterator.</comment>
+    </method>
     <method name="i_cal_recur_iterator_set_start" corresponds="icalrecur_iterator_set_start" since="3.0">
         <parameter type="ICalRecurIterator *" name="iterator" comment="The iterator"/>
         <parameter type="ICalTime *" name="start" comment="The date-time to move the iterator to"/>
@@ -29,6 +34,26 @@ Note: CAN NOT be used with RRULEs that contain COUNT.</comment>
         <parameter type="ICalTime *" name="end" comment="The date-time at which the iterator will stop"/>
         <returns type="gboolean" comment="true if succeeded, false if failed"/>
         <comment xml:space="preserve">Sets the date-time at which the iterator will stop at the latest. Values equal to or greater than end will not be returned by the iterator.</comment>
+    </method>
+    <method name="i_cal_recur_iterator_set_range" corresponds="icalrecur_iterator_set_range" since="4.0">
+        <parameter type="ICalRecurIterator *" name="iterator" comment="The iterator"/>
+        <parameter type="const ICalTime *" name="from" comment="The start date-time for the iterator"/>
+        <parameter type="const ICalTime *" name="to" comment="The end date-time for the iterator"/>
+        <returns type="gboolean" comment="%TRUE if succeeded, %FALSE failed, like when the recurrence type is unsupported."/>
+        <comment xml:space="preserve">Sets the date-times over which the iterator will run,
+where @from is a value between DTSTART and UNTIL.
+
+If @to is a null time, the forward iterator will return values
+up to and including UNTIL (if present), otherwise up to the year 2582.
+
+If @to is non-null time and later than @from,
+the forward iterator will return values up to and including @to.
+
+If @to is non-null time and earlier than @from,
+the reverse iterator will be set to start at @from
+and will return values down to and including @to.
+
+Note: CAN NOT be used with RRULEs that contain COUNT.</comment>
     </method>
     <method name="i_cal_recur_iterator_free" corresponds="icalrecur_iterator_free" annotation="skip" kind="destructor" since="1.0">
         <parameter type="ICalRecurIterator *" name="iterator" comment="The iterator to be freed"/>

--- a/src/libical-glib/api/i-cal-recur.xml
+++ b/src/libical-glib/api/i-cal-recur.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="Recur">
-    <method name="i_cal_recur_expand_recurrence" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_recur_expand_recurrence" corresponds="icalrecur_expand_recurrence" kind="custom" since="1.0">
         <parameter type="const gchar *" name="rule" comment="The rule of the recurrence"/>
         <parameter type="time_t" name="start" comment="The start seconds past the POSIX epoch"/>
         <parameter type="gint" name="count" comment="The number of elements to be filled up in the @array"/>
@@ -57,5 +57,17 @@
         <parameter type="ICalRecurrenceSkip" name="kind" comment="The frequency enum"/>
         <returns type="const gchar *" comment="The string representation of skip"/>
         <comment xml:space="preserve">Converts an enum representation to a string representation for the skip.</comment>
-        </method>
+    </method>
+    <enum name="ICalInvalidRruleHandling" native_name="ical_invalid_rrule_handling" default_native="I_CAL_RRULE_TREAT_AS_ERROR">
+        <element name="ICAL_RRULE_TREAT_AS_ERROR"/>
+        <element name="ICAL_RRULE_IGNORE_INVALID"/>
+    </enum>
+    <method name="i_cal_recur_get_invalid_rrule_handling_setting" corresponds="ical_get_invalid_rrule_handling_setting" since="4.0">
+        <returns type="ICalInvalidRruleHandling" comment="The current setting"/>
+        <comment xml:space="preserve">Returns the current behaviour what to do when an RRULE is invalid.</comment>
+    </method>
+    <method name="i_cal_recur_set_invalid_rrule_handling_setting" corresponds="ical_set_invalid_rrule_handling_setting" since="4.0">
+        <parameter type="ICalInvalidRruleHandling" name="value" comment="the setting"/>
+        <comment xml:space="preserve">Sets what to do when an invalid RRULE is recognized.</comment>
+    </method>
 </structure>

--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -61,11 +61,11 @@
 	<returns type="ICalArray *" annotation="transfer full" translator_argus="NULL, FALSE" comment="Array of calendars. Currently always NULL."/>
 	<comment xml:space="preserve">Gets an array of calendars supporting rscale (currently always return NULL).</comment>
     </method>
-    <method name="i_cal_recurrence_new_default" corresponds="CUSTOM" annotation="skip" kind="private" since="1.0">
+    <method name="i_cal_recurrence_new_default" corresponds="icalrecurrencetype_new" annotation="skip" kind="private" since="1.0">
         <returns type="struct icalrecurrencetype *" comment="The default value."/>
         <custom>	return icalrecurrencetype_new();</custom>
     </method>
-    <method name="i_cal_recurrence_new" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_recurrence_new" corresponds="icalrecurrencetype_new" kind="constructor" since="1.0">
         <returns type="ICalRecurrence *" annotation="transfer full" comment="The newly created #ICalRecurrence." />
         <comment xml:space="preserve">Creates a new #ICalRecurrence.</comment>
         <custom>	return i_cal_recurrence_new_full(i_cal_recurrence_new_default(), NULL);</custom>
@@ -125,14 +125,14 @@
         <returns type="gchar *" annotation="transfer full" comment="The string representation of @recur." translator="i_cal_memory_str_to_glib"/>
         <comment xml:space="preserve">Converts a #ICalRecurrence to a string.</comment>
     </method>
-    <method name="i_cal_recurrence_get_until" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_recurrence_get_until" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The until of #ICalRecurrence."/>
         <comment>Gets the until from #ICalRecurrence.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), NULL);
 	return i_cal_time_new_full (((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->until);</custom>
     </method>
-    <method name="i_cal_recurrence_set_until" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_recurrence_set_until" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalTime *" name="until" comment="The until of #ICalRecurrence"/>
         <comment>Sets the until from #ICalRecurrence.</comment>
@@ -140,63 +140,63 @@
 	g_return_if_fail (until != NULL &amp;&amp; I_CAL_IS_TIME(until));
 	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->until = *(icaltimetype *)i_cal_object_get_native ((ICalObject *)until);</custom>
     </method>
-    <method name="i_cal_recurrence_get_freq" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_recurrence_get_freq" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="ICalRecurrenceFrequency" comment="The freq of #ICalRecurrence."/>
         <comment>Gets the freq from #ICalRecurrence.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_NO_RECURRENCE);
 	return (ICalRecurrenceFrequency) (((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->freq);</custom>
     </method>
-    <method name="i_cal_recurrence_set_freq" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_recurrence_set_freq" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceFrequency" name="freq" comment="The freq of #ICalRecurrence"/>
         <comment>Sets the freq from #ICalRecurrence.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	((struct icalrecurrencetype *) i_cal_object_get_native ((ICalObject *)recur))->freq = (icalrecurrencetype_frequency) freq;</custom>
     </method>
-    <method name="i_cal_recurrence_get_count" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_recurrence_get_count" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="gint" comment="The count of #ICalRecurrence."/>
         <comment>Gets the count from #ICalRecurrence.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0);
 	return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->count;</custom>
     </method>
-    <method name="i_cal_recurrence_set_count" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_recurrence_set_count" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="gint" name="count" comment="The count of #ICalRecurrence"/>
         <comment>Sets the count from #ICalRecurrence.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->count = count;</custom>
     </method>
-    <method name="i_cal_recurrence_get_interval" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_recurrence_get_interval" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="gshort" comment="The interval of #ICalRecurrence."/>
         <comment>Gets the interval from #ICalRecurrence.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), 0);
 	return ((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->interval;</custom>
     </method>
-    <method name="i_cal_recurrence_set_interval" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_recurrence_set_interval" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="gshort" name="interval" comment="The interval of #ICalRecurrence"/>
         <comment>Sets the interval from #ICalRecurrence.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->interval = interval;</custom>
     </method>
-    <method name="i_cal_recurrence_get_week_start" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_recurrence_get_week_start" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <returns type="ICalRecurrenceWeekday" comment="The week_start of #ICalRecurrence."/>
         <comment>Gets the week_start from #ICalRecurrence.</comment>
         <custom>	g_return_val_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur), I_CAL_NO_WEEKDAY);
 	return (ICalRecurrenceWeekday) (((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->week_start);</custom>
     </method>
-    <method name="i_cal_recurrence_set_week_start" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_recurrence_set_week_start" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceWeekday" name="week_start" comment="The week_start of #ICalRecurrence"/>
         <comment>Sets the week_start from #ICalRecurrence.</comment>
         <custom>	g_return_if_fail (recur != NULL &amp;&amp; I_CAL_IS_RECURRENCE (recur));
 	((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->week_start = (icalrecurrencetype_weekday) week_start;</custom>
     </method>
-    <method name="i_cal_recurrence_get_by_array" corresponds="CUSTOM" kind="get" since="4.0">
+    <method name="i_cal_recurrence_get_by_array" corresponds="none" kind="get" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <returns type="GArray *" annotation="transfer full, element-type gshort" comment="The by[byrule] of #ICalRecurrence."/>
@@ -208,7 +208,7 @@
     if (by->size) g_array_append_vals (array, by->data, by->size);
 	return array;</custom>
     </method>
-    <method name="i_cal_recurrence_get_by_array_size" corresponds="CUSTOM" kind="get" since="4.0">
+    <method name="i_cal_recurrence_get_by_array_size" corresponds="none" kind="get" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <returns type="guint" comment="The current size of the given 'by' array."/>
@@ -218,7 +218,7 @@
     icalrecurrence_by_data *by = &amp;((struct icalrecurrencetype *)i_cal_object_get_native ((ICalObject *)recur))->by[byrule];
 	return by->size;</custom>
     </method>
-    <method name="i_cal_recurrence_set_by_array" corresponds="CUSTOM" kind="set" since="4.0">
+    <method name="i_cal_recurrence_set_by_array" corresponds="none" kind="set" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="GArray *" name="values" annotation="element-type gshort" comment="The array of values"/>
@@ -230,7 +230,7 @@
     g_return_if_fail(icalrecur_resize_by(by, values->len));
     memcpy(by->data, values->data, values->len * sizeof(by->data[0]));</custom>
     </method>
-    <method name="i_cal_recurrence_get_by" corresponds="CUSTOM" kind="get" since="4.0">
+    <method name="i_cal_recurrence_get_by" corresponds="none" kind="get" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="guint" name="index" comment="The index in the by[byrule] array of #ICalRecurrence."/>
@@ -242,7 +242,7 @@
     g_return_val_if_fail (index &lt; (guint)by->size, 0);
 	return by->data[index];</custom>
     </method>
-    <method name="i_cal_recurrence_set_by" corresponds="CUSTOM" kind="set" since="4.0">
+    <method name="i_cal_recurrence_set_by" corresponds="none" kind="set" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="guint" name="index" comment="The index in the 'by' array"/>
@@ -254,7 +254,7 @@
     if (((guint)by->size) &lt; (index + 1)) g_return_if_fail (icalrecur_resize_by(by, index + 1));
 	by->data[index] = value;</custom>
     </method>
-    <method name="i_cal_recurrence_resize_by_array" corresponds="CUSTOM" kind="others" since="4.0">
+    <method name="i_cal_recurrence_resize_by_array" corresponds="icalrecur_resize_by" kind="custom" since="4.0">
         <parameter type="ICalRecurrence *" name="recur" comment="The #ICalRecurrence"/>
         <parameter type="ICalRecurrenceByRule" name="byrule" comment="The 'by' part to use."/>
         <parameter type="guint" name="size" comment="The new size of the 'by' array"/>

--- a/src/libical-glib/api/i-cal-reqstat.xml
+++ b/src/libical-glib/api/i-cal-reqstat.xml
@@ -16,7 +16,7 @@
         <returns type="gchar *" annotation="transfer full" comment="A string." translator="i_cal_memory_str_to_glib"/>
         <comment xml:space="preserve">Converts #ICalReqstat to a string representation.</comment>
     </method>
-    <method name="i_cal_reqstat_new_default" corresponds="CUSTOM" kind="private" annotation="skip" since="1.0">
+    <method name="i_cal_reqstat_new_default" corresponds="none" kind="private" annotation="skip" since="1.0">
         <returns type="struct icalreqstattype" annotation="transfer full" comment="The newly created #ICalReqstat" />
         <comment xml:space="preserve">Creates a new default #ICalReqstat.</comment>
         <custom>        struct icalreqstattype reqstattype;
@@ -25,28 +25,28 @@
         reqstattype.debug = NULL;
         return reqstattype;</custom>
     </method>
-    <method name="i_cal_reqstat_get_code" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_reqstat_get_code" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalReqstat *" name="reqstat" comment="The #ICalReqstat"/>
         <returns type="ICalRequestStatus" comment="The code of @reqstat."/>
         <comment>Gets the code of #ICalReqstat.</comment>
         <custom>        g_return_val_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT (reqstat), I_CAL_UNKNOWN_STATUS);
         return (ICalRequestStatus) (((struct icalreqstattype *)i_cal_object_get_native ((ICalObject *)reqstat))->code);</custom>
     </method>
-    <method name="i_cal_reqstat_set_code" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_reqstat_set_code" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalReqstat *" name="reqstat" comment="The #ICalReqstat"/>
         <parameter type="ICalRequestStatus" name="code" comment="The code of @reqstat"/>
         <comment>Sets the code of #ICalReqstat.</comment>
         <custom>        g_return_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT (reqstat));
         ((struct icalreqstattype *)i_cal_object_get_native ((ICalObject *)reqstat))->code = (icalrequeststatus) (code);</custom>
     </method>
-    <method name="i_cal_reqstat_get_desc" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_reqstat_get_desc" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalReqstat *" name="reqstat" comment="The #ICalReqstat"/>
         <returns type="const gchar *" annotation="transfer none" comment="The desc of @reqstat."/>
         <comment>Gets the desc of #ICalReqstat.</comment>
         <custom>        g_return_val_if_fail (reqstat != NULL &amp;&amp; I_CAL_IS_REQSTAT ((ICalReqstat *)reqstat), NULL);
         return ((struct icalreqstattype *)i_cal_object_get_native ((ICalObject *)reqstat))->desc;</custom>
     </method>
-    <method name="i_cal_reqstat_get_debug" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_reqstat_get_debug" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalReqstat *" name="reqstat" comment="The #ICalReqstat"/>
         <returns type="const gchar *" annotation="transfer none" comment="The debug of @reqstat."/>
         <comment>Gets the debug of #ICalReqstat.</comment>

--- a/src/libical-glib/api/i-cal-time-span.xml
+++ b/src/libical-glib/api/i-cal-time-span.xml
@@ -6,7 +6,7 @@
 
 -->
 <structure namespace="ICal" name="TimeSpan" native="struct icaltime_span" is_bare="true" default_native="icaltime_span_new(icaltime_null_time(), icaltime_null_time(), 0)" includes="libical-glib/i-cal-time.h">
-    <method name="i_cal_time_span_new_timet" corresponds="CUSTOM" kind="constructor" since="3.0.5">
+    <method name="i_cal_time_span_new_timet" corresponds="none" kind="constructor" since="3.0.5">
         <parameter type="time_t" name="start" comment="Start of the time span"/>
         <parameter type="time_t" name="end" comment="End of the time span"/>
         <parameter type="gboolean" name="is_busy" comment="Whether the time span is busy"/>
@@ -18,7 +18,7 @@
     span.is_busy = is_busy ? 1 : 0;
     return i_cal_time_span_new_full(span);</custom>
     </method>
-    <method name="i_cal_time_span_clone" corresponds="CUSTOM" kind="constructor" since="3.0.5">
+    <method name="i_cal_time_span_clone" corresponds="none" kind="constructor" since="3.0.5">
         <parameter type="const ICalTimeSpan *" name="src" comment="A time span to clone"/>
         <returns type="ICalTimeSpan *" annotation="transfer full" comment="The newly created #ICalTimeSpan, clone of @src." />
         <comment xml:space="preserve">Creates a new #ICalTimeSpan, clone of @src. Free it with g_object_unref(), when no longer needed.</comment>
@@ -28,42 +28,42 @@
     g_return_val_if_fail (span != NULL, NULL);
     return i_cal_time_span_new_full(*span);</custom>
     </method>
-    <method name="i_cal_time_span_get_start" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_span_get_start" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalTimeSpan *" name="timespan" comment="The #ICalTimeSpan to be queried"/>
         <returns type="time_t" comment="The start." />
         <comment xml:space="preserve">Gets the start of #ICalTimeSpan.</comment>
         <custom>	g_return_val_if_fail (timespan != NULL, 0);
 	return ((struct icaltime_span *)i_cal_object_get_native ((ICalObject *)timespan))->start;</custom>
     </method>
-    <method name="i_cal_time_span_set_start" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_span_set_start" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTimeSpan *" name="timespan" comment="The #ICalTimeSpan to be set"/>
         <parameter type="time_t" name="start" comment="The start" />
         <comment xml:space="preserve">Sets the start of #ICalTimeSpan.</comment>
         <custom>	g_return_if_fail (timespan != NULL);
 	((struct icaltime_span *)i_cal_object_get_native ((ICalObject *)timespan))->start = start;</custom>
     </method>
-    <method name="i_cal_time_span_get_end" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_span_get_end" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalTimeSpan *" name="timespan" comment="The #ICalTimeSpan to be queried"/>
         <returns type="time_t" comment="The end." />
         <comment xml:space="preserve">Gets the end of #ICalTimeSpan.</comment>
         <custom>	g_return_val_if_fail (timespan != NULL, 0);
 	return ((struct icaltime_span *)i_cal_object_get_native ((ICalObject *)timespan))->end;</custom>
     </method>
-    <method name="i_cal_time_span_set_end" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_span_set_end" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTimeSpan *" name="timespan" comment="The #ICalTimeSpan to be set"/>
         <parameter type="time_t" name="end" comment="The end" />
         <comment xml:space="preserve">Sets the end of #ICalTimeSpan.</comment>
         <custom>	g_return_if_fail (timespan != NULL);
 	((struct icaltime_span *)i_cal_object_get_native ((ICalObject *)timespan))->end = end;</custom>
     </method>
-    <method name="i_cal_time_span_get_is_busy" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_span_get_is_busy" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalTimeSpan *" name="timespan" comment="The #ICalTimeSpan to be queried"/>
         <returns type="gboolean" comment="The is_busy." />
         <comment xml:space="preserve">Gets the is_busy of #ICalTimeSpan.</comment>
         <custom>	g_return_val_if_fail (timespan != NULL, FALSE);
 	return ((struct icaltime_span *)i_cal_object_get_native ((ICalObject *)timespan))->is_busy != 0;</custom>
     </method>
-    <method name="i_cal_time_span_set_is_busy" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_span_set_is_busy" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTimeSpan *" name="timespan" comment="The #ICalTimeSpan to be set"/>
         <parameter type="gboolean" name="is_busy" comment="The is_busy" />
         <comment xml:space="preserve">Sets the is_busy of #ICalTimeSpan.</comment>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -6,12 +6,13 @@
 
 -->
 <structure namespace="ICal" name="Time" native="struct icaltimetype" is_bare="true" default_native="icaltime_null_time()">
-    <method name="i_cal_time_new" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <skip>icaltime_get_timezone</skip> <!-- it is used below, but casts a const return value to a (void *) to avoid compiler warning -->
+    <method name="i_cal_time_new" corresponds="icaltime_null_time" kind="constructor" since="1.0">
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime. It is a null time" />
         <comment xml:space="preserve">Creates a new #ICalTime.</comment>
         <custom>	return i_cal_time_new_full(icaltime_null_time());</custom>
     </method>
-    <method name="i_cal_time_clone" corresponds="CUSTOM" kind="constructor" since="1.0">
+    <method name="i_cal_time_clone" corresponds="none" kind="constructor" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to clone"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The newly created #ICalTime, copy of @timetype." />
         <comment xml:space="preserve">Creates a new #ICalTime, copy of @timetype.</comment>
@@ -163,7 +164,7 @@
         <returns type="ICalTime *" annotation="transfer full" comment="The #ICalTime normalized"/>
         <comment xml:space="preserve">Normalizes the icaltime, so that all fields are within the normal range.</comment>
     </method>
-    <method name="i_cal_time_normalize_inplace" corresponds="CUSTOM" since="3.0.5">
+    <method name="i_cal_time_normalize_inplace" corresponds="icaltime_normalize" kind="custom" since="3.0.5">
         <parameter type="ICalTime *" name="tt" comment="The #ICalTime to be normalized"/>
         <comment xml:space="preserve">Normalizes the @tt, so that all fields are within the normal range.</comment>
         <custom xml:space="preserve">    icaltimetype *itt;
@@ -181,7 +182,7 @@
         <returns type="ICalTime *" annotation="transfer full" comment="The converted #ICalTime" />
         <comment xml:space="preserve">Converts @tt to @zone and return new #ICalTime object.</comment>
     </method>
-    <method name="i_cal_time_convert_to_zone_inplace" corresponds="CUSTOM" since="3.0.5">
+    <method name="i_cal_time_convert_to_zone_inplace" corresponds="icaltime_convert_to_zone" since="3.0.5">
         <parameter type="ICalTime *" name="tt" comment="The #ICalTime to be converted"/>
         <parameter type="ICalTimezone *" name="zone" annotation="nullable" comment="The target timezone"/>
         <comment xml:space="preserve">Converts @tt to @zone and store the result into @tt.</comment>
@@ -243,112 +244,112 @@
         <returns type="ICalDuration *" annotation="transfer full" comment="The #ICalDuration between two #ICalTime."/>
         <comment xml:space="preserve">Gets the duration between two time.</comment>
 	</method>
-    <method name="i_cal_time_get_year" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_year" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The year."/>
         <comment xml:space="preserve">Gets the year of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->year;</custom>
     </method>
-    <method name="i_cal_time_set_year" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_year" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gint" name="year" comment="The year"/>
         <comment>Sets the year of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->year = year;</custom>
     </method>
-    <method name="i_cal_time_get_month" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_month" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The month." />
         <comment xml:space="preserve">Gets the month of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->month;</custom>
     </method>
-    <method name="i_cal_time_set_month" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_month" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gint" name="month" comment="The month"/>
         <comment>Sets the month of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->month = month;</custom>
     </method>
-    <method name="i_cal_time_get_day" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_day" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The day." />
         <comment xml:space="preserve">Gets the day of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->day;</custom>
     </method>
-    <method name="i_cal_time_set_day" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_day" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gint" name="day" comment="The day"/>
         <comment>Sets the day of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->day = day;</custom>
     </method>
-    <method name="i_cal_time_get_hour" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_hour" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The hour." />
         <comment xml:space="preserve">Gets the hour of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->hour;</custom>
     </method>
-    <method name="i_cal_time_set_hour" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_hour" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gint" name="hour" comment="The hour"/>
         <comment>Sets the hour of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->hour = hour;</custom>
     </method>
-    <method name="i_cal_time_get_minute" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_minute" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The minute." />
         <comment xml:space="preserve">Gets the minute of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->minute;</custom>
     </method>
-    <method name="i_cal_time_set_minute" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_minute" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gint" name="minute" comment="The minute"/>
         <comment>Sets the minute of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->minute = minute;</custom>
     </method>
-    <method name="i_cal_time_get_second" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_second" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The second." />
         <comment xml:space="preserve">Gets the second of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->second;</custom>
     </method>
-    <method name="i_cal_time_set_second" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_second" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gint" name="second" comment="The second"/>
         <comment>Sets the second of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->second = second;</custom>
     </method>
-    <method name="i_cal_time_set_is_date" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_is_date" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gboolean" name="is_date" comment="The is_date"/>
         <comment>Sets the is_date of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->is_date = is_date ? 1 : 0;</custom>
     </method>
-    <method name="i_cal_time_is_daylight" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_is_daylight" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gboolean" comment="The is_daylight." />
         <comment xml:space="preserve">Gets the is_daylight of #ICalTime.</comment>
         <custom>	g_return_val_if_fail (timetype != NULL, 0);
 	return ((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->is_daylight;</custom>
     </method>
-    <method name="i_cal_time_set_is_daylight" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_is_daylight" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set"/>
         <parameter type="gboolean" name="is_daylight" comment="The is_daylight"/>
         <comment>Sets the is_daylight of #ICalTime.</comment>
         <custom>	g_return_if_fail (timetype != NULL &amp;&amp; I_CAL_IS_TIME(timetype));
 	((struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype))->is_daylight = is_daylight ? 1 : 0;</custom>
     </method>
-    <method name="i_cal_time_get_date" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_date" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <parameter type="gint *" name="year" annotation="out caller-allocates, optional" comment="Out parameter for the 'year' part of the date"/>
         <parameter type="gint *" name="month" annotation="out caller-allocates, optional" comment="Out parameter for the 'month' part of the date"/>
@@ -365,7 +366,7 @@
     if(day)
         *day = itt->day; </custom>
     </method>
-    <method name="i_cal_time_set_date" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_date" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set to"/>
         <parameter type="gint" name="year" comment="The 'year' part of the date" />
         <parameter type="gint" name="month" comment="The 'month' part of the date" />
@@ -379,7 +380,7 @@
     itt->month = month;
     itt->day = day; </custom>
     </method>
-    <method name="i_cal_time_get_time" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_time_get_time" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <parameter type="gint *" name="hour" annotation="out caller-allocates, optional" comment="Out parameter for the 'hour' part of the time"/>
         <parameter type="gint *" name="minute" annotation="out caller-allocates, optional" comment="Out parameter for the 'minute' part of the time"/>
@@ -396,7 +397,7 @@
     if(second)
         *second = itt->second; </custom>
     </method>
-    <method name="i_cal_time_set_time" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_time_set_time" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set to"/>
         <parameter type="gint" name="hour" comment="The 'hour' part of the time" />
         <parameter type="gint" name="minute" comment="The 'minute' part of the time" />

--- a/src/libical-glib/api/i-cal-timezone.xml
+++ b/src/libical-glib/api/i-cal-timezone.xml
@@ -10,7 +10,7 @@
         <returns type="ICalTimezone *" annotation="transfer full, nullable" translator="i_cal_timezone_new_full" translator_argus="NULL, FALSE" comment="The newly created object of the type #ICalTimezone." />
         <comment xml:space="preserve">The constructor of the type #ICalTimezone.</comment>
     </method>
-    <method name="i_cal_timezone_destroy" corresponds="CUSTOM" annotation="skip" kind="private" since="1.0">
+    <method name="i_cal_timezone_destroy" corresponds="icaltimezone_free" annotation="skip" kind="private" since="1.0">
         <parameter type="icaltimezone *" name="zone" comment="The #ICalTimezone to be freed"/>
         <comment xml:space="preserve">The destructor of the type #ICalTimezone to fully destroy the object by providing 1 as the second argument of i_cal_time_zone_free. The method is used as a default destructor for introspection.</comment>
         <custom>        icaltimezone_free (zone, 1);</custom>
@@ -28,6 +28,10 @@
     <method name="i_cal_timezone_set_tzid_prefix" corresponds="icaltimezone_set_tzid_prefix" kind="set" since="1.0">
         <parameter type="const gchar *" name="new_prefix" comment="The #ICalTimezone to be set"/>
         <comment xml:space="preserve">Sets the prefix to be used for tzid's generated from system tzdata. Must be globally unique (such as a domain name owned by the developer of the calling application), and begin and end with forward slashes. Do not change or de-allocate the string buffer after calling this.</comment>
+    </method>
+    <method name="i_cal_timezone_get_tzid_prefix" corresponds="icaltimezone_tzid_prefix" kind="get" since="4.0">
+        <returns type="const gchar *" annotation="transfer none" comment="the current timezone ID prefix used by the libical"/>
+        <comment xml:space="preserve">Returns the current timezone ID prefix used by the libical. See i_cal_timezone_set_tzid_prefix().</comment>
     </method>
     <method name="i_cal_timezone_free_builtin_timezones" corresponds="icaltimezone_free_builtin_timezones" kind="others" since="1.0">
         <comment xml:space="preserve">Frees any builtin timezone information.</comment>
@@ -86,7 +90,7 @@
         <returns type="ICalComponent *" annotation="transfer full" translator_argus="(GObject *)zone" comment="The VTIMEZONE component of the @zone."/>
         <comment xml:space="preserve">Returns the VTIMEZONE component of a timezone.</comment>
     </method>
-    <method name="i_cal_timezone_set_component" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_timezone_set_component" corresponds="icaltimezone_set_component" kind="custom" since="1.0">
         <parameter type="ICalTimezone *" name="zone" comment="The #ICalTimezone to be set"/>
         <parameter type="ICalComponent *" name="comp" comment="The VTIMEZONE component of an #ICalTimezone, initializing the tzid, location and tzname fields"/>
         <returns type="gint" comment="Whether the action is successful. 1 for success, 0 for failure."/>
@@ -125,7 +129,7 @@
         <returns type="gint" comment="UTC offset of the @zone"/>
         <comment>Calculates the UTC offset of a given UTC time in the given timezone.  It is the number of seconds to add to UTC to get local time.  The is_daylight flag is set to 1 if the time is in daylight-savings time.</comment>
     </method>
-    <method name="i_cal_timezone_array_new" corresponds="CUSTOM" kind="other" since="1.0">
+    <method name="i_cal_timezone_array_new" corresponds="icaltimezone_array_new" kind="custom" since="1.0">
         <returns type="ICalArray *" annotation="transfer full" translator_argus="NULL, FALSE" comment="Create a new array."/>
         <comment xml:space="preserve">Creates a new array of timezones.</comment>
         <custom>    ICalArray *zones_array;
@@ -134,12 +138,12 @@
     i_cal_object_set_native_destroy_func(I_CAL_OBJECT (zones_array), (GDestroyNotify) i_cal_timezone_array_destroy);
     return zones_array;</custom>
     </method>
-    <method name="i_cal_timezone_array_destroy" corresponds="CUSTOM" annotation="skip" kind="private" since="1.0">
+    <method name="i_cal_timezone_array_destroy" corresponds="icaltimezone_array_free" annotation="skip" kind="private" since="1.0">
         <parameter type="icalarray *" name="zones_array" annotation="nullable" comment="The icalarray created by i_cal_timezone_array_new() to be freed"/>
         <comment xml:space="preserve">The destructor of the icalarray of icaltimezone elements to fully destroy the native object.</comment>
         <custom>        icaltimezone_array_free (zones_array);</custom>
     </method>
-    <method name="i_cal_timezone_array_append_from_vtimezone" corresponds="CUSTOM" kind="other" since="1.0">
+    <method name="i_cal_timezone_array_append_from_vtimezone" corresponds="icaltimezone_array_append_from_vtimezone" kind="other" since="1.0">
         <parameter type="ICalArray *" name="timezones" comment="The timezones to be populated"/>
         <parameter type="ICalComponent *" name="child" comment="The component to be appended to @timezones"/>
         <comment>Populate the array of timezones with a component.
@@ -201,11 +205,30 @@
         <returns type="gboolean" comment="true if success."/>
         <comment>Outputs a list of timezone changes for the given timezone to the given file, up to the maximum year given.</comment>
     </method>
-    <method name="i_cal_timezone_array_element_at" corresponds="CUSTOM" kind="other" since="1.0">
+    <method name="i_cal_timezone_array_element_at" corresponds="none" kind="custom" since="1.0">
         <parameter type="ICalArray *" name="timezones" comment="The array to be visited"/>
         <parameter type="guint" name="index" comment="The index"/>
         <returns type="ICalTimezone *" annotation="transfer full" translator_argus="timezones, FALSE" comment="The #ICalTimezone at the position @index in @timezones."/>
         <comment>Gets the #ICalTimezone at specified position in array.</comment>
         <custom>        return i_cal_timezone_new_full ((gpointer)i_cal_array_element_at (timezones, index), (GObject *)timezones, FALSE);</custom>
+    </method>
+    <method name="i_cal_timezone_truncate_vtimezone" corresponds="icaltimezone_truncate_vtimezone" kind="other" since="4.0">
+        <parameter type="ICalComponent *" name="comp" comment="an #ICalComponent"/>
+        <parameter type="const ICalTime *" name="start" comment="a start #ICalTime"/>
+        <parameter type="const ICalTime *" name="end" comment="an end #ICalTime"/>
+        <parameter type="gboolean" name="ms_compatible" comment="whether to truncate the timezoen in a Microsoft-compatible way"/>
+        <comment xml:space="preserve">Truncate a VTIMEZONE component to the given start and end times.
+If either time is null, then no truncation will occur at that point.
+If either time is non-null, then it MUST be specified as UTC.
+If the start time is non-null and ms_compatible is zero,
+then the DTSTART of RRULEs will be adjusted to occur after the start time.</comment>
+    </method>
+    <method name="i_cal_tzutil_get_zone_directory" corresponds="icaltzutil_get_zone_directory" kind="others" since="4.0">
+        <returns type="const gchar *" comment="The path to look for the zonefiles"/>
+        <comment xml:space="preserve">Returns the full path to the system zoneinfo directory (where zone.tab lives).</comment>
+    </method>
+    <method name="i_cal_tzutil_set_zone_directory" corresponds="icaltzutil_set_zone_directory" kind="others" since="4.0">
+        <parameter type="const gchar *" name="path" comment="The path to look for the zonefiles"/>
+        <comment xml:space="preserve">Sets the full path to the system zoneinfo directory (where zone.tab lives).</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-trigger.xml
+++ b/src/libical-glib/api/i-cal-trigger.xml
@@ -26,14 +26,14 @@
         <returns type="gboolean" comment="true if yes, false if not."/>
         <comment xml:space="preserve">Checks if a #ICalTrigger is a bad trigger.</comment>
     </method>
-    <method name="i_cal_trigger_get_time" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_trigger_get_time" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalTrigger *" name="trigger" comment="The #ICalTrigger"/>
         <returns type="ICalTime *" annotation="transfer full" comment="The time of #ICalTrigger."/>
         <comment>Gets the time from #ICalTrigger.</comment>
         <custom>	g_return_val_if_fail (trigger != NULL &amp;&amp; I_CAL_IS_TRIGGER (trigger), NULL);
 	return i_cal_time_new_full (((struct icaltriggertype *)i_cal_object_get_native ((ICalObject *)trigger))->time);</custom>
     </method>
-    <method name="i_cal_trigger_set_time" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_trigger_set_time" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTrigger *" name="trigger" comment="The #ICalTrigger"/>
         <parameter type="ICalTime *" name="time" comment="The time of #ICalTrigger"/>
         <comment>Sets the time from #ICalTrigger.</comment>
@@ -41,14 +41,14 @@
 	g_return_if_fail (time != NULL &amp;&amp; I_CAL_IS_TIME(time));
 	((struct icaltriggertype *)i_cal_object_get_native ((ICalObject *)trigger))->time = *(struct icaltimetype *)i_cal_object_get_native ((ICalObject *)time);</custom>
     </method>
-    <method name="i_cal_trigger_get_duration" corresponds="CUSTOM" kind="get" since="1.0">
+    <method name="i_cal_trigger_get_duration" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalTrigger *" name="trigger" comment="The #ICalTrigger"/>
         <returns type="ICalDuration *" annotation="transfer full" comment="The duration of #ICalTrigger."/>
         <comment>Gets the duration from #ICalTrigger.</comment>
         <custom>	g_return_val_if_fail (trigger != NULL &amp;&amp; I_CAL_IS_TRIGGER (trigger), NULL);
 	return i_cal_duration_new_full (((struct icaltriggertype *)i_cal_object_get_native ((ICalObject *)trigger))->duration);</custom>
     </method>
-    <method name="i_cal_trigger_set_duration" corresponds="CUSTOM" kind="set" since="1.0">
+    <method name="i_cal_trigger_set_duration" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalTrigger *" name="trigger" comment="The #ICalTrigger"/>
         <parameter type="ICalDuration *" name="duration" comment="The duration of #ICalTrigger"/>
         <comment>Sets the duration from #ICalTrigger.</comment>

--- a/src/libical-glib/api/i-cal-value.xml
+++ b/src/libical-glib/api/i-cal-value.xml
@@ -68,7 +68,7 @@ be cloned."/>
         <returns type="gboolean" comment="true if yes, false if not."/>
         <comment xml:space="preserve">Checks whether the #ICalValueKind is valid.</comment>
     </method>
-    <method name="i_cal_value_encode_ical_string" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_value_encode_ical_string" corresponds="icalvalue_encode_ical_string" kind="custom" since="1.0">
         <parameter type="const gchar *" name="szText" comment="A string"/>
         <returns type="gchar *" annotation="nullable, transfer full" comment="The encoded string. NULL if fail."/>
         <comment xml:space="preserve">Encodes a character string in ical format, escape certain characters, etc.</comment>
@@ -89,7 +89,7 @@ be cloned."/>
 
     return buffer;</custom>
     </method>
-    <method name="i_cal_value_decode_ical_string" corresponds="CUSTOM" since="1.0">
+    <method name="i_cal_value_decode_ical_string" corresponds="icalvalue_decode_ical_string" since="1.0">
         <parameter type="const gchar *" name="szText" comment="A string"/>
         <returns type="gchar *" annotation="nullable, transfer full" comment="The decoded string. NULL if fail."/>
         <comment xml:space="preserve">Extracts the original character string encoded by the above function.</comment>

--- a/src/libical-glib/tools/generator.c
+++ b/src/libical-glib/tools/generator.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "header-parser.h"
+
 #include "generator.h"
 
 #include <errno.h>
@@ -1697,7 +1703,9 @@ gchar *get_source_method_body(Method *method, const gchar *nameSpace)
 
     (void)g_stpcpy(buffer + strlen(buffer), "\n{\n");
 
-    if (g_strcmp0(method->corresponds, (gchar *)"CUSTOM") != 0) {
+    if (method->custom != NULL) {
+        (void)g_stpcpy(buffer + strlen(buffer), method->custom);
+    } else {
         checkers = get_source_run_time_checkers(method, nameSpace);
         if (checkers != NULL) {
             (void)g_stpcpy(buffer + strlen(buffer), checkers);
@@ -1774,10 +1782,6 @@ gchar *get_source_method_body(Method *method, const gchar *nameSpace)
             g_free(translator);
         }
         (void)g_stpcpy(buffer + strlen(buffer), ";");
-    } else if (method->custom != NULL) {
-        (void)g_stpcpy(buffer + strlen(buffer), method->custom);
-    } else {
-        printf("WARNING: No function body for the method: %s\n", method->name);
     }
     (void)g_stpcpy(buffer + strlen(buffer), "\n}");
 
@@ -2219,46 +2223,25 @@ static void generate_checks_file(const gchar *filename, GList *structures /* Str
     (void)g_string_free(calls, TRUE);
 }
 
-static gint generate_library(const gchar *apis_dir)
+static GList * /* Structure * */
+parse_api_files(const gchar *apis_dir,
+                GHashTable *type2kind,      /* nullable */
+                GHashTable *type2structure) /* nullable */
 {
-    xmlDoc *doc;
-    xmlNode *node;
-    Structure *structure;
-    gchar *path;
-    const gchar *filename;
-    Enumeration *enumeration;
-    gchar *buffer;
-    GList *structures;
-    GList *iter_list;
-    GList *filenames = NULL;
-    GList *iter_filenames;
     GDir *dir;
     GError *local_error = NULL;
-    gint res = 0;
-    gint len;
-
-    g_return_val_if_fail(apis_dir != NULL, 1);
-    g_return_val_if_fail(g_file_test(apis_dir, G_FILE_TEST_IS_DIR), 1);
-
-    buffer = g_new(gchar, BUFFER_SIZE);
-    *buffer = '\0';
-
-    /* Cache the type and its kind, like ICalComponnet--->std or ICalPropertyKind--->enum */
-    type2kind = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
-    /* Cache the type and the structure where it is defined,
-       like ICalComponent--->Structure_storing_ICalComponent */
-    type2structure = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
-
-    initialize_default_value_table();
-    structures = NULL;
+    GList *filenames = NULL, *iter_filenames;
+    GList *structures = NULL;
+    Structure *structure;
+    const gchar *filename;
+    gboolean success = TRUE;
 
     dir = g_dir_open(apis_dir, 0, &local_error);
     if (!dir) {
         g_warning("Failed to open API directory '%s': %s", apis_dir,
                   local_error ? local_error->message : "Unknown error");
         g_clear_error(&local_error);
-        g_free(buffer);
-        return 1;
+        return NULL;
     }
 
     /* Parse the all the XML files into the Structure */
@@ -2266,10 +2249,15 @@ static gint generate_library(const gchar *apis_dir)
         filenames = g_list_prepend(filenames, g_strdup(filename));
     }
     filenames = g_list_sort(filenames, (GCompareFunc)g_strcmp0);
-    for (iter_filenames = g_list_first(filenames); iter_filenames != NULL;
+    for (iter_filenames = g_list_first(filenames); iter_filenames != NULL && success;
          iter_filenames = g_list_next(iter_filenames)) {
+        xmlDoc *doc;
+        xmlNode *node;
+        gchar *path;
+        guint len;
+
         filename = iter_filenames->data;
-        len = (gint)strlen(filename);
+        len = strlen(filename);
 
         if (len <= 4 || g_ascii_strncasecmp(filename + len - 4, ".xml", 4) != 0)
             continue;
@@ -2279,8 +2267,8 @@ static gint generate_library(const gchar *apis_dir)
         if (doc == NULL) {
             printf("The doc %s cannot be parsed.\n", path);
             g_free(path);
-            res = 1;
-            goto out;
+            success = FALSE;
+            break;
         }
 
         g_free(path);
@@ -2289,20 +2277,20 @@ static gint generate_library(const gchar *apis_dir)
         if (node == NULL) {
             printf("The root node cannot be retrieved from the doc\n");
             xmlFreeDoc(doc);
-            res = 1;
-            goto out;
+            success = FALSE;
+            break;
         }
 
         structure = structure_new();
         if (!parse_structure(node, structure)) {
             printf("The node cannot be parsed into a structure.\n");
             xmlFreeDoc(doc);
-            res = 1;
+            success = FALSE;
             structure_free(structure);
-            goto out;
+            break;
         }
 
-        if (structure->native != NULL) {
+        if (structure->native != NULL && type2kind != NULL && type2structure != NULL) {
             (void)g_hash_table_insert(type2kind,
                                       g_strconcat(structure->nameSpace, structure->name, NULL),
                                       (void *)"std");
@@ -2319,32 +2307,74 @@ static gint generate_library(const gchar *apis_dir)
                     printf("Please supply a default value for the bare structure %s\n",
                            structure->name);
                     xmlFreeDoc(doc);
-                    res = 1;
+                    success = FALSE;
                     structure_free(structure);
-                    goto out;
+                    break;
                 }
             }
         }
 
-        for (iter_list = g_list_first(structure->enumerations); iter_list != NULL;
-             iter_list = g_list_next(iter_list)) {
-            enumeration = (Enumeration *)iter_list->data;
-            (void)g_hash_table_insert(type2kind, g_strdup(enumeration->name), (void *)"enum");
-            (void)g_hash_table_insert(type2structure, g_strdup(enumeration->name), structure);
+        if (type2kind != NULL && type2structure != NULL) {
+            GList *iter_list;
 
-            if (enumeration->defaultNative != NULL) {
-                (void)g_hash_table_insert(defaultValues, g_strdup(enumeration->name),
-                                          g_strdup(enumeration->defaultNative));
-            } else {
-                printf("Please supply a default value for enum %s\n", enumeration->name);
-                xmlFreeDoc(doc);
-                res = 1;
-                structure_free(structure);
-                goto out;
+            for (iter_list = g_list_first(structure->enumerations); iter_list != NULL;
+                 iter_list = g_list_next(iter_list)) {
+                Enumeration *enumeration = (Enumeration *)iter_list->data;
+                (void)g_hash_table_insert(type2kind, g_strdup(enumeration->name), (void *)"enum");
+                (void)g_hash_table_insert(type2structure, g_strdup(enumeration->name), structure);
+
+                if (enumeration->defaultNative != NULL) {
+                    (void)g_hash_table_insert(defaultValues, g_strdup(enumeration->name),
+                                              g_strdup(enumeration->defaultNative));
+                } else {
+                    printf("Please supply a default value for enum %s\n", enumeration->name);
+                    xmlFreeDoc(doc);
+                    success = FALSE;
+                    structure_free(structure);
+                    break;
+                }
             }
         }
         structures = g_list_append(structures, structure);
         xmlFreeDoc(doc);
+    }
+
+    g_list_free_full(filenames, g_free);
+    g_dir_close(dir);
+
+    if (!success) {
+        g_list_free_full(structures, (GDestroyNotify)structure_free);
+        structures = NULL;
+    }
+
+    return structures;
+}
+
+static gint generate_library(const gchar *apis_dir)
+{
+    gchar *buffer;
+    GList *structures;
+    GList *iter_list;
+    gint res = 0;
+
+    g_return_val_if_fail(apis_dir != NULL, 1);
+    g_return_val_if_fail(g_file_test(apis_dir, G_FILE_TEST_IS_DIR), 1);
+
+    buffer = g_new(gchar, BUFFER_SIZE);
+    *buffer = '\0';
+
+    /* Cache the type and its kind, like ICalComponnet--->std or ICalPropertyKind--->enum */
+    type2kind = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    /* Cache the type and the structure where it is defined,
+       like ICalComponent--->Structure_storing_ICalComponent */
+    type2structure = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+
+    initialize_default_value_table();
+
+    structures = parse_api_files(apis_dir, type2kind, type2structure);
+    if (structures == NULL) {
+        res = 1;
+        goto out;
     }
 
     /* Generate the forward declarations header file */
@@ -2356,18 +2386,16 @@ static gint generate_library(const gchar *apis_dir)
     /* Generate all the header and source files for each structure */
     for (iter_list = g_list_first(structures); iter_list != NULL;
          iter_list = g_list_next(iter_list)) {
-        structure = (Structure *)iter_list->data;
+        Structure *structure = (Structure *)iter_list->data;
         generate_header_and_source(structure, (char *)"");
     }
 
     generate_checks_file("ical-glib-build-check.c", structures);
 out:
-    g_dir_close(dir);
     g_hash_table_destroy(type2kind);
     g_hash_table_destroy(type2structure);
     g_hash_table_destroy(defaultValues);
     g_list_free_full(structures, (GDestroyNotify)structure_free);
-    g_list_free_full(filenames, g_free);
     g_free(buffer);
 
     return res;
@@ -2479,12 +2507,116 @@ void generate_header_header_file(GList *structures)
     g_free(buffer);
 }
 
+static gboolean
+remove_symbols_with_prefix_cb(gpointer key,
+                              gpointer value,
+                              gpointer user_data)
+{
+    const gchar *symbol = key;
+    const gchar *prefix = user_data;
+
+    _unused(value);
+
+    return prefix != NULL && *prefix != '\0' && g_str_has_prefix(symbol, prefix);
+}
+
+static gint
+sort_symbols_by_name_cb(gconstpointer aa,
+                        gconstpointer bb)
+{
+    const char *symbol_a = *((const char **)aa);
+    const char *symbol_b = *((const char **)bb);
+    return g_strcmp0(symbol_a, symbol_b);
+}
+
+static gboolean
+check_api_files(const gchar *apis_dir,
+                GHashTable *symbols)
+{
+    GList *structures, *link;
+    gboolean success = TRUE;
+
+    structures = parse_api_files(apis_dir, NULL, NULL);
+
+    for (link = structures; link != NULL; link = g_list_next(link)) {
+        const Structure *structure = link->data;
+        GList *iter;
+
+        for (iter = structure->methods; iter != NULL; iter = g_list_next(iter)) {
+            const Method *method = iter->data;
+            /* do not check whether the 'corresponds' exists, it can be CUSTOM or sometimes repeated */
+            if (method->corresponds != NULL) {
+                g_hash_table_remove(symbols, method->corresponds);
+                /* some methods have their counter parts without the"_r" suffix, cover them too */
+                if (g_str_has_suffix(method->corresponds, "_r")) {
+                    gchar *stripped = g_strndup(method->corresponds, strlen(method->corresponds) - 2);
+                    g_hash_table_remove(symbols, stripped);
+                    g_free(stripped);
+                }
+            }
+        }
+
+        for (iter = structure->enumerations; iter != NULL; iter = g_list_next(iter)) {
+            const Enumeration *enumr = iter->data;
+            if (enumr->nativeName != NULL)
+                g_hash_table_remove(symbols, enumr->nativeName);
+        }
+
+        if (structure->skips != NULL) {
+            guint ii;
+            for (ii = 0; ii < structure->skips->len; ii++) {
+                gchar *skip_symbol = g_ptr_array_index(structure->skips, ii);
+                if (g_str_has_suffix(skip_symbol, "*")) {
+                    gchar *prefix = g_strndup(skip_symbol, strlen(skip_symbol) - 1);
+                    g_hash_table_foreach_remove(symbols, remove_symbols_with_prefix_cb, prefix);
+                    g_free(prefix);
+                } else {
+                    g_hash_table_remove(symbols, skip_symbol);
+                }
+            }
+        }
+    }
+
+    g_list_free_full(structures, (GDestroyNotify)structure_free);
+
+    success = g_hash_table_size(symbols) == 0;
+    if (!success) {
+        GHashTableIter iter;
+        GPtrArray *sorted;
+        gpointer key = NULL;
+        guint ii;
+
+        fprintf(stderr,
+                "The following %u symbols are not covered by the libical-glib API files. "
+                "Either add the definitions for them or declare them as <skip>symbol</skip> under <structure/>\n",
+                g_hash_table_size(symbols));
+
+        sorted = g_ptr_array_sized_new(g_hash_table_size(symbols));
+        g_hash_table_iter_init(&iter, symbols);
+        while (g_hash_table_iter_next(&iter, &key, NULL)) {
+            const gchar *symbol = key;
+            g_ptr_array_add(sorted, (gpointer)symbol);
+        }
+        g_ptr_array_sort(sorted, sort_symbols_by_name_cb);
+        for (ii = 0; ii < sorted->len; ii++) {
+            const gchar *symbol = g_ptr_array_index(sorted, ii);
+            if (ii > 0)
+                fprintf(stderr, " ");
+            fprintf(stderr, "%s", symbol);
+        }
+        fprintf(stderr, "\n");
+        g_ptr_array_unref(sorted);
+    }
+
+    return success;
+}
+
 int main(int argc, char *argv[])
 {
     const gchar *apis_dir;
     gint res;
 
-    if (argc != 3) {
+    if (argc < 3) {
         fprintf(stderr,
                 "Requires two arguments, the first is path to templates, "
                 "the second is a path to XML files with an API description\n");
@@ -2495,6 +2627,40 @@ int main(int argc, char *argv[])
     templates_dir = argv[1];
     /* The directory to search for XML files */
     apis_dir = argv[2];
+
+    if (argc > 3) {
+        GHashTable *symbols;
+        int ii;
+
+        if (strcmp(argv[3], "--check-api-files") != 0) {
+            fprintf(stderr, "Unknown argument '%s', expects '--check-api-files'\n", argv[3]);
+            return 2;
+        }
+        if (((argc - 4) & 1) != 0) {
+            fprintf(stderr, "Expects pair of arguments, path to a header file and export token\n");
+            return 3;
+        }
+
+        symbols = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+
+        for (ii = 4; ii < argc; ii += 2) {
+            GError *error = NULL;
+            if (!parse_header_file(symbols, argv[ii], argv[ii + 1], &error)) {
+                fprintf(stderr, "Failed to parse header file '%s': %s\n",
+                        argv[ii], error ? error->message : "Unknown error");
+                g_hash_table_unref(symbols);
+                g_clear_error(&error);
+                return 4;
+            }
+        }
+
+        if (check_api_files(apis_dir, symbols))
+            ii = 0;
+        else
+            ii = 5;
+        g_hash_table_unref(symbols);
+        return ii;
+    }
 
     res = generate_library(apis_dir);
     close_private_header();

--- a/src/libical-glib/tools/header-parser.c
+++ b/src/libical-glib/tools/header-parser.c
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Red Hat <www.redhat.com>
+ * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+ */
+
+/* This is a very naive C header parser, which extracts public symbols */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <glib.h>
+#include <string.h>
+
+#include "header-parser.h"
+
+static gchar *
+skip_white_spaces(gchar *ptr,
+                  gboolean *out_was_new_line)
+{
+    while (*ptr == '\t' || *ptr == '\r' || *ptr == '\n' || *ptr == ' ') {
+        if (out_was_new_line)
+            *out_was_new_line = (*out_was_new_line) || *ptr == '\r' || *ptr == '\n';
+        ptr++;
+    }
+
+    return ptr;
+}
+
+static gchar *
+skip_after(gchar *ptr,
+           const gchar *after,
+           gchar *out_last_char)
+{
+    while (*ptr && !strchr(after, *ptr)) {
+        if (out_last_char)
+            *out_last_char = *ptr;
+        ptr++;
+    }
+
+    while (*ptr && strchr(after, *ptr))
+        ptr++;
+
+    return ptr;
+}
+
+static gchar *
+skip_ident(gchar *ptr)
+{
+    while (*ptr && ((*ptr >= '0' && *ptr <= '9') || (*ptr >= 'a' && *ptr <= 'z') || (*ptr >= 'A' && *ptr <= 'Z') || *ptr == '_'))
+        ptr++;
+
+    return ptr;
+}
+
+gboolean
+parse_header_file(GHashTable *symbols, /* caller allocates, char * ~> itself */
+                  const char *filename,
+                  const char *export_token,
+                  GError **error)
+{
+    gchar *content = NULL, *start, *ptr;
+    gboolean is_new_line = TRUE, read_func_name = FALSE;
+    guint export_token_len = export_token ? strlen(export_token) : 0;
+
+    if (!g_file_get_contents(filename, &content, NULL, error))
+        return FALSE;
+
+    if (export_token != NULL && !*export_token)
+        export_token = NULL;
+
+    start = content;
+    ptr = content;
+
+    while (*start) {
+        ptr = skip_white_spaces(ptr, &is_new_line);
+        start = ptr;
+
+        if (*ptr == '/') {
+            if (ptr[1] == '/') {
+                ptr = skip_after(ptr, "\r\n", NULL);
+                is_new_line = TRUE;
+            } else if (ptr[1] == '*') {
+                while (ptr[0] && ptr[1] && !(ptr[0] == '*' && ptr[1] == '/')) {
+                    if (!is_new_line && (*ptr == '\n' || *ptr == '\r'))
+                        is_new_line = TRUE;
+                    ptr++;
+                }
+                if (ptr[0] == '*' && ptr[1] == '/')
+                    ptr += 2;
+            }
+        } else if (*ptr == '#') {
+            gboolean done = FALSE;
+
+            if (strncmp(ptr, "#define", 7) == 0) {
+                /* covers "#define func(args) otherfunc(args) */
+                ptr += 7;
+                ptr = skip_white_spaces(ptr, NULL);
+                start = ptr;
+                ptr = skip_ident(ptr);
+                if (*ptr == '(')
+                    g_hash_table_add(symbols, g_strndup(start, ptr - start));
+            }
+
+            while (!done) {
+                char last_char = 0;
+                ptr = skip_after(ptr, "\r\n", &last_char);
+                done = last_char != '\\';
+            }
+
+            is_new_line = TRUE;
+        } else if (*ptr != 0) {
+            ptr = skip_ident(ptr);
+            if (ptr == start) {
+                ptr++;
+                is_new_line = FALSE;
+            } else if (strncmp(start, "typedef", 7) == 0) {
+                ptr = skip_white_spaces(ptr, NULL);
+                start = ptr;
+                ptr = skip_ident(ptr);
+                /* catch: typedef enum enumname { ... } typename;*/
+                if (strncmp(start, "enum", ptr - start) == 0) {
+                    ptr = skip_after(ptr, "};", NULL);
+                    if (ptr > start && ptr[-1] != ';') {
+                        ptr = skip_white_spaces(ptr, NULL);
+                        start = ptr;
+                        ptr = skip_ident(ptr);
+                        if (start != ptr) {
+                            g_hash_table_add(symbols, g_strndup(start, ptr - start));
+                            ptr = skip_after(ptr, ";", NULL);
+                        }
+                    }
+                } else {
+                    ptr = skip_after(ptr, ";", NULL);
+                }
+            } else if (is_new_line) {
+                read_func_name = export_token == NULL || (ptr - start == export_token_len && strncmp(start, export_token, export_token_len) == 0);
+                is_new_line = FALSE;
+                if (!read_func_name && ptr - start == 4 && strncmp(start, "enum", ptr - start) == 0) {
+                    ptr = skip_white_spaces(ptr, NULL);
+                    start = ptr;
+                    ptr = skip_ident(ptr);
+                    if (start != ptr) {
+                        gchar *ident = g_strndup(start, ptr - start);
+                        g_hash_table_add(symbols, g_strconcat("enum ", ident, NULL));
+                        g_free(ident);
+                        ptr = skip_after(ptr, "}", NULL);
+                    }
+                }
+            } else if (read_func_name) {
+                gchar *next = skip_white_spaces(ptr, &is_new_line);
+
+                if (*next == '(') {
+                    g_hash_table_add(symbols, g_strndup(start, ptr - start));
+                    read_func_name = FALSE;
+                    ptr = skip_after(ptr, ";", NULL);
+                }
+            }
+        }
+    }
+
+    g_free(content);
+
+    return TRUE;
+}

--- a/src/libical-glib/tools/header-parser.h
+++ b/src/libical-glib/tools/header-parser.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Red Hat <www.redhat.com>
+ * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+ */
+
+#ifndef HEADER_PARSER_H
+#define HEADER_PARSER_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gboolean
+parse_header_file(GHashTable *symbols, /* caller allocates, char * ~> itself */
+                  const char *filename,
+                  const char *export_token,
+                  GError **error);
+
+G_END_DECLS
+
+#endif /* HEADER_PARSER_H */

--- a/src/libical-glib/tools/xml-parser.c
+++ b/src/libical-glib/tools/xml-parser.c
@@ -25,6 +25,7 @@ Structure *structure_new(void)
     structure->defaultNative = NULL;
     structure->dependencies = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
     structure->declarations = NULL;
+    structure->skips = NULL;
     return structure;
 }
 
@@ -62,6 +63,7 @@ void structure_free(Structure *structure)
     g_free(structure->defaultNative);
     g_free(structure->new_full_extraCode);
     g_hash_table_destroy(structure->dependencies);
+    g_clear_pointer(&structure->skips, g_ptr_array_unref);
     g_free(structure);
 }
 
@@ -603,6 +605,13 @@ gboolean parse_structure(xmlNode *node, Structure *structure)
                 structure->enumerations = g_list_append(structure->enumerations, enumeration);
             }
             enumeration = NULL;
+        } else if (g_strcmp0((const gchar *)child->name, "skip") == 0) {
+            gchar *symbol = dup_node_content(child);
+            if (symbol != NULL) {
+                if (structure->skips == NULL)
+                    structure->skips = g_ptr_array_new_with_free_func(g_free);
+                g_ptr_array_add(structure->skips, symbol);
+            }
         }
     }
 

--- a/src/libical-glib/tools/xml-parser.h
+++ b/src/libical-glib/tools/xml-parser.h
@@ -60,6 +60,7 @@ typedef struct Structure {
     gchar *cloneFunc;
     gchar *defaultNative;
     GList *declarations;
+    GPtrArray *skips; /* gchar * */
 } Structure;
 
 typedef struct Declaration {


### PR DESCRIPTION
It adds a very simple and naive C header file parser into the generator,
with which it can read exported symbols and enums and then compares whether
all of them are included (or skipped) in the libical-glib API (.xml) files.
    
Configure the project with `-DLIBICAL_GLIB_CHECK_API_FILES=True` to enable it,
unless the project is configured with the `-DLIBICAL_DEVMODE=True`, which
enables it automatically.
    
Any new symbols should be added into the .xml files in the `src/libical-glib/api/`.
In case the symbol should be skipped, as not suitable for the introspection
or such, then add it into the corresponding .xml file as `<skip>symbol</skip>`
under a `<structure/>` element. Some common skipped symbols are declared
in the `src/libical-glib/api/i-cal-component.xml`. When the "symbol" ends
with a star (`*`), then it's treated as a wildcard and any symbols with such
prefix are skipped.

----
An example of a missing symbol can be found here (before GitHub garbage-collects it): https://github.com/mcrha/libical/actions/runs/17641921028/job/50130749135 - search for the `icalproperty_class_to_string` near the end of the build log.