### PR TITLE
libical-glib: Fix typedef redefinition

### DIFF
--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -7,10 +7,6 @@ endif()
 
 add_definitions(-Dlibical_ical_EXPORTS)
 
-# a C11 compliant compiler is required to build this library
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-
 # build ical-glib-src-generator
 add_executable(
   ical-glib-src-generator

--- a/src/libical-glib/i-cal-object.h.in
+++ b/src/libical-glib/i-cal-object.h.in
@@ -28,6 +28,30 @@
 LIBICAL_ICAL_EXPORT
 G_DECLARE_DERIVABLE_TYPE(ICalObject, i_cal_object, I_CAL, OBJECT, GObject)
 
+/* it's the same as G_DECLARE_DERIVABLE_TYPE() (as of glib 2.82), only without
+   typedef for the ModuleObjName, because it's in the i-cal-forward-declarations.h */
+#define I_CAL_GLIB_DECLARE_DERIVABLE_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName) \
+  GType module_obj_name##_get_type (void);                                                               \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                       \
+  /*typedef struct _##ModuleObjName ModuleObjName;*/                                                     \
+  typedef struct _##ModuleObjName##Class ModuleObjName##Class;                                           \
+  struct _##ModuleObjName { ParentName parent_instance; };                                               \
+                                                                                                         \
+  _GLIB_DEFINE_AUTOPTR_CHAINUP (ModuleObjName, ParentName)                                               \
+  G_DEFINE_AUTOPTR_CLEANUP_FUNC (ModuleObjName##Class, g_type_class_unref)                               \
+                                                                                                         \
+  G_GNUC_UNUSED static inline ModuleObjName * MODULE##_##OBJ_NAME (gpointer ptr) {                       \
+    return G_TYPE_CHECK_INSTANCE_CAST (ptr, module_obj_name##_get_type (), ModuleObjName); }             \
+  G_GNUC_UNUSED static inline ModuleObjName##Class * MODULE##_##OBJ_NAME##_CLASS (gpointer ptr) {        \
+    return G_TYPE_CHECK_CLASS_CAST (ptr, module_obj_name##_get_type (), ModuleObjName##Class); }         \
+  G_GNUC_UNUSED static inline gboolean MODULE##_IS_##OBJ_NAME (gpointer ptr) {                           \
+    return G_TYPE_CHECK_INSTANCE_TYPE (ptr, module_obj_name##_get_type ()); }                            \
+  G_GNUC_UNUSED static inline gboolean MODULE##_IS_##OBJ_NAME##_CLASS (gpointer ptr) {                   \
+    return G_TYPE_CHECK_CLASS_TYPE (ptr, module_obj_name##_get_type ()); }                               \
+  G_GNUC_UNUSED static inline ModuleObjName##Class * MODULE##_##OBJ_NAME##_GET_CLASS (gpointer ptr) {    \
+    return G_TYPE_INSTANCE_GET_CLASS (ptr, module_obj_name##_get_type (), ModuleObjName##Class); }       \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+
 G_BEGIN_DECLS
 /**
  * ICalObject:

--- a/src/libical-glib/tools/header-structure-boilerplate-template
+++ b/src/libical-glib/tools/header-structure-boilerplate-template
@@ -2,7 +2,7 @@
 #define ${namespaceLowerSnake}_TYPE_${nameLowerSnake} \
     (${lowerSnake}_get_type ())
 LIBICAL_ICAL_EXPORT
-G_DECLARE_DERIVABLE_TYPE(${upperCamel}, ${lowerSnake}, ${namespaceLowerSnake}, ${nameLowerSnake}, ICalObject)
+I_CAL_GLIB_DECLARE_DERIVABLE_TYPE(${upperCamel}, ${lowerSnake}, ${namespaceLowerSnake}, ${nameLowerSnake}, ICalObject)
 
 /**
  * ${upperCamel}:


### PR DESCRIPTION
The i-cal-forward-declarations.h and the respective object file both had "typedef struct _ObjName ObjName;" which is not allowed before C standard 11. Rather than depend on it, inline the glib macro without the offending typedef, allowing to have it split in a common header.

Closes https://github.com/libical/libical/issues/1096