### PR TITLE
src/libical-glib/CMakeLists.txt - Require C99, not C11

### DIFF
--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -7,10 +7,6 @@ endif()
 
 add_definitions(-Dlibical_ical_EXPORTS)
 
-# a C11 compliant compiler is required to build this library
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-
 # build ical-glib-src-generator
 add_executable(
   ical-glib-src-generator

--- a/src/libical-glib/tools/header-header-template
+++ b/src/libical-glib/tools/header-header-template
@@ -13,7 +13,6 @@
 
 #define __LIBICAL_GLIB_H_INSIDE__
 
-#include <libical-glib/i-cal-forward-declarations.h>
 ${allHeaders}
 #undef __LIBICAL_GLIB_H_INSIDE__
 

--- a/src/libical-glib/tools/header-structure-boilerplate-template
+++ b/src/libical-glib/tools/header-structure-boilerplate-template
@@ -1,6 +1,6 @@
 
-#define ${namespaceLowerSnake}_TYPE_${nameLowerSnake} \
-    (${lowerSnake}_get_type ())
+#define ${namespaceLowerSnake}_TYPE_${nameLowerSnake} (${lowerSnake}_get_type ())
+
 LIBICAL_ICAL_EXPORT
 G_DECLARE_DERIVABLE_TYPE(${upperCamel}, ${lowerSnake}, ${namespaceLowerSnake}, ${nameLowerSnake}, ICalObject)
 


### PR DESCRIPTION
This is C and not C++.
We require the C99 standard for C code.

(found while running clang-tidy which was confusing generator.c as C++ source code. because that's what compile-commands.json said)