### PR TITLE
icalduration: from/as_int to from/as_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ for details about API changes since libical 3.x.
 - CMake option -DGOBJECT_INTROSPECTION=True by default.
 - `icaltzutil_get_zone_directory()` can use the TZDIR environment to find system zoneinfo
 - `icaltimezone_set_tzid_prefix()` now allows setting an empty tzid prefix.
+- `icalduration_from_int` and `icalduration_as_int` have been renamed to
+    `icalduration_from_seconds` and `icalduration_as_seconds`, respectively.
 
 ### Deprecated
 

--- a/src/Net-ICal-Libical/lib/Net/ICal/Libical/Duration.pm
+++ b/src/Net-ICal-Libical/lib/Net/ICal/Libical/Duration.pm
@@ -63,7 +63,7 @@ sub new {
   } elsif ($arg =~ /^[-+]?\d+$/){
     # Seconds
     $self = Net::ICal::Libical::Property::new($package,'DURATION');
-    $self->{'dur'} = Net::ICal::Libical::icaldurationtype_new_from_int($arg);
+    $self->{'dur'} = Net::ICal::Libical::icaldurationtype_new_from_seconds($arg);
   } elsif ($arg) {
     # iCalendar string
     $self = Net::ICal::Libical::Property::new($package,'DURATION');
@@ -121,11 +121,11 @@ sub seconds {
 
   if($seconds){
     $self->{'dur'} =
-    Net::ICal::Libical::icaldurationtype_from_int($seconds);
+    Net::ICal::Libical::icaldurationtype_from_seconds($seconds);
     $self->_update_value();
   }
 
-  return Net::ICal::Libical::icaldurationtype_as_int($self->{'dur'});
+  return Net::ICal::Libical::icaldurationtype_as_seconds($self->{'dur'});
 
 }
 

--- a/src/Net-ICal-Libical/netical.i
+++ b/src/Net-ICal-Libical/netical.i
@@ -270,9 +270,9 @@ struct icaldurationtype
     unsigned int seconds;
 };
 
-struct icaldurationtype icaldurationtype_from_int(int t);
+struct icaldurationtype icaldurationtype_from_seconds(int t);
 struct icaldurationtype icaldurationtype_from_string(const char*);
-int icaldurationtype_as_int(struct icaldurationtype duration);
+int icaldurationtype_as_seconds(struct icaldurationtype duration);
 char* icaldurationtype_as_ical_string(struct icaldurationtype d);
 struct icaldurationtype icaldurationtype_null_duration();
 int icaldurationtype_is_null_duration(struct icaldurationtype d);

--- a/src/Net-ICal-Libical/netical_wrap.c
+++ b/src/Net-ICal-Libical/netical_wrap.c
@@ -1855,7 +1855,7 @@ XS(_wrap_icaltime_days_in_month) {
     XSRETURN(argvi);
 }
 
-XS(_wrap_icaldurationtype_from_int) {
+XS(_wrap_icaldurationtype_from_seconds) {
 
     struct icaldurationtype * _result;
     int  _arg0;
@@ -1864,10 +1864,10 @@ XS(_wrap_icaldurationtype_from_int) {
 
     cv = cv;
     if ((items < 1) || (items > 1))
-        croak("Usage: icaldurationtype_from_int(t);");
+        croak("Usage: icaldurationtype_from_seconds(t);");
     _arg0 = (int )SvIV(ST(0));
     _result = (struct icaldurationtype *) malloc(sizeof(struct icaldurationtype ));
-    *(_result) = icaldurationtype_from_int(_arg0);
+    *(_result) = icaldurationtype_from_seconds(_arg0);
     ST(argvi) = sv_newmortal();
     sv_setref_pv(ST(argvi++),"struct icaldurationtypePtr", (void *) _result);
     XSRETURN(argvi);
@@ -1891,7 +1891,7 @@ XS(_wrap_icaldurationtype_from_string) {
     XSRETURN(argvi);
 }
 
-XS(_wrap_icaldurationtype_as_int) {
+XS(_wrap_icaldurationtype_as_seconds) {
 
     int  _result;
     struct icaldurationtype * _arg0;
@@ -1900,12 +1900,12 @@ XS(_wrap_icaldurationtype_as_int) {
 
     cv = cv;
     if ((items < 1) || (items > 1))
-        croak("Usage: icaldurationtype_as_int(duration);");
+        croak("Usage: icaldurationtype_as_seconds(duration);");
     if (SWIG_GetPtr(ST(0),(void **) &_arg0,"struct icaldurationtypePtr")) {
-        croak("Type error in argument 1 of icaldurationtype_as_int. Expected struct icaldurationtypePtr.");
+        croak("Type error in argument 1 of icaldurationtype_as_seconds. Expected struct icaldurationtypePtr.");
         XSRETURN(1);
     }
-    _result = (int )icaldurationtype_as_int(*_arg0);
+    _result = (int )icaldurationtype_as_seconds(*_arg0);
     ST(argvi) = sv_newmortal();
     sv_setiv(ST(argvi++),(IV) _result);
     XSRETURN(argvi);
@@ -2967,9 +2967,9 @@ XS(boot_Net__ICal__Libical) {
 	 newXS("Net::ICal::Libical::icaltime_compare", _wrap_icaltime_compare, file);
 	 newXS("Net::ICal::Libical::icaltime_compare_date_only", _wrap_icaltime_compare_date_only, file);
 	 newXS("Net::ICal::Libical::icaltime_days_in_month", _wrap_icaltime_days_in_month, file);
-	 newXS("Net::ICal::Libical::icaldurationtype_from_int", _wrap_icaldurationtype_from_int, file);
+	 newXS("Net::ICal::Libical::icaldurationtype_from_seconds", _wrap_icaldurationtype_from_seconds, file);
 	 newXS("Net::ICal::Libical::icaldurationtype_from_string", _wrap_icaldurationtype_from_string, file);
-	 newXS("Net::ICal::Libical::icaldurationtype_as_int", _wrap_icaldurationtype_as_int, file);
+	 newXS("Net::ICal::Libical::icaldurationtype_as_seconds", _wrap_icaldurationtype_as_seconds, file);
 	 newXS("Net::ICal::Libical::icaldurationtype_as_ical_string", _wrap_icaldurationtype_as_ical_string, file);
 	 newXS("Net::ICal::Libical::icaldurationtype_null_duration", _wrap_icaldurationtype_null_duration, file);
 	 newXS("Net::ICal::Libical::icaldurationtype_is_null_duration", _wrap_icaldurationtype_is_null_duration, file);

--- a/src/Net-ICal-Libical/netical_wrap.doc
+++ b/src/Net-ICal-Libical/netical_wrap.doc
@@ -333,13 +333,13 @@ icaldurationtype_seconds_get(struct icaldurationtype *);
 
 ----------
 
-icaldurationtype_from_int(t);
+icaldurationtype_from_seconds(t);
         [ returns struct icaldurationtype  ]
 
 icaldurationtype_from_string(char *);
         [ returns struct icaldurationtype  ]
 
-icaldurationtype_as_int(duration);
+icaldurationtype_as_seconds(duration);
         [ returns int  ]
 
 icaldurationtype_as_ical_string(d);

--- a/src/libical-glib/api/i-cal-duration.xml
+++ b/src/libical-glib/api/i-cal-duration.xml
@@ -90,7 +90,7 @@
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
 	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->seconds = seconds;</custom>
     </method>
-    <method name="i_cal_duration_new_from_int" corresponds="icaldurationtype_from_int" kind="constructor" since="1.0">
+    <method name="i_cal_duration_new_from_seconds" corresponds="icaldurationtype_from_seconds" kind="constructor" since="1.0">
         <parameter type="gint" name="t" comment="The duration in second"/>
         <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration" />
         <comment xml:space="preserve">Creates a #ICalDuration from the duration in second.</comment>
@@ -100,7 +100,7 @@
         <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration" />
         <comment xml:space="preserve">Creates a #ICalDuration from the duration in string.</comment>
     </method>
-    <method name="i_cal_duration_as_int" corresponds="icaldurationtype_as_int" kind="others" since="1.0">
+    <method name="i_cal_duration_as_seconds" corresponds="icaldurationtype_as_seconds" kind="others" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be converted"/>
         <returns type="gint" comment="The duration in second" />
         <comment xml:space="preserve">Converts the #ICalDuration to the representation in second.</comment>

--- a/src/libical-glib/api/i-cal-trigger.xml
+++ b/src/libical-glib/api/i-cal-trigger.xml
@@ -5,8 +5,8 @@
 
 
 -->
-<structure namespace="ICal" name="Trigger" native="struct icaltriggertype" is_bare="true" default_native="icaltriggertype_from_int (0)">
-    <method name="i_cal_trigger_new_from_int" corresponds="icaltriggertype_from_int" kind="constructor" since="1.0">
+<structure namespace="ICal" name="Trigger" native="struct icaltriggertype" is_bare="true" default_native="icaltriggertype_from_seconds (0)">
+    <method name="i_cal_trigger_new_from_seconds" corresponds="icaltriggertype_from_seconds" kind="constructor" since="1.0">
         <parameter type="const gint" name="reltime" comment="An integer"/>
         <returns type="ICalTrigger *" annotation="transfer full" comment="The newly created #ICalTrigger."/>
         <comment xml:space="preserve">Creates a #ICalTrigger from integer.</comment>

--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -195,19 +195,19 @@ struct icaltriggertype icalvalue_get_trigger(const icalvalue *impl)
 {
     struct icaltriggertype tr;
 
-    tr.duration = icaldurationtype_from_int(0);
+    tr.duration = icaldurationtype_from_seconds(0);
     tr.time = icaltime_null_time();
 
     icalerror_check_arg_rx((impl != 0), "value", tr);
 
     if (impl->kind == ICAL_DATETIME_VALUE) {
-        tr.duration = icaldurationtype_from_int(0);
+        tr.duration = icaldurationtype_from_seconds(0);
         tr.time = impl->data.v_time;
     } else if (impl->kind == ICAL_DURATION_VALUE) {
         tr.time = icaltime_null_time();
         tr.duration = impl->data.v_duration;
     } else {
-        tr.duration = icaldurationtype_from_int(0);
+        tr.duration = icaldurationtype_from_seconds(0);
         tr.time = icaltime_null_time();
         icalerror_set_errno(ICAL_BADARG_ERROR);
     }

--- a/src/libical/icalduration.c
+++ b/src/libical/icalduration.c
@@ -20,7 +20,7 @@
 #include "icaltimezone.h"
 
 /* From Seth Alves, <alves@hungry.com>   */
-struct icaldurationtype icaldurationtype_from_int(int t)
+struct icaldurationtype icaldurationtype_from_seconds(int t)
 {
     struct icaldurationtype dur;
 
@@ -230,7 +230,7 @@ char *icaldurationtype_as_ical_string_r(struct icaldurationtype d)
     return buf;
 }
 
-int icaldurationtype_as_int(struct icaldurationtype dur)
+int icaldurationtype_as_seconds(struct icaldurationtype dur)
 {
     if (dur.days != 0 || dur.weeks != 0) {
         /* The length of a day is position-dependent */
@@ -345,7 +345,7 @@ struct icaldurationtype icaltime_subtract(struct icaltimetype t1, struct icaltim
         icaltime_t t1t = icaltime_as_timet_with_zone(t1, t1.zone);
         icaltime_t t2t = icaltime_as_timet_with_zone(t2, t2.zone);
 
-        ret = icaldurationtype_from_int((int)(t1t - t2t));
+        ret = icaldurationtype_from_seconds((int)(t1t - t2t));
     }
     return ret;
 }

--- a/src/libical/icalduration.h
+++ b/src/libical/icalduration.h
@@ -49,13 +49,10 @@ struct icaldurationtype {
  * ```c
  * // create a new icaldurationtype with a duration of 60 seconds
  * struct icaldurationtype duration;
- * duration = icaldurationtype_from_int(60);
- *
- * // verify that the duration is one minute
- * assert(duration.minutes == 1);
+ * duration = icaldurationtype_from_seconds(60);
  * ```
  */
-LIBICAL_ICAL_EXPORT struct icaldurationtype icaldurationtype_from_int(int t);
+LIBICAL_ICAL_EXPORT struct icaldurationtype icaldurationtype_from_seconds(int t);
 
 /**
  * @brief Creates a new ::icaldurationtype from a duration given as a string.
@@ -87,13 +84,13 @@ LIBICAL_ICAL_EXPORT struct icaldurationtype icaldurationtype_from_string(const c
  * ```c
  * // create icaldurationtype with given duration
  * struct icaldurationtype duration;
- * duration = icaldurationtype_from_int(3532342);
+ * duration = icaldurationtype_from_seconds(3532342);
  *
  * // get the duration in seconds and verify it
- * assert(icaldurationtype_as_int(duration) == 3532342);
+ * assert(icaldurationtype_as_seconds(duration) == 3532342);
  * ```
  */
-LIBICAL_ICAL_EXPORT int icaldurationtype_as_int(struct icaldurationtype duration);
+LIBICAL_ICAL_EXPORT int icaldurationtype_as_seconds(struct icaldurationtype duration);
 
 /**
  * Converts an icaldurationtype into the iCal format as string.
@@ -109,7 +106,7 @@ LIBICAL_ICAL_EXPORT int icaldurationtype_as_int(struct icaldurationtype duration
  * ```c
  * // create new duration
  * struct icaldurationtype duration;
- * duration = icaldurationtype_from_int(3424224);
+ * duration = icaldurationtype_from_seconds(3424224);
  *
  * // print as ical-formatted string
  * char *ical = icaldurationtype_as_ical_string(duration);
@@ -135,7 +132,7 @@ LIBICAL_ICAL_EXPORT char *icaldurationtype_as_ical_string(struct icaldurationtyp
  * ```c
  * // create new duration
  * struct icaldurationtype duration;
- * duration = icaldurationtype_from_int(3424224);
+ * duration = icaldurationtype_from_seconds(3424224);
  *
  * // print as ical-formatted string
  * printf("%s\n", icaldurationtype_as_ical_string(duration));
@@ -161,7 +158,7 @@ LIBICAL_ICAL_EXPORT char *icaldurationtype_as_ical_string_r(struct icaldurationt
  * assert(duration.minutes  == 0);
  * assert(duration.seconds  == 0);
  * assert(icalduration_is_null_duration(duration));
- * assert(icalduration_as_int(duration) == 0);
+ * assert(icalduration_as_seconds(duration) == 0);
  * ```
  */
 LIBICAL_ICAL_EXPORT struct icaldurationtype icaldurationtype_null_duration(void);
@@ -232,7 +229,7 @@ LIBICAL_ICAL_EXPORT bool icaldurationtype_is_bad_duration(struct icaldurationtyp
  *
  * // create time and duration objects
  * time = icaltime_today();
- * duration = icaldurationtype_from_int(60);
+ * duration = icaldurationtype_from_seconds(60);
  *
  * // add the duration to the time object
  * time = icaltime_add(time, duration);

--- a/src/libical/icaltypes.c
+++ b/src/libical/icaltypes.c
@@ -40,12 +40,12 @@ bool icaltriggertype_is_bad_trigger(struct icaltriggertype tr)
     return false;
 }
 
-struct icaltriggertype icaltriggertype_from_int(const int reltime)
+struct icaltriggertype icaltriggertype_from_seconds(const int reltime)
 {
     struct icaltriggertype tr;
 
     tr.time = icaltime_null_time();
-    tr.duration = icaldurationtype_from_int(reltime);
+    tr.duration = icaldurationtype_from_seconds(reltime);
 
     return tr;
 }
@@ -57,7 +57,7 @@ struct icaltriggertype icaltriggertype_from_string(const char *str)
     icalerrorenum e;
 
     tr.time = icaltime_null_time();
-    tr.duration = icaldurationtype_from_int(0);
+    tr.duration = icaldurationtype_from_seconds(0);
 
     /* Suppress errors so a failure in icaltime_from_string() does not cause an abort */
     es = icalerror_get_error_state(ICAL_MALFORMEDDATA_ERROR);

--- a/src/libical/icaltypes.h
+++ b/src/libical/icaltypes.h
@@ -32,7 +32,7 @@ struct icaltriggertype {
     struct icaldurationtype duration;
 };
 
-LIBICAL_ICAL_EXPORT struct icaltriggertype icaltriggertype_from_int(const int reltime);
+LIBICAL_ICAL_EXPORT struct icaltriggertype icaltriggertype_from_seconds(const int reltime);
 
 LIBICAL_ICAL_EXPORT struct icaltriggertype icaltriggertype_from_string(const char *str);
 

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -1398,15 +1398,32 @@ icalparameter_xliccomparetype icalvalue_compare(const icalvalue *a, const icalva
     }
 
     case ICAL_DURATION_VALUE: {
-        int dur_a = icaldurationtype_as_int(a->data.v_duration);
-        int dur_b = icaldurationtype_as_int(b->data.v_duration);
+        struct icaldurationtype dur_a = a->data.v_duration,
+                                dur_b = b->data.v_duration;
+        int a_days = (int)(7 * dur_a.weeks + dur_a.days) * (dur_a.is_neg == 1 ? -1 : 1),
+            b_days = (int)(7 * dur_b.weeks + dur_b.days) * (dur_a.is_neg == 1 ? -1 : 1);
+        int a_secs = (int)(dur_a.seconds + 60 * (dur_a.minutes + 60 * dur_a.hours)) *
+                     (dur_a.is_neg == 1 ? -1 : 1),
+            b_secs = (int)(dur_b.seconds + 60 * (dur_b.minutes + 60 * dur_b.hours)) *
+                     (dur_b.is_neg == 1 ? -1 : 1);
 
-        if (dur_a > dur_b) {
-            return ICAL_XLICCOMPARETYPE_GREATER;
-        } else if (dur_a < dur_b) {
-            return ICAL_XLICCOMPARETYPE_LESS;
+        if (a_secs == b_secs) {
+            if (a_days > b_days) {
+                return ICAL_XLICCOMPARETYPE_GREATER;
+            } else if (a_days < b_days) {
+                return ICAL_XLICCOMPARETYPE_LESS;
+            } else {
+                return ICAL_XLICCOMPARETYPE_EQUAL;
+            }
+        } else if (a_days == b_days) {
+            if (a_secs > b_secs) {
+                return ICAL_XLICCOMPARETYPE_GREATER;
+            } else {
+                return ICAL_XLICCOMPARETYPE_LESS;
+            }
         } else {
-            return ICAL_XLICCOMPARETYPE_EQUAL;
+            /* We can't compare a mix of nominal and accurate durations */
+            return ICAL_XLICCOMPARETYPE_NOTEQUAL;
         }
     }
 

--- a/src/test/libical-glib/duration.py
+++ b/src/test/libical-glib/duration.py
@@ -16,12 +16,12 @@ from gi.repository import ICalGLib  # noqa E402
 length = 1000000000
 badString = 'This is a bad string'
 
-duration = ICalGLib.Duration.new_from_int(length)
-assert duration.as_int() == length
+duration = ICalGLib.Duration.new_from_seconds(length)
+assert duration.as_seconds() == length
 length_in_string = duration.as_ical_string()
 duration1 = ICalGLib.Duration.new_from_string(length_in_string)
 assert duration1.as_ical_string() == length_in_string
-assert length == duration1.as_int()
+assert length == duration1.as_seconds()
 
 duration = ICalGLib.Duration.new_from_string(badString)
 durationBad = ICalGLib.Duration.new_bad_duration()

--- a/src/test/libical-glib/period.py
+++ b/src/test/libical-glib/period.py
@@ -43,7 +43,7 @@ assert end.get_minute() == 16
 assert end.get_second() == 25
 
 duration = period.get_duration()
-assert duration.as_int() == 0
+assert duration.as_seconds() == 0
 
 string = '19970101T182346Z/PT5H30M'
 period = ICalGLib.Period.new_from_string(string)

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -1695,19 +1695,19 @@ void test_duration(void)
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("PT8H30M", icaldurationtype_as_int(d), 30600);
+    int_is("PT8H30M", icaldurationtype_as_seconds(d), 30600);
 
     d = icaldurationtype_from_string("-PT8H30M");
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("-PT8H30M", icaldurationtype_as_int(d), -30600);
+    int_is("-PT8H30M", icaldurationtype_as_seconds(d), -30600);
 
     d = icaldurationtype_from_string("PT10H10M10S");
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("PT10H10M10S", icaldurationtype_as_int(d), 36610);
+    int_is("PT10H10M10S", icaldurationtype_as_seconds(d), 36610);
 
     icalerror_set_errors_are_fatal(false);
 
@@ -1717,47 +1717,47 @@ void test_duration(void)
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("P7W", icaldurationtype_as_int(d), 0);
+    int_is("P7W", icaldurationtype_as_seconds(d), 0);
 
     d = icaldurationtype_from_string("P2DT8H30M");
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("P2DT8H30M", icaldurationtype_as_int(d), 0);
+    int_is("P2DT8H30M", icaldurationtype_as_seconds(d), 0);
 
     d = icaldurationtype_from_string("P2W1DT5H");
     if (VERBOSE) {
-        printf("%s %d\n", icaldurationtype_as_ical_string(d), icaldurationtype_as_int(d));
+        printf("%s %d\n", icaldurationtype_as_ical_string(d), icaldurationtype_as_seconds(d));
     }
-    int_is("P2W1DT5H", icaldurationtype_as_int(d), 0);
+    int_is("P2W1DT5H", icaldurationtype_as_seconds(d), 0);
 
     d = icaldurationtype_from_string("P-2DT8H30M");
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("P-2DT8H30M", icaldurationtype_as_int(d), 0);
+    int_is("P-2DT8H30M", icaldurationtype_as_seconds(d), 0);
 
     d = icaldurationtype_from_string("P7W8H");
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("P7W8H", icaldurationtype_as_int(d), 0);
+    int_is("P7W8H", icaldurationtype_as_seconds(d), 0);
 
     d = icaldurationtype_from_string("T10H");
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("T10H", icaldurationtype_as_int(d), 0);
+    int_is("T10H", icaldurationtype_as_seconds(d), 0);
 
     icalerror_set_errors_are_fatal(true);
 
-    d = icaldurationtype_from_int(4233600);
+    d = icaldurationtype_from_seconds(4233600);
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
     str_is("PT4233600S", icaldurationtype_as_ical_string(d), "PT4233600S");
 
-    d = icaldurationtype_from_int(4424400);
+    d = icaldurationtype_from_seconds(4424400);
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
@@ -2766,7 +2766,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
     str_is("Start is 1997-08-01 12:00:00 (floating)",
            ictt_as_string(icalcomponent_get_dtstart(c)), "1997-08-01 12:00:00 (floating)");
@@ -2789,7 +2789,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
     str_is("Start is 1997-08-01 12:00:00 Z UTC",
            ictt_as_string(icalcomponent_get_dtstart(c)), "1997-08-01 12:00:00 Z UTC");
@@ -2816,7 +2816,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
     str_is("Start is 1997-08-01 12:00:00 (floating)",
            ictt_as_string(icalcomponent_get_dtstart(c)), "1997-08-01 12:00:00 (floating)");
@@ -2841,7 +2841,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
     ok("Start is 1997-08-01 12:00:00 Z UTC",
        (0 == strcmp("1997-08-01 12:00:00 Z UTC", ictt_as_string(icalcomponent_get_dtstart(c)))));
@@ -2864,7 +2864,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
     ok("Start is 1997-08-01 12:00:00 Z UTC",
        (0 == strcmp("1997-08-01 12:00:00 Z UTC", ictt_as_string(icalcomponent_get_dtstart(c)))));
@@ -2885,7 +2885,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
     ok("Start is 1997-08-01 12:00:00 Z UTC",
        (0 == strcmp("1997-08-01 12:00:00 Z UTC", ictt_as_string(icalcomponent_get_dtstart(c)))));
@@ -2908,7 +2908,7 @@ void test_convenience(void)
     }
 
     icalcomponent_set_duration(c, icaldurationtype_from_string("PT1H30M"));
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 60;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
 #if ADD_TESTS_BROKEN_BUILTIN_TZDATA
     ok("Start is 1997-08-01 12:00:00 Europe/Rome",
@@ -2938,7 +2938,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 3600;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 3600;
 
     ok("Duration is 7 h", (duration == 7));
 
@@ -2960,7 +2960,7 @@ void test_convenience(void)
         printf("\n%s\n", icalcomponent_as_ical_string(c));
     }
 
-    duration = icaldurationtype_as_int(icalcomponent_get_duration(c)) / 3600;
+    duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 3600;
 
     ok("Duration is 7 h", (duration == 7));
 
@@ -3788,7 +3788,7 @@ void test_file_locks(void)
     if (icalfileset_get_first_component(fs) == 0) {
         c = make_component(0);
 
-        d = icaldurationtype_from_int(1);
+        d = icaldurationtype_from_seconds(1);
 
         icalcomponent_set_duration(c, d);
 
@@ -3825,7 +3825,7 @@ void test_file_locks(void)
             assert(c != 0);
 
             d = icalcomponent_get_duration(c);
-            d = icaldurationtype_from_int(icaldurationtype_as_int(d) + 1);
+            d = icaldurationtype_from_seconds(icaldurationtype_as_seconds(d) + 1);
 
             icalcomponent_set_duration(c, d);
             icalcomponent_set_summary(c, "Child");
@@ -3858,7 +3858,7 @@ void test_file_locks(void)
             assert(c != 0);
 
             d = icalcomponent_get_duration(c);
-            d = icaldurationtype_from_int(icaldurationtype_as_int(d) + 1);
+            d = icaldurationtype_from_seconds(icaldurationtype_as_seconds(d) + 1);
 
             icalcomponent_set_duration(c, d);
             icalcomponent_set_summary(c, "Parent");
@@ -3883,11 +3883,11 @@ void test_file_locks(void)
     i = 1;
 
     c = icalfileset_get_first_component(fs);
-    final = icaldurationtype_as_int(icalcomponent_get_duration(c));
+    final = icaldurationtype_as_seconds(icalcomponent_get_duration(c));
     for (c = icalfileset_get_next_component(fs); c != 0; c = icalfileset_get_next_component(fs)) {
         struct icaldurationtype d = icalcomponent_get_duration(c);
 
-        sec = icaldurationtype_as_int(d);
+        sec = icaldurationtype_as_seconds(d);
 
         /*printf("%d,%d ",i,sec); */
         assert(i == sec);
@@ -5772,7 +5772,7 @@ static void test_implicit_dtend_duration(void)
     if (VERBOSE) {
         printf("%s\n", icaldurationtype_as_ical_string(d));
     }
-    int_is("icaldurationtype_as_int(d)", 0, icaldurationtype_as_int(d));
+    int_is("icaldurationtype_as_seconds(d)", 0, icaldurationtype_as_seconds(d));
 
     if (VERBOSE) {
         printf("%s\n", icaltime_as_ical_string(end));


### PR DESCRIPTION
Change icalduration_from_int and icalduration_as_int to icalduration_from_seconds and icalduration_as_seconds, respectively. Fixes #1044.

This is essentially a global search and replace of these two names, except the code in [src/libical/icalvalue.c](https://github.com/libical/libical/compare/master...CMendia:seconds?expand=1#diff-1dd2e567bcf8e9ee5fbfc53404fe5907d3bab50954eaafcc0c30cbdbede810fd), which is new. The new code fixes comparison of nominal and accurate durations.

Because of #202, I have ignored most of the Perl code that still needs to be changed.