### PR TITLE
icaltime - do not attempt to adjust null times

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -306,6 +306,10 @@ becomes
     sscanf(geo.lon, "%lf", &lon);
 ```
 
+## icaltime_adjust
+
+The `icaltime_adjust` function no longer adjusts null icaltimetypes.
+
 ### Working with `icalvalue` and `icalproperty`
 
 Code like this in libical 3.0:

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -611,6 +611,7 @@ struct icaltimetype icaltime_null_date(void)
 
 bool icaltime_is_valid_time(const struct icaltimetype t)
 {
+    // Note that we allow year, month and day to be zero to support null times
     if (t.year < 0 || t.year > 9999 ||
         t.month < 0 || t.month > 12 ||
         t.day < 0 || t.day > 31 ||
@@ -769,6 +770,10 @@ void icaltime_adjust(struct icaltimetype *tt,
     int second, minute, hour, day;
     int minutes_overflow, hours_overflow, days_overflow = 0, years_overflow;
     int days_in_month;
+
+    if (icaltime_is_null_time(*tt)) { // do not attempt to adjust null times
+        return;
+    }
 
     /* If we are passed a date make sure to ignore hour minute and second */
     if (tt->is_date) {

--- a/src/test/libical-glib/timezone.py
+++ b/src/test/libical-glib/timezone.py
@@ -51,7 +51,7 @@ assert utc.get_display_name() == 'UTC'
 utc2 = ICalGLib.Timezone.get_utc_timezone()
 assert utc == utc2
 
-time = ICalGLib.Time.new()
+time = ICalGLib.Time.new_from_timet_with_zone(1494096400, 0, utc)
 before = time.get_hour()
 ICalGLib.Time.convert_timezone(time, la, chicago)
 after = time.get_hour()

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -430,6 +430,24 @@ void test_icaltime_compare_utc_zone(void)
     int_is("a < b", icaltime_compare(a, b), -1);
 }
 
+void test_icaltime_normalize(void)
+{
+    icalcomponent *comp = icalcomponent_new_vpatch();
+    ok("icaltime_normalize new vpatch", (comp != 0));
+    struct icaltimetype t = icalcomponent_get_dtstamp(comp);
+    ok("icaltime_normalize dtstamp time is valid", icaltime_is_valid_time(t));
+    if (VERBOSE) {
+        printf("Time: %d-%d-%d %d:%d:%d (is_valid: %d)\n", t.year, t.month, t.day, t.hour, t.minute, t.second, icaltime_is_valid_time(t));
+    }
+
+    struct icaltimetype norm = icaltime_normalize(t);
+    ok("icaltime_normalize normalize normalized dtstamp time is valid", icaltime_is_valid_time(norm));
+    if (VERBOSE) {
+        printf("Normalized Time: %d-%d-%d %d:%d:%d (is_valid: %d)\n", norm.year, norm.month, norm.day, norm.hour, norm.minute, norm.second, icaltime_is_valid_time(norm));
+    }
+    icalcomponent_free(comp);
+}
+
 void test_parameters(void)
 {
     icalparameter *p;
@@ -7033,6 +7051,7 @@ int main(int argc, char *argv[])
     test_run("Test manipulating tzid", test_tzid_setter, do_test, do_header);
     test_run("Test icaltime proper zone set", test_icaltime_proper_zone, do_test, do_header);
     test_run("Test property values from string", test_value_from_string, do_test, do_header);
+    test_run("Test normalizing time", test_icaltime_normalize, do_test, do_header);
     /** OPTIONAL TESTS go here... **/
 
 #if defined(LIBICAL_CXX_BINDINGS)


### PR DESCRIPTION
Tell icaltime_adjust() to skip null icaltimetypes

fixes: #1051