### PR TITLE
Buildsystem - print message and error from CMake for removed options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,11 @@ set(PROJECT_VERSION "4.0")
 # library build types
 set(LIBRARY_TYPE SHARED)
 
+# Print message and error exit for these options that are no longer supported
+libical_removed_option(ICAL_ALLOW_EMPTY_PROPERTIES)
+libical_removed_option(ICAL_ERRORS_ARE_FATAL)
 ########################################################
+
 libical_option(LIBICAL_DEVMODE "Developer mode" False)
 if(LIBICAL_DEVMODE)
   # generate compile_commands.json

--- a/cmake/modules/LibIcalMacrosInternal.cmake
+++ b/cmake/modules/LibIcalMacrosInternal.cmake
@@ -17,6 +17,19 @@ function(libical_option option description)
   )
 endfunction()
 
+# Warn and exit if old cmake options are encountered
+function(libical_removed_option option)
+  if(DEFINED ${option})
+    if(${PROJECT_VERSION} VERSION_LESS "4.1.0")
+      message(
+        FATAL_ERROR
+        "The CMake option ${option} has been removed. "
+        "Please refer to docs/MigrationGuide_to_4.md for more information."
+      )
+    endif()
+  endif()
+endfunction()
+
 # Warn about deprecated cmake options then call libical_option
 function(libical_deprecated_option deprecated_option option description)
   set(extra_option_arguments ${ARGN})


### PR DESCRIPTION
If a removed CMake option is encountered, print a message to notify the user about it and fatal exit cmake.