### PR TITLE
src/test/CMakeLists.txt - use buildme() instead of testme()

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -302,8 +302,8 @@ endif()
 
 ########### next target ###############
 
-testme(icalcomponent_fuzz1 icalcomponent_fuzz1.c)
-testme(icalcomponent_fuzz2 icalcomponent_fuzz2.c)
+buildme(icalcomponent_fuzz1 icalcomponent_fuzz1.c)
+buildme(icalcomponent_fuzz2 icalcomponent_fuzz2.c)
 
 testme(icaltime_fuzz icaltime_fuzz.c)
 testme(icalcomponent_timefuzz icalcomponent_timefuzz.c)


### PR DESCRIPTION
For icalcomponent_fuzz1 and icalcomponent_fuzz2 we only want to build them, and then later the tests are created using testme() for the various fuzzer files.