### PR TITLE
Allow empty properties at runtime, rather than compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@
 #   Change the behavior at runtime using the icalerror_set_errors_are_fatal() function.
 #   Query the behavior at runtime using the icalerror_get_errors_are_fatal() function.
 #
-# -DICAL_ALLOW_EMPTY_PROPERTIES=[true|false]
-#  Set to prevent empty properties from being replaced with X-LIC-ERROR properties.
-#  Default=false
-#
 # -DLIBICAL_ENABLE_BUILTIN_TZDATA=[true|false]
 #  Set to build using our own timezone data.
 #  Default=false (use the system timezone data on non-Windows systems)
@@ -532,17 +528,6 @@ if(LIBICAL_ENABLE_ERRORS_ARE_FATAL)
   set(ICAL_ERRORS_ARE_FATAL 1)
 else()
   set(ICAL_ERRORS_ARE_FATAL 0)
-endif()
-
-libical_option(
-  ICAL_ALLOW_EMPTY_PROPERTIES
-  "Prevents empty properties from being replaced with X-LIC-ERROR properties."
-  False
-)
-if(ICAL_ALLOW_EMPTY_PROPERTIES)
-  set(ICAL_ALLOW_EMPTY_PROPERTIES 1)
-else()
-  set(ICAL_ALLOW_EMPTY_PROPERTIES 0)
 endif()
 
 if(WIN32 OR WINCE)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -198,10 +198,6 @@ Use these CMake options to adjust the library behavior as follows:
   Set to make icalerror_* calls abort instead of internally signaling an error.
   Default=false
 
-- ICAL_ALLOW_EMPTY_PROPERTIES=[true|false]
-  Set to prevent empty properties from being replaced with X-LIC-ERROR properties.
-  Default=false
-
 - LIBICAL_ENABLE_BUILTIN_TZDATA=[true|false]
   Set to build using our own (instead of the system's) timezone data.
   Default=false (use the system timezone data on non-Windows systems)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -180,9 +180,6 @@ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
    error */
 #define ICAL_ERRORS_ARE_FATAL ${ICAL_ERRORS_ARE_FATAL}
 
-/* Define to prevent empty properties from being replaced with X-LIC-ERROR properties */
-#define ICAL_ALLOW_EMPTY_PROPERTIES ${ICAL_ALLOW_EMPTY_PROPERTIES}
-
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "${CMAKE_PROJECT_HOMEPAGE_URL}"
 

--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -4,7 +4,7 @@ A guide to help developers port their code from libical v3.x to libical 4.0.
 
 ## CMake options
 
-Some CMake option names have been renamed (deprecated) to the LIBICAL namespace.
+Some CMake option names have been removed or renamed (deprecated) to the LIBICAL namespace.
 
 Please change your build scripts to use the new names before the next major release.
 
@@ -12,6 +12,7 @@ User-specific:
 
 | Old Name                     | New Name                             |
 |------------------------------|--------------------------------------|
+| ICAL_ALLOW_EMPTY_PROPERTIES  | removed                              |
 | ICAL_BUILD_DOCS              | LIBICAL_BUILD_DOCS                   |
 | ICAL_ERRORS_ARE_FATAL        | LIBICAL_ENABLE_ERRORS_ARE_FATAL      |
 | ICAL_GLIB                    | LIBICAL_GLIB                         |
@@ -52,6 +53,14 @@ you can handle code that no longer exists in 4.0 with:
      <...old code for the libical 3.0 version ...>
      #endif
 ```
+
+## ICAL_ALLOW_EMPTY_PROPERTIES
+
+The `ICAL_ALLOW_EMPTY_PROPERTIES` conditional compile macro and accompanying CMake option `ICAL_ALLOW_EMPTY_PROPERTIES`
+are removed.
+
+To allow empty properties you can use the new runtime functions `icalproperty_set_allow_empty_properties()`
+and `icalproperty_get_allow_empty_properties()`.
 
 ## PVL_USE_MACROS
 
@@ -104,6 +113,8 @@ The following functions have been added:
 * `icaltzutil_set_zone_directory()`
 * `icalcomponent_clone()`
 * `icalproperty_clone()`
+* `icalproperty_set_allow_empty_properties()`
+* `icalproperty_get_allow_empty_properties()`
 * `icalparameter_clone()`
 * `icalparameter_kind_value_kind()`
 * `icalparameter_is_multivalued()`

--- a/src/libical-glib/api/i-cal-property.xml
+++ b/src/libical-glib/api/i-cal-property.xml
@@ -344,4 +344,12 @@
         <returns type="const gchar *" comment="The string representation of #ICalPropertyResourcetype."/>
         <comment xml:space="preserve">Converts the #ICalPropertyResourcetype to string.</comment>
     </method>
+    <method name="i_cal_property_set_allow_empty_properties" corresponds="icalproperty_set_allow_empty_properties" since="4.0">
+        <parameter type="gboolean" name="value" comment="value to set"/>
+        <comment xml:space="preserve">Sets if empty properties are allowed.</comment>
+    </method>
+    <method name="i_cal_property_get_allow_empty_properties" corresponds="icalproperty_get_allow_empty_properties" since="4.0">
+        <returns type="gboolean" comment="whether empty properties are allowed" />
+        <comment xml:space="preserve">Returns true if empty properties are allowed.</comment>
+    </method>
 </structure>

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1184,37 +1184,36 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
             str = NULL;
 
         } else {
-#if ICAL_ALLOW_EMPTY_PROPERTIES
-            /* Don't replace empty properties with an error.
-               Set an empty length string (not null) as the value instead */
-            if (vcount == 0) {
-                icalproperty_set_value(prop, icalvalue_new(ICAL_NO_VALUE));
-            }
-
-            break;
-#else
-            if (vcount == 0) {
-                char temp[200]; /* HACK */
-
-                icalproperty_kind isa_prop_kind = icalproperty_isa(prop);
-                icalcomponent *tail = icalpvl_data(icalpvl_tail(parser->components));
-
-                snprintf(temp, sizeof(temp), "No value for %s property. Removing entire property",
-                         icalproperty_kind_to_string(isa_prop_kind));
-
-                insert_error(parser, tail, str, temp, ICAL_XLICERRORTYPE_VALUEPARSEERROR);
-
-                /* Remove the troublesome property */
-                icalcomponent_remove_property(tail, prop);
-                icalproperty_free(prop);
-                prop = 0;
-                tail = 0;
-                parser->state = ICALPARSER_ERROR;
-                return 0;
-            } else {
+            if (icalproperty_get_allow_empty_properties()) {
+                /* Don't replace empty properties with an error.
+                   Set an empty length string (not null) as the value instead */
+                if (vcount == 0) {
+                    icalproperty_set_value(prop, icalvalue_new(ICAL_NO_VALUE));
+                }
                 break;
+            } else {
+                if (vcount == 0) {
+                    char temp[200]; /* HACK */
+
+                    icalproperty_kind isa_prop_kind = icalproperty_isa(prop);
+                    icalcomponent *tail = icalpvl_data(icalpvl_tail(parser->components));
+
+                    snprintf(temp, sizeof(temp), "No value for %s property. Removing entire property",
+                             icalproperty_kind_to_string(isa_prop_kind));
+
+                    insert_error(parser, tail, str, temp, ICAL_XLICERRORTYPE_VALUEPARSEERROR);
+
+                    /* Remove the troublesome property */
+                    icalcomponent_remove_property(tail, prop);
+                    icalproperty_free(prop);
+                    prop = 0;
+                    tail = 0;
+                    parser->state = ICALPARSER_ERROR;
+                    return 0;
+                } else {
+                    break;
+                }
             }
-#endif
         }
     }
 

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -31,6 +31,18 @@ struct icalproperty_impl {
     icalcomponent *parent;
 };
 
+static ICAL_GLOBAL_VAR bool icalprop_allow_empty_properties = false;
+
+void icalproperty_set_allow_empty_properties(bool enable)
+{
+    icalprop_allow_empty_properties = enable;
+}
+
+bool icalproperty_get_allow_empty_properties(void)
+{
+    return icalprop_allow_empty_properties;
+}
+
 void icalproperty_add_parameters(icalproperty *prop, va_list args)
 {
     void *vp;
@@ -429,16 +441,12 @@ char *icalproperty_as_ical_string_r(icalproperty *prop)
 
         if (str != 0) {
             icalmemory_append_string(&buf, &buf_ptr, &buf_size, str);
-#if ICAL_ALLOW_EMPTY_PROPERTIES == 0
-        } else {
+        } else if (!icalproperty_get_allow_empty_properties()) {
             icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
-#endif
         }
         icalmemory_free_buffer(str);
-    } else {
-#if ICAL_ALLOW_EMPTY_PROPERTIES == 0
+    } else if (!icalproperty_get_allow_empty_properties()) {
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
-#endif
     }
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, newline);

--- a/src/libical/icalproperty.h
+++ b/src/libical/icalproperty.h
@@ -189,6 +189,31 @@ LIBICAL_ICAL_EXPORT bool icalproperty_enum_belongs_to_property(icalproperty_kind
  */
 LIBICAL_ICAL_EXPORT void icalproperty_normalize(icalproperty *prop);
 
+/**
+ * Sets if empty properties are permitted.
+ *
+ * Determines the library behavior whenever an empty property is encountered.
+ * When not set (the default) empty properties are replaced with X-LIC-ERROR properties.
+ * Otherwise, processing proceeds normally and the property value will be empty.
+ *
+ * @param enable If true, libical allows empty properties; otherwise empty properties
+ *               are replaced by X-LIC-ERROR properties.
+ *
+ * Note that if icalerror_get_errors_are_fatal is also true a SIGABRT will be raised
+ * whenever an empty property is encountered.
+ * @since 4.0
+ */
+LIBICAL_ICAL_EXPORT void icalproperty_set_allow_empty_properties(bool enable);
+
+/**
+ * Returns if empty properties are allowed; else are replaced with X-LIC-ERROR properties.
+ *
+ * @return true if empty properties are allowed; else returns false
+ * @since 4.0
+ *
+ */
+LIBICAL_ICAL_EXPORT bool icalproperty_get_allow_empty_properties(void);
+
 /* This is exposed so that callers will not have to allocate and
    deallocate iterators. Pretend that you can't see it. */
 typedef struct icalparamiter {

--- a/src/libicalvcard/vcardproperty.c
+++ b/src/libicalvcard/vcardproperty.c
@@ -16,6 +16,7 @@
 #include "vcardvalue.h"
 #include "icalerror.h"
 #include "icalmemory.h"
+#include "icalproperty.h"
 #include "icalpvl.h"
 
 #include <stdlib.h>
@@ -503,16 +504,12 @@ char *vcardproperty_as_vcard_string_r(vcardproperty *prop)
 
         if (str != 0) {
             icalmemory_append_string(&buf, &buf_ptr, &buf_size, str);
-#if ICAL_ALLOW_EMPTY_PROPERTIES == 0
-        } else {
+        } else if (!icalproperty_get_allow_empty_properties()) {
             icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
-#endif
         }
         icalmemory_free_buffer(str);
-    } else {
-#if ICAL_ALLOW_EMPTY_PROPERTIES == 0
+    } else if (!icalproperty_get_allow_empty_properties()) {
         icalmemory_append_string(&buf, &buf_ptr, &buf_size, "ERROR: No Value");
-#endif
     }
 
     icalmemory_append_string(&buf, &buf_ptr, &buf_size, newline);


### PR DESCRIPTION
Replace the compile time ICAL_ALLOW_EMPTY_PROPERTIES macro with a runtime setter/getter for enabling the library to allow empty properties.

fixes: #1036