### PR TITLE
icalduration.c - sscanf can also return EOF

### DIFF
--- a/src/libical/icalduration.c
+++ b/src/libical/icalduration.c
@@ -102,7 +102,7 @@ struct icaldurationtype icaldurationtype_from_string(const char *str)
             /* Get all of the digits, not one at a time */
             scan_size = sscanf(&str[i], "%10d", &digits); /*limit to 10digits.
                                                                   increase as needed */
-            if (scan_size == 0) {
+            if (scan_size != 1) {
                 goto error;
             }
             break;


### PR DESCRIPTION
Handle the condition that sscanf can also return EOF by testing that the number of items processed is 1; else there was a failure.