### PR TITLE
ical_file.cmake - print "#error" blocks into ical.h for old macros

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,4 +1,4 @@
-definitions: [./cmake,./src/test,./docs]
+definitions: [./cmake,./src/libical/,./src/test,./docs]
 indent: 2
 line_length: 120
 list_expansion: favour-expansion

--- a/src/libical/ical_file.cmake
+++ b/src/libical/ical_file.cmake
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: Allen Winter <winter@kde.org>
 # SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 
+# Write a "#error" block if the user has defined a macro that is no longer supported
+function(libical_removed_macros option)
+  file(APPEND ${ICAL_FILE_H_FILE} "#if defined(${option})\n")
+  file(APPEND ${ICAL_FILE_H_FILE} "#error You are specifying the ${option} macro which is no longer supported\n")
+  file(APPEND ${ICAL_FILE_H_FILE} "#endif\n")
+endfunction()
+
 # ORDERING OF HEADERS IS SIGNIFICANT. Don't change this ordering.
 # It is required to make the combined header ical.h properly.
 set(
@@ -38,6 +45,11 @@ file(APPEND ${ICAL_FILE_H_FILE} "#ifndef S_SPLINT_S\n")
 file(APPEND ${ICAL_FILE_H_FILE} "#ifdef __cplusplus\n")
 file(APPEND ${ICAL_FILE_H_FILE} "extern \"C\" {\n")
 file(APPEND ${ICAL_FILE_H_FILE} "#endif\n")
+
+libical_removed_macros(ICAL_ENABLE_ERRORS_ARE_FATAL)
+libical_removed_macros(ICAL_ALLOW_EMPTY_PROPERTIES)
+libical_removed_macros(PVL_USE_MACROS)
+libical_removed_macros(ICAL_SETERROR_ISFUNC)
 
 foreach(_current_FILE ${COMBINEDHEADERSICAL})
   file(STRINGS ${_current_FILE} _lines NEWLINE_CONSUME)


### PR DESCRIPTION
Write a "#error" block into ical.h if the user defined a macro that is no longer supported.