### PR TITLE
clang-tidy fixes bugprone-switch-missing-default-case

### DIFF
--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -511,6 +511,8 @@ void icalparameter_decode_value(char *value)
                 *out = '"';
                 found_escaped_char = 1;
                 break;
+            default:
+                break;
             }
         }
 

--- a/src/libicalvcal/icalvcal.c
+++ b/src/libicalvcal/icalvcal.c
@@ -93,6 +93,9 @@ static const char *get_string_value(VObject *object, int *free_string)
     case VCVT_STRINGZ:
         *free_string = 0;
         return (char *)vObjectStringZValue(object);
+
+    default:
+        break;
     }
 
     *free_string = 0;

--- a/src/libicalvcard/vcardparser.c
+++ b/src/libicalvcard/vcardparser.c
@@ -1049,12 +1049,16 @@ const char *vcardparser_errstr(int err)
         return "End of data while parsing quoted value";
     case PE_QSTRING_EOL:
         return "End of line while parsing quoted value";
+    case PE_QSTRING_EOV:
+        return "End of line while parsing multi or structured value";
     case PE_VALUE_INVALID:
         return "Invalid value for property";
     case PE_ILLEGAL_CHAR:
         return "Illegal character in vCard";
+    case PE_NUMERR:
+    default:
+        return "Unknown error";
     }
-    return "Unknown error";
 }
 
 vcardcomponent *vcardparser_parse_string(const char *str)

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6873,7 +6873,6 @@ int main(int argc, char *argv[])
     extern int optopt;
 #endif
 #if defined(HAVE_GETOPT)
-    int errflg = 0;
     int c;
 #endif
     int do_test = 0;
@@ -6911,15 +6910,11 @@ int main(int argc, char *argv[])
             do_header = 1;
             break;
         }
-        case '?': {
-            errflg++;
+        default: { /* '?' */
+            fprintf(stderr, "Usage: %s [-v|-q|-l]\n", strrchr(argv[0], '/'));
+            exit(1);
         }
         }
-    }
-
-    if (errflg > 0) {
-        fprintf(stderr, "Usage: %s [-v|-q|-l]\n", strrchr(argv[0], '/'));
-        exit(1);
     }
 
     if (optind < argc) {


### PR DESCRIPTION
Fixes:
```
switching on non-enum value without default case may not cover all cases
```