### PR TITLE
icalvalue_compare() - return ICAL_XLICCOMPARETYPE_NONE on failure

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -120,6 +120,9 @@ The icalerror unit always compiles the `icalerror_set_errno` function.
 * The `icaltzutil_set_zone_directory()` and `icaltzutil_get_zone_directory()` functions are now called
   `icaltimezone_set_system_zone_directory()` and `icaltimezone_get_system_zone_directory()` respectively.
 
+* In previous versions, the `icalvalue_compare()` function returned 0 if unknown or null value types
+  were encountered; in this version, ICAL_XLICCOMPARETYPE_NONE is returned instead.
+
 ### New functions
 
 The following functions have been added:

--- a/src/libical-glib/api/i-cal-value.xml
+++ b/src/libical-glib/api/i-cal-value.xml
@@ -51,7 +51,7 @@
     <parameter type="const ICalValue *" name="a" comment="A #ICalValue"/>
     <parameter type="const ICalValue *" name="b" comment="A #ICalValue"/>
     <returns type="ICalParameterXliccomparetype" comment="The compare result."/>
-    <comment xml:space="preserve">Compares two #ICalValue.</comment>
+    <comment xml:space="preserve">Compares two #ICalValue. If the values do not have the same type ICAL_XLICCOMPARETYPE_NOTEQUAL is returned. ICAL_XLICCOMPARETYPE_NONE is returned if the values type is unknown or one of the values is null.</comment>
   </method>
   <method name="i_cal_value_kind_from_string" corresponds="icalvalue_string_to_kind" since="1.0">
     <parameter type="const gchar *" name="str" comment="A string"/>

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -1329,15 +1329,10 @@ static bool icalvalue_is_time(const icalvalue *a)
     return false;
 }
 
-/*
- * In case of error, this function returns 0. This is partly bogus, as 0 is
- * not part of the returned enum.
- * FIXME We should probably add an error value to the enum.
- */
 icalparameter_xliccomparetype icalvalue_compare(const icalvalue *a, const icalvalue *b)
 {
-    icalerror_check_arg_rz((a != 0), "a");
-    icalerror_check_arg_rz((b != 0), "b");
+    icalerror_check_arg_rx((a != 0), "a", ICAL_XLICCOMPARETYPE_NONE);
+    icalerror_check_arg_rx((b != 0), "b", ICAL_XLICCOMPARETYPE_NONE);
 
     /* Not the same type; they can only be unequal */
     if (!(icalvalue_is_time(a) && icalvalue_is_time(b)) && icalvalue_isa(a) != icalvalue_isa(b)) {
@@ -1504,7 +1499,7 @@ icalparameter_xliccomparetype icalvalue_compare(const icalvalue *a, const icalva
     case ICAL_NO_VALUE:
     default: {
         icalerror_warn("Comparison not implemented for value type");
-        return 0;
+        return ICAL_XLICCOMPARETYPE_NONE;
     }
     }
 }

--- a/src/libical/icalvalue.h
+++ b/src/libical/icalvalue.h
@@ -42,6 +42,16 @@ LIBICAL_ICAL_EXPORT icalvalue_kind icalvalue_isa(const icalvalue *value);
 
 LIBICAL_ICAL_EXPORT bool icalvalue_isa_value(void *);
 
+/**
+ * Compares two icalvalues.
+ *
+ * @param a an icalvalue to compare
+ * @param b an icalvalue to compare
+ *
+ * @return an icalparameter_xliccomparetype representing how @p a and @p b compare;
+ * if the values do not have the same type ICAL_XLICCOMPARETYPE_NOTEQUAL is returned;
+ * ICAL_XLICCOMPARETYPE_NONE is returned if the values type is unknown or one of the values is null.
+ */
 LIBICAL_ICAL_EXPORT icalparameter_xliccomparetype icalvalue_compare(const icalvalue *a,
                                                                     const icalvalue *b);
 

--- a/src/libicalss/icalgauge.c
+++ b/src/libicalss/icalgauge.c
@@ -196,7 +196,9 @@ int icalgauge_compare_recurse(icalcomponent *comp, icalcomponent *gauge)
             /* Now see if the comparison is equivalent to the comparison
                specified in the gauge */
 
-            if (rel == compare) {
+            if (rel == ICAL_XLICCOMPARETYPE_NONE || compare == ICAL_XLICCOMPARETYPE_NONE) {
+                localpass = 0;
+            } else if (rel == compare) {
                 localpass++;
             } else if (compare == ICAL_XLICCOMPARETYPE_LESSEQUAL &&
                        (rel == ICAL_XLICCOMPARETYPE_LESS || rel == ICAL_XLICCOMPARETYPE_EQUAL)) {


### PR DESCRIPTION
Instead of returning 0 (not a legit icalparameter_xliccomparetype) return ICAL_XLICCOMPARETYPE_NONE if a failure (unknown value type) is encountered.