### PR TITLE
cppcheck unsuppress cstyleCast

### DIFF
--- a/cppcheck-suppressions.xml
+++ b/cppcheck-suppressions.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions>
   <suppress>
-    <id>cstyleCast</id>
-  </suppress>
-  <suppress>
     <id>unusedStructMember</id>
   </suppress>
 </suppressions>

--- a/src/test/vcf_leak.cpp
+++ b/src/test/vcf_leak.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     }
 
     using vcardptr = std::unique_ptr<VObject, decltype(&cleanVObject)>;
-    const vcardptr ptr(Parse_MIME((char *)content.c_str(), static_cast<unsigned long>(content.size())), cleanVObject);
+    const vcardptr ptr(Parse_MIME(static_cast<const char *>(content.c_str()), static_cast<unsigned long>(content.size())), cleanVObject);
 
     return 0;
 }


### PR DESCRIPTION
note that src/java has many cstyleCasts in its *.cpp files but we aren't dealing with the java bindings at this time.