### PR TITLE
Buildsystem - rename CMake option ICAL_ERRORS_ARE_FATAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #  Build the Java bindings.
 #  Default=true
 #
-# -DICAL_ERRORS_ARE_FATAL=[true|false]
+# -DLIBICAL_ENABLE_ERRORS_ARE_FATAL=[true|false]
 #  Set to make icalerror_* calls abort instead of internally signaling an error
 #  Default=false
 #  Notes:
@@ -522,8 +522,13 @@ else()
   set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 endif()
 
-libical_option(ICAL_ERRORS_ARE_FATAL "icalerror_* calls will abort instead of internally signaling an error." False)
-if(ICAL_ERRORS_ARE_FATAL)
+libical_deprecated_option(
+  ICAL_ERRORS_ARE_FATAL
+  LIBICAL_ENABLE_ERRORS_ARE_FATAL
+  "icalerror_* calls will abort instead of internally signaling an error."
+  False
+)
+if(LIBICAL_ENABLE_ERRORS_ARE_FATAL)
   set(ICAL_ERRORS_ARE_FATAL 1)
 else()
   set(ICAL_ERRORS_ARE_FATAL 0)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -194,7 +194,7 @@ This C library can be built with bindings for these other languages:
 
 Use these CMake options to adjust the library behavior as follows:
 
-- ICAL_ERRORS_ARE_FATAL=[true|false]
+- LIBICAL_ENABLE_ERRORS_ARE_FATAL=[true|false]
   Set to make icalerror_* calls abort instead of internally signaling an error.
   Default=false
 

--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -13,6 +13,7 @@ User-specific:
 | Old Name                     | New Name                             |
 |------------------------------|--------------------------------------|
 | ICAL_BUILD_DOCS              | LIBICAL_BUILD_DOCS                   |
+| ICAL_ERRORS_ARE_FATAL        | LIBICAL_ENABLE_ERRORS_ARE_FATAL      |
 | ICAL_GLIB                    | LIBICAL_GLIB                         |
 | ICAL_GLIB_VAPI               | LIBICAL_GLIB_VAPI                    |
 | ICAL_GLIB_BUILD_DOCS         | LIBICAL_GLIB_BUILD_DOCS              |

--- a/docs/UsingLibical.md
+++ b/docs/UsingLibical.md
@@ -300,7 +300,7 @@ If any of the constructors fail, they will return 0. If you try to
 insert 0 into a property or component, or use a zero-valued object
 reference, libical will either silently ignore the error or will abort
 with an error message. This behavior is controlled by a compile time
-flag (`ICAL_ERRORS_ARE_FATAL`), and will abort by default.
+flag (`LIBICAL_ENABLE_ERRORS_ARE_FATAL`), and will abort by default.
 
 #### 5.1.2 varargs Constructors
 
@@ -1388,17 +1388,17 @@ As of libical version 0.18, this routine only converts `PARSEERROR` errors
 and it always generates a 3.x (failure) code. This makes it more
 of a good idea than a really useful bit of code.
 
-#### 5.6.4 `ICAL_ERRORS_ARE_FATAL` and `icalerror_errors_are_fatal`
+#### 5.6.4 `LIBICAL_ENABLE_ERRORS_ARE_FATAL` and `icalerror_errors_are_fatal`
 
 If `icalerror_get_errors_are_fatal()` returns 1, then any error
 condition will cause the program to abort. The abort occurs
 in `icalerror_set_errno()`, and is done with an assert(0) if NDEBUG
 is undefined, and with `icalerror_crash_here()` if NDEBUG is defined.
-Initially, `icalerror_get_errors_are_fatal()` is 1 when `ICAL_ERRORS_ARE_FATAL`
-is defined, and 0 otherwise. Since `ICAL_ERRORS_ARE_FATAL` is defined
+Initially, `icalerror_get_errors_are_fatal()` is 1 when `LIBICAL_ENABLE_ERRORS_ARE_FATAL`
+is defined, and 0 otherwise. Since `LIBICAL_ENABLE_ERRORS_ARE_FATAL` is defined
 by default, `icalerror_get_errors_are_fatal()` is also set to 1 by default.
 
-You can change the compiled-in `ICAL_ERRORS_ARE_FATAL` behavior at runtime
+You can change the compiled-in `LIBICAL_ENABLE_ERRORS_ARE_FATAL` behavior at runtime
 by calling `icalerror_set_errors_are_fatal(0)` (i.e, errors are not fatal)
 or `icalerror_set_errors_are_fatal(1)` (i.e, errors are fatal).
 

--- a/scripts/buildtests.sh
+++ b/scripts/buildtests.sh
@@ -450,7 +450,7 @@ CPPCHECK() {
     --template='{file}:{line},{severity},{id},{message}' \
     --checkers-report=cppcheck-report.txt \
     -D __cppcheck__ \
-    -D ICAL_ERRORS_ARE_FATAL=0 \
+    -D LIBICAL_ENABLE_ERRORS_ARE_FATAL=0 \
     -D ICAL_PACKAGE="\"x\"" \
     -D ICAL_VERSION="\"y\"" \
     -D _unused="(void)" \


### PR DESCRIPTION
Rename ICAL_ERRORS_ARE_FATAL to LIBICAL_ENABLE_ERRORS_ARE_FATAL

GH-380