### PR TITLE
cxx: Allow assignment after detach()

### DIFF
--- a/src/libical/icalparameter_cxx.cpp
+++ b/src/libical/icalparameter_cxx.cpp
@@ -31,10 +31,12 @@ ICalParameter &ICalParameter::operator=(const ICalParameter &v)
 
     if (imp != NULL) {
         icalparameter_free(imp);
-        imp = icalparameter_clone(v.imp);
-        if (imp == NULL) {
-            throw icalerrno;
-        }
+        imp = NULL;
+    }
+
+    imp = icalparameter_clone(v.imp);
+    if (imp == NULL) {
+        throw icalerrno;
     }
 
     return *this;

--- a/src/libical/icalproperty_cxx.cpp
+++ b/src/libical/icalproperty_cxx.cpp
@@ -33,10 +33,12 @@ ICalProperty &ICalProperty::operator=(const ICalProperty &v)
 
     if (imp != NULL) {
         icalproperty_free(imp);
-        imp = icalproperty_clone(v.imp);
-        if (imp == NULL) {
-            throw icalerrno;
-        }
+        imp = NULL;
+    }
+
+    imp = icalproperty_clone(v.imp);
+    if (imp == NULL) {
+        throw icalerrno;
     }
 
     return *this;

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -44,10 +44,12 @@ VComponent &VComponent::operator=(const VComponent &v)
 
     if (imp != NULL) {
         icalcomponent_free(imp);
-        imp = icalcomponent_clone(v.imp);
-        if (imp == NULL) {
-            throw icalerrno;
-        }
+        imp = NULL;
+    }
+
+    imp = icalcomponent_clone(v.imp);
+    if (imp == NULL) {
+        throw icalerrno;
     }
 
     return *this;


### PR DESCRIPTION
Before the change, assigning a value into a class after calling `detach()` resulted into no-op. Let the assignment work even after `detach()` call.

Closes https://github.com/libical/libical/issues/1006