### PR TITLE
icalparser.c - add crash guard in icalparser_string_line_generator

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -1281,17 +1281,18 @@ char *icalparser_string_line_generator(char *out, size_t buf_size, void *d)
 
     if (data->pos == 0) {
         data->pos = data->str;
-
-        /* Skip the UTF-8 marker at the beginning of the string */
-        if (((unsigned char)data->pos[0]) == 0xEF &&
-            ((unsigned char)data->pos[1]) == 0xBB &&
-            ((unsigned char)data->pos[2]) == 0xBF) {
-            data->pos += 3;
+        if (data->pos && strlen(data->pos) > 2) {
+            /* Skip the UTF-8 marker at the beginning of the string */
+            if (((unsigned char)data->pos[0]) == 0xEF &&
+                ((unsigned char)data->pos[1]) == 0xBB &&
+                ((unsigned char)data->pos[2]) == 0xBF) {
+                data->pos += 3;
+            }
         }
     }
 
     /* If the pointer is at the end of the string, we are done */
-    if (*(data->pos) == 0) {
+    if (!data->pos || *(data->pos) == 0) {
         return 0;
     }
 


### PR DESCRIPTION
in the case of short strings (less than 3 chars) we could crash.