### PR TITLE
Rename icaltime_add and icaltime_subtract to icalduration

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -112,6 +112,9 @@ The icalerror unit always compiles the `icalerror_set_errno` function.
   have been renamed to `icaldurationtype_from_seconds()` and `icaldurationtype_as_seconds()`, respectively.
   Their functionality has not changed.
 
+* Similarly, the `icaltime_add()` and `icaltime_subtract()` functions are now called
+  `icalduration_extend()` and `icalduration_from_times()`.  Their functionality has not changed.
+
 ### New functions
 
 The following functions have been added:

--- a/src/Net-ICal-Libical/netical.i
+++ b/src/Net-ICal-Libical/netical.i
@@ -277,11 +277,11 @@ char* icaldurationtype_as_ical_string(struct icaldurationtype d);
 struct icaldurationtype icaldurationtype_null_duration();
 int icaldurationtype_is_null_duration(struct icaldurationtype d);
 
-struct icaltimetype  icaltime_add(struct icaltimetype t,
-                  struct icaldurationtype  d);
+struct icaltimetype icalduration_extend(struct icaltimetype t,
+                                        struct icaldurationtype  d);
 
-struct icaldurationtype  icaltime_subtract(struct icaltimetype t1,
-                       struct icaltimetype t2);
+struct icaldurationtype icalduration_from_times(struct icaltimetype t1,
+                                            struct icaltimetype t2);
 
 
 /***********************************************************************

--- a/src/Net-ICal-Libical/netical_wrap.c
+++ b/src/Net-ICal-Libical/netical_wrap.c
@@ -1967,7 +1967,7 @@ XS(_wrap_icaldurationtype_is_null_duration) {
     XSRETURN(argvi);
 }
 
-XS(_wrap_icaltime_add) {
+XS(_wrap_icalduration_extend) {
 
     struct icaltimetype * _result;
     struct icaltimetype * _arg0;
@@ -1977,23 +1977,23 @@ XS(_wrap_icaltime_add) {
 
     cv = cv;
     if ((items < 2) || (items > 2))
-        croak("Usage: icaltime_add(t,d);");
+        croak("Usage: icalduration_extend(t,d);");
     if (SWIG_GetPtr(ST(0),(void **) &_arg0,"struct icaltimetypePtr")) {
-        croak("Type error in argument 1 of icaltime_add. Expected struct icaltimetypePtr.");
+        croak("Type error in argument 1 of icalduration_extend. Expected struct icaltimetypePtr.");
         XSRETURN(1);
     }
     if (SWIG_GetPtr(ST(1),(void **) &_arg1,"struct icaldurationtypePtr")) {
-        croak("Type error in argument 2 of icaltime_add. Expected struct icaldurationtypePtr.");
+        croak("Type error in argument 2 of icalduration_extend. Expected struct icaldurationtypePtr.");
         XSRETURN(1);
     }
     _result = (struct icaltimetype *) malloc(sizeof(struct icaltimetype ));
-    *(_result) = icaltime_add(*_arg0,*_arg1);
+    *(_result) = icalduration_extend(*_arg0,*_arg1);
     ST(argvi) = sv_newmortal();
     sv_setref_pv(ST(argvi++),"struct icaltimetypePtr", (void *) _result);
     XSRETURN(argvi);
 }
 
-XS(_wrap_icaltime_subtract) {
+XS(_wrap_icalduration_from_times) {
 
     struct icaldurationtype * _result;
     struct icaltimetype * _arg0;
@@ -2003,17 +2003,17 @@ XS(_wrap_icaltime_subtract) {
 
     cv = cv;
     if ((items < 2) || (items > 2))
-        croak("Usage: icaltime_subtract(t1,t2);");
+        croak("Usage: icalduration_from_times(t1,t2);");
     if (SWIG_GetPtr(ST(0),(void **) &_arg0,"struct icaltimetypePtr")) {
-        croak("Type error in argument 1 of icaltime_subtract. Expected struct icaltimetypePtr.");
+        croak("Type error in argument 1 of icalduration_from_times. Expected struct icaltimetypePtr.");
         XSRETURN(1);
     }
     if (SWIG_GetPtr(ST(1),(void **) &_arg1,"struct icaltimetypePtr")) {
-        croak("Type error in argument 2 of icaltime_subtract. Expected struct icaltimetypePtr.");
+        croak("Type error in argument 2 of icalduration_from_times. Expected struct icaltimetypePtr.");
         XSRETURN(1);
     }
     _result = (struct icaldurationtype *) malloc(sizeof(struct icaldurationtype ));
-    *(_result) = icaltime_subtract(*_arg0,*_arg1);
+    *(_result) = icalduration_from_times(*_arg0,*_arg1);
     ST(argvi) = sv_newmortal();
     sv_setref_pv(ST(argvi++),"struct icaldurationtypePtr", (void *) _result);
     XSRETURN(argvi);
@@ -2973,8 +2973,8 @@ XS(boot_Net__ICal__Libical) {
 	 newXS("Net::ICal::Libical::icaldurationtype_as_ical_string", _wrap_icaldurationtype_as_ical_string, file);
 	 newXS("Net::ICal::Libical::icaldurationtype_null_duration", _wrap_icaldurationtype_null_duration, file);
 	 newXS("Net::ICal::Libical::icaldurationtype_is_null_duration", _wrap_icaldurationtype_is_null_duration, file);
-	 newXS("Net::ICal::Libical::icaltime_add", _wrap_icaltime_add, file);
-	 newXS("Net::ICal::Libical::icaltime_subtract", _wrap_icaltime_subtract, file);
+	 newXS("Net::ICal::Libical::icalduration_extend, _wrap_icalduration_extend, file);
+	 newXS("Net::ICal::Libical::icalduration_from_times", _wrap_icalduration_from_times, file);
 	 newXS("Net::ICal::Libical::icalperiodtype_from_string", _wrap_icalperiodtype_from_string, file);
 	 newXS("Net::ICal::Libical::icalperiodtype_as_ical_string", _wrap_icalperiodtype_as_ical_string, file);
 	 newXS("Net::ICal::Libical::icalperiodtype_null_period", _wrap_icalperiodtype_null_period, file);

--- a/src/Net-ICal-Libical/netical_wrap.doc
+++ b/src/Net-ICal-Libical/netical_wrap.doc
@@ -351,10 +351,10 @@ icaldurationtype_null_duration();
 icaldurationtype_is_null_duration(d);
         [ returns int  ]
 
-icaltime_add(t,d);
+icalduration_extend(t,d);
         [ returns struct icaltimetype  ]
 
-icaltime_subtract(t1,t2);
+icalduration_from_times(t1,t2);
         [ returns struct icaldurationtype  ]
 
 3.  class icalperiodtype

--- a/src/libical-glib/api/i-cal-duration.xml
+++ b/src/libical-glib/api/i-cal-duration.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!--
   SPDX-FileCopyrightText: 2015 William Yu <williamyu@gnome.org>
 
@@ -8,101 +9,101 @@
 <structure namespace="ICal" name="Duration" native="struct icaldurationtype" is_bare="true" default_native="icaldurationtype_null_duration()">
     <method name="i_cal_duration_is_neg" corresponds="none" kind="get" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
-        <returns type="gboolean" comment="The is_neg." />
+        <returns type="gboolean" comment="The is_neg."/>
         <comment xml:space="preserve">Gets the is_neg of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
-	return (((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->is_neg) ? TRUE : FALSE;</custom>
+	return (((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;is_neg) ? TRUE : FALSE;</custom>
     </method>
     <method name="i_cal_duration_set_is_neg" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="gboolean" name="is_neg" comment="The is_neg"/>
         <comment>Sets the is_neg of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
-	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->is_neg = is_neg ? 1 : 0;</custom>
+	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;is_neg = is_neg ? 1 : 0;</custom>
     </method>
     <method name="i_cal_duration_get_days" corresponds="none" kind="get" since="1.0">
-	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
-        <returns type="guint" comment="The days." />
+        <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
+        <returns type="guint" comment="The days."/>
         <comment xml:space="preserve">Gets the days of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
-	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->days;</custom>
+	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;days;</custom>
     </method>
     <method name="i_cal_duration_set_days" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="days" comment="The days"/>
         <comment>Sets the days of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
-	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->days = days;</custom>
+	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;days = days;</custom>
     </method>
     <method name="i_cal_duration_get_weeks" corresponds="none" kind="get" since="1.0">
-	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
-        <returns type="guint" comment="The weeks." />
+        <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
+        <returns type="guint" comment="The weeks."/>
         <comment xml:space="preserve">Gets the weeks of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
-	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->weeks;</custom>
+	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;weeks;</custom>
     </method>
     <method name="i_cal_duration_set_weeks" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="weeks" comment="The weeks"/>
         <comment>Sets the weeks of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
-	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->weeks = weeks;</custom>
+	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;weeks = weeks;</custom>
     </method>
     <method name="i_cal_duration_get_hours" corresponds="none" kind="get" since="1.0">
-	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
-        <returns type="guint" comment="The hours." />
+        <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
+        <returns type="guint" comment="The hours."/>
         <comment xml:space="preserve">Gets the hours of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
-	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->hours;</custom>
+	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;hours;</custom>
     </method>
     <method name="i_cal_duration_set_hours" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="hours" comment="The hours"/>
         <comment>Sets the hours of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
-	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->hours = hours;</custom>
+	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;hours = hours;</custom>
     </method>
     <method name="i_cal_duration_get_minutes" corresponds="none" kind="get" since="1.0">
-	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
-        <returns type="guint" comment="The minutes." />
+        <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
+        <returns type="guint" comment="The minutes."/>
         <comment xml:space="preserve">Gets the minutes of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
-	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->minutes;</custom>
+	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;minutes;</custom>
     </method>
     <method name="i_cal_duration_set_minutes" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="minutes" comment="The minutes"/>
         <comment>Sets the minutes of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
-	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->minutes = minutes;</custom>
+	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;minutes = minutes;</custom>
     </method>
     <method name="i_cal_duration_get_seconds" corresponds="none" kind="get" since="1.0">
-	<parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
-        <returns type="guint" comment="The seconds." />
+        <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be queried"/>
+        <returns type="guint" comment="The seconds."/>
         <comment xml:space="preserve">Gets the seconds of #ICalDuration.</comment>
         <custom>	g_return_val_if_fail (duration != NULL, 0);
-	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->seconds;</custom>
+	return ((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;seconds;</custom>
     </method>
     <method name="i_cal_duration_set_seconds" corresponds="none" kind="set" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be set"/>
         <parameter type="guint" name="seconds" comment="The seconds"/>
         <comment>Sets the seconds of #ICalDuration.</comment>
         <custom>	g_return_if_fail (duration != NULL &amp;&amp; I_CAL_IS_DURATION (duration));
-	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))->seconds = seconds;</custom>
+	((struct icaldurationtype *)i_cal_object_get_native ((ICalObject *)duration))-&gt;seconds = seconds;</custom>
     </method>
     <method name="i_cal_duration_new_from_seconds" corresponds="icaldurationtype_from_seconds" kind="constructor" since="4.0">
         <parameter type="gint" name="t" comment="The duration in second"/>
-        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration" />
+        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration"/>
         <comment xml:space="preserve">Creates a #ICalDuration from the duration in second.</comment>
     </method>
     <method name="i_cal_duration_new_from_string" corresponds="icaldurationtype_from_string" kind="constructor" since="1.0">
         <parameter type="const gchar *" name="str" comment="The string representation of the duration"/>
-        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration" />
+        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration"/>
         <comment xml:space="preserve">Creates a #ICalDuration from the duration in string.</comment>
     </method>
     <method name="i_cal_duration_as_seconds" corresponds="icaldurationtype_as_seconds" kind="others" since="4.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be converted"/>
-        <returns type="gint" comment="The duration in second" />
+        <returns type="gint" comment="The duration in second"/>
         <comment xml:space="preserve">Extracts the duration in seconds from an #ICalDuration. Does not consider negative durations.</comment>
     </method>
     <method name="i_cal_duration_as_ical_string" corresponds="icaldurationtype_as_ical_string_r" kind="others" since="1.0">
@@ -111,21 +112,33 @@
         <comment xml:space="preserve">Converts the #ICalDuration to the representation in string</comment>
     </method>
     <method name="i_cal_duration_new_null_duration" corresponds="icaldurationtype_null_duration" kind="constructor" since="1.0">
-        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration" />
+        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration"/>
         <comment xml:space="preserve">Creates a #ICalDuration with all the fields to be zero.</comment>
     </method>
     <method name="i_cal_duration_new_bad_duration" corresponds="icaldurationtype_bad_duration" kind="constructor" since="1.0">
-        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration" />
+        <returns type="ICalDuration *" annotation="transfer full" comment="The newly created #ICalDuration"/>
         <comment xml:space="preserve">Creates a bad #ICalDuration.</comment>
     </method>
     <method name="i_cal_duration_is_null_duration" corresponds="icaldurationtype_is_null_duration" kind="others" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be checked"/>
-        <returns type="gboolean" comment="true if @duration is the null_duration, false if not." />
+        <returns type="gboolean" comment="true if @duration is the null_duration, false if not."/>
         <comment xml:space="preserve">Checks whether the #ICalDuration is the null_duration.</comment>
     </method>
     <method name="i_cal_duration_is_bad_duration" corresponds="icaldurationtype_is_bad_duration" kind="others" since="1.0">
         <parameter type="ICalDuration *" name="duration" comment="The #ICalDuration to be checked"/>
-        <returns type="gboolean" comment="true if @duration is the bad_duration, false if not." />
+        <returns type="gboolean" comment="true if @duration is the bad_duration, false if not."/>
         <comment xml:space="preserve">Checks whether the #ICalDuration is the bad_duration.</comment>
+    </method>
+    <method name="i_cal_duration_extend" corresponds="icalduration_extend" kind="other" since="4.0">
+        <parameter type="ICalTime *" name="t" comment="A #ICalTime to be operated on"/>
+        <parameter type="ICalDuration *" name="d" comment="A #ICalDuration as the difference"/>
+        <returns type="ICalTime *" annotation="transfer full" comment="The #ICalTime results. The native object is the same. But since it is a bare object, so it won't cause segmentation."/>
+        <comment xml:space="preserve">Extends a time duration.</comment>
+    </method>
+    <method name="i_cal_duration_from_times" corresponds="icalduration_from_times" kind="other" since="4.0">
+        <parameter type="ICalTime *" name="t1" comment="The subtracted #ICalTime"/>
+        <parameter type="ICalTime *" name="t2" comment="The subtracting #ICalTime"/>
+        <returns type="ICalDuration *" annotation="transfer full" comment="The #ICalDuration between two #ICalTime."/>
+        <comment xml:space="preserve">Creates a duration between two time endpoints.</comment>
     </method>
 </structure>

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -232,18 +232,6 @@
         <returns type="gint" comment="Whether one #ICalTimeSpan is contained in another #ICalTimeSpan."/>
         <comment xml:space="preserve">Checks whether one #ICalTimeSpan is contained in another #ICalTimeSpan.</comment>
     </method>
-    <method name="i_cal_time_add" corresponds="icaltime_add" kind="other" since="2.0">
-        <parameter type="ICalTime *" name="t" comment="A #ICalTime to be operated on"/>
-        <parameter type="ICalDuration *" name="d" comment="A #ICalDuration as the difference"/>
-        <returns type="ICalTime *" annotation="transfer full" comment="The #ICalTime results. The native object is the same. But since it is a bare object, so it won't cause segmentation."/>
-        <comment xml:space="preserve">Adds a time duration on the time.</comment>
-    </method>
-    <method name="i_cal_time_subtract" corresponds="icaltime_subtract" kind="other" since="2.0">
-        <parameter type="ICalTime *" name="t1" comment="The subtracted #ICalTime"/>
-        <parameter type="ICalTime *" name="t2" comment="The subtracting #ICalTime"/>
-        <returns type="ICalDuration *" annotation="transfer full" comment="The #ICalDuration between two #ICalTime."/>
-        <comment xml:space="preserve">Gets the duration between two time.</comment>
-	</method>
     <method name="i_cal_time_get_year" corresponds="none" kind="get" since="1.0">
         <parameter type="const ICalTime *" name="timetype" comment="The #ICalTime to be queried"/>
         <returns type="gint" comment="The year."/>

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -865,7 +865,7 @@ static icaltime_span icaltime_span_from_time(const struct icaltimetype t, const 
                                     t.zone ? t.zone : icaltimezone_get_utc_timezone());
     ret.end =
         icaltime_as_timet_with_zone(
-            icaltime_add(t, d),
+            icalduration_extend(t, d),
             t.zone ? t.zone : icaltimezone_get_utc_timezone());
     return ret;
 }
@@ -898,7 +898,7 @@ static icaltime_span icaltime_span_from_datetimeperiod(const struct icaldatetime
 
     if (!icaldurationtype_is_null_duration(dur)) {
         ret.end = icaltime_as_timet_with_zone(
-            icaltime_add(start, dur),
+            icalduration_extend(start, dur),
             start.zone ? start.zone : icaltimezone_get_utc_timezone());
     }
     return ret;
@@ -1021,7 +1021,7 @@ void icalcomponent_foreach_recurrence(icalcomponent *comp,
                     /* make sure we include any recurrence that ends in timespan */
                     /* duration should be positive */
                     dtduration.is_neg = 1;
-                    mystart = icaltime_add(mystart, dtduration);
+                    mystart = icalduration_extend(mystart, dtduration);
                     dtduration.is_neg = 0;
 
                     icalrecur_iterator_set_start(rrule_itr, mystart);
@@ -1580,14 +1580,14 @@ struct icaltimetype icalcomponent_get_dtend(icalcomponent *comp)
             duration = icaldurationtype_null_duration();
         }
 
-        ret = icaltime_add(start, duration);
+        ret = icalduration_extend(start, duration);
     } else if (end_prop == 0 && dur_prop == 0) {
         if (kind == ICAL_VEVENT_COMPONENT) {
             struct icaltimetype start = icalcomponent_get_dtstart(inner);
             if (icaltime_is_date(start)) {
                 struct icaldurationtype duration = icaldurationtype_null_duration();
                 duration.days = 1;
-                ret = icaltime_add(start, duration);
+                ret = icalduration_extend(start, duration);
             } else {
                 ret = start;
             }
@@ -1676,7 +1676,7 @@ struct icaldurationtype icalcomponent_get_duration(icalcomponent *comp)
         struct icaltimetype start = icalcomponent_get_dtstart(inner);
         struct icaltimetype end = icalproperty_get_datetime_with_component(end_prop, comp);
 
-        ret = icaltime_subtract(end, start);
+        ret = icalduration_from_times(end, start);
     } else if (end_prop == 0 && dur_prop == 0) {
         struct icaltimetype start = icalcomponent_get_dtstart(inner);
         ret = icaldurationtype_null_duration();
@@ -2599,7 +2599,7 @@ struct icaltimetype icalcomponent_get_due(icalcomponent *comp)
         struct icaltimetype start = icalcomponent_get_dtstart(inner);
         struct icaldurationtype duration = icalproperty_get_duration(dur_prop);
 
-        struct icaltimetype due = icaltime_add(start, duration);
+        struct icaltimetype due = icalduration_extend(start, duration);
 
         return due;
     }
@@ -2627,7 +2627,7 @@ void icalcomponent_set_due(icalcomponent *comp, struct icaltimetype v)
 
         struct icaltimetype due = icalcomponent_get_due(inner);
 
-        struct icaldurationtype dur = icaltime_subtract(due, start);
+        struct icaldurationtype dur = icalduration_from_times(due, start);
 
         icalproperty_set_duration(dur_prop, dur);
     }

--- a/src/libical/icalduration.c
+++ b/src/libical/icalduration.c
@@ -279,7 +279,7 @@ bool icaldurationtype_is_bad_duration(struct icaldurationtype d)
     return (d.is_neg == -1);
 }
 
-struct icaltimetype icaltime_add(struct icaltimetype t, struct icaldurationtype d)
+struct icaltimetype icalduration_extend(struct icaltimetype t, struct icaldurationtype d)
 {
     struct icaltimetype t_days;
     if (t.is_date &&
@@ -327,7 +327,7 @@ struct icaltimetype icaltime_add(struct icaltimetype t, struct icaldurationtype 
     return t;
 }
 
-struct icaldurationtype icaltime_subtract(struct icaltimetype t1, struct icaltimetype t2)
+struct icaldurationtype icalduration_from_times(struct icaltimetype t1, struct icaltimetype t2)
 {
     if ((!t1.is_date && t2.is_date) ||
         (t1.is_date && !t2.is_date)) {

--- a/src/libical/icalduration.h
+++ b/src/libical/icalduration.h
@@ -235,7 +235,7 @@ LIBICAL_ICAL_EXPORT bool icaldurationtype_is_null_duration(struct icaldurationty
 LIBICAL_ICAL_EXPORT bool icaldurationtype_is_bad_duration(struct icaldurationtype d);
 
 /**
- * @brief Adds a duration to an icaltime object and returns the result.
+ * @brief Extends a time duration.
  * @param t The time object to add the duration to
  * @param d The duration to add to the time object
  * @return The new ::icaltimetype which has been added the duration to
@@ -250,17 +250,17 @@ LIBICAL_ICAL_EXPORT bool icaldurationtype_is_bad_duration(struct icaldurationtyp
  * duration = icaldurationtype_from_seconds(60);
  *
  * // add the duration to the time object
- * time = icaltime_add(time, duration);
+ * time = icalduration_extend(time, duration);
  * ```
  */
-LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_add(struct icaltimetype t,
-                                                     struct icaldurationtype d);
+LIBICAL_ICAL_EXPORT struct icaltimetype icalduration_extend(struct icaltimetype t,
+                                                            struct icaldurationtype d);
 
 /**
- * @brief Returns the difference between two ::icaltimetype as a duration.
+ * @brief Creates a duration from two ::icaltimetype endpoints.
  * @param t1 The first point in time
  * @param t2 The second point in time
- * @return An ::icaldurationtype representing the duration the elapsed between
+ * @return An ::icaldurationtype representing the duration elapsed between
  * @a t1 and @a t2
  *
  * @par Usage
@@ -270,10 +270,10 @@ LIBICAL_ICAL_EXPORT struct icaltimetype icaltime_add(struct icaltimetype t,
  * struct icaldurationtype duration;
  *
  * // calculate duration between time points
- * duration = icaltime_subtract(t1, t2);
+ * duration = icalduration_from_times(t1, t2);
  * ```
  */
-LIBICAL_ICAL_EXPORT struct icaldurationtype icaltime_subtract(struct icaltimetype t1,
-                                                              struct icaltimetype t2);
+LIBICAL_ICAL_EXPORT struct icaldurationtype icalduration_from_times(struct icaltimetype t1,
+                                                                    struct icaltimetype t2);
 
 #endif /* !ICALDURATION_H */

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -755,13 +755,6 @@ int icaltime_compare_date_only_tz(const struct icaltimetype a_in,
     return 0;
 }
 
-/* These are defined in icalduration.c:
-struct icaltimetype  icaltime_add(struct icaltimetype t,
-                                  struct icaldurationtype  d)
-struct icaldurationtype  icaltime_subtract(struct icaltimetype t1,
-                                           struct icaltimetype t2)
-*/
-
 void icaltime_adjust(struct icaltimetype *tt,
                      const int days, const int hours,
                      const int minutes, const int seconds)

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -927,8 +927,8 @@ icalrequeststatus VAlarm::getTriggerTime(VComponent &c, struct icaltriggertype *
                         // dtend from the dtstart.
                         struct icaltimetype recur_time = c.get_recurrenceid();
                         if (icaltime_is_null_time(recur_time) != 1) {
-                            struct icaldurationtype dur = icaltime_subtract(c.get_dtstart(), tt);
-                            tt = icaltime_add(recur_time, dur);
+                            struct icaldurationtype dur = icalduration_from_times(c.get_dtstart(), tt);
+                            tt = icalduration_extend(recur_time, dur);
                         }
                     } else if (c.isa() == ICAL_VTODO_COMPONENT) {
                         tt = c.get_due();
@@ -974,7 +974,7 @@ icalrequeststatus VAlarm::getTriggerTime(VComponent &c, struct icaltriggertype *
         };
 
         // now offset using tr.duration
-        tr->time = icaltime_add(tt, tr->duration);
+        tr->time = icalduration_extend(tt, tr->duration);
     }
     // else absolute time trigger
 


### PR DESCRIPTION
Rename icaltime_add() => icalduration_extend
Rename icaltime_subtract() => icalduration_from_times

fixes: #1055