### PR TITLE
Fix install ical_jni library destination

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -130,7 +130,7 @@ if(LIBICAL_BUILD_TESTING)
   endif()
 endif()
 
-install(TARGETS ical_jni EXPORT icalTargets DESTINATION lib)
+install(TARGETS ical_jni EXPORT icalTargets DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})
 
 ########### install files ###############
 


### PR DESCRIPTION
Install the libical_jni library alongside all the other libraries. i.e if LIBRARY_INSTALL_DIR is set to something other than "lib"