### PR TITLE
clang-tidy fixes readability-braces-around-statements

### DIFF
--- a/src/libical-glib/tools/generator.c
+++ b/src/libical-glib/tools/generator.c
@@ -1868,8 +1868,9 @@ gchar *get_true_type(const gchar *type)
     type_len = (guint)strlen(type);
     end = type_len - 1;
 
-    for (i = 0; i < const_prefix_len && i < type_len && const_prefix[i] == type[i]; i++)
+    for (i = 0; i < const_prefix_len && i < type_len && const_prefix[i] == type[i]; i++) {
         ;
+    }
 
     if (i == const_prefix_len) {
         start = i + 1;
@@ -2063,8 +2064,9 @@ gchar *get_source_run_time_checkers(Method *method, const gchar *nameSpace)
             }
             for (i = 0;
                  i < nameSpace_len && trueType[i] && nameSpace[i] == trueType[i];
-                 i++)
+                 i++) {
                 ;
+            }
 
             if (i == nameSpace_len) {
                 (void)g_stpcpy(buffer + strlen(buffer), "\t");

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -2673,8 +2673,9 @@ void test_fblist(void)
 
     foo = icalspanlist_as_freebusy_matrix(sl, 3600);
 
-    for (i = 0; foo[i] != -1; i++)
+    for (i = 0; foo[i] != -1; i++) {
         ; /* find number entries */
+    }
 
     int_is("Calculating freebusy hourly matrix", i, (7 * 24));
 


### PR DESCRIPTION
Fixes:
```
statement should be inside braces
```

don't care about for loops with an empty body