### PR TITLE
clang-tidy fixes bugprone-suspicious-string-compare

### DIFF
--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -97,7 +97,7 @@ void icalstrarray_remove(icalstrarray *array, const char *del)
 
     for (size_t i = 0; i < array->num_elements; i++) {
         char **elem = icalarray_element_at(array, i);
-        if (strcmp(*elem, del)) {
+        if (strcmp(*elem, del) != 0) {
             icalarray_set_element_at(array, elem, j++);
         } else {
             icalmemory_free_buffer(*elem);

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -1499,7 +1499,7 @@ icaltimezone *icaltimezone_get_builtin_timezone_from_tzid(const char *tzid)
 
     tzid_prefix = icaltimezone_tzid_prefix();
     /* Check that the TZID starts with our unique prefix. */
-    if (strncmp(tzid, tzid_prefix, strlen(tzid_prefix))) {
+    if (strncmp(tzid, tzid_prefix, strlen(tzid_prefix)) != 0) {
         int ii;
 
         for (ii = 0; glob_compat_tzids[ii].tzid; ii++) {

--- a/src/libical/icaltimezone_p.c
+++ b/src/libical/icaltimezone_p.c
@@ -456,7 +456,7 @@ icalcomponent *icaltimezone_fetch_timezone(const char *location)
 
     /* read version 1 header */
     EFREAD(&header, 44, 1, f);
-    if (memcmp(header.magic, "TZif", 4)) {
+    if (memcmp(header.magic, "TZif", 4) != 0) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
         goto error;
     }
@@ -493,7 +493,7 @@ icalcomponent *icaltimezone_fetch_timezone(const char *location)
 
         /* read version 2+ header */
         EFREAD(&header, 44, 1, f);
-        if (memcmp(header.magic, "TZif", 4)) {
+        if (memcmp(header.magic, "TZif", 4) != 0) {
             icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
             goto error;
         }
@@ -756,7 +756,7 @@ icalcomponent *icaltimezone_fetch_timezone(const char *location)
             if (types[prev_idx].gmtoff != zone->gmtoff_from ||
                 types[idx].gmtoff != zone->gmtoff_to ||
                 (types[idx].zname != NULL &&
-                 strcmp(types[idx].zname, zone->name))) {
+                 strcmp(types[idx].zname, zone->name) != 0)) {
                 zone->rdate_comp = NULL;
                 terminate = 1;
             }

--- a/src/test/icalrecur_test.c
+++ b/src/test/icalrecur_test.c
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
                 }
             }
 
-            if (strcmp(instances, actual_instances)) {
+            if (strcmp(instances, actual_instances) != 0) {
                 nof_errors++;
                 test_error = 1;
 
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
                     sep = ",";
                 }
 
-                if (strcmp(instances, actual_instances)) {
+                if (strcmp(instances, actual_instances) != 0) {
                     nof_errors++;
 
                     if (!test_error) {


### PR DESCRIPTION
Fixes, for example:
```
function 'memcmp' is called without explicitly comparing result
function 'strcmp' is called without explicitly comparing result
```