### PR TITLE
icalcomponent_get_status() - return ICAL_STATUS_NONE on failure

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -129,6 +129,9 @@ The icalerror unit always compiles the `icalerror_set_errno` function.
 * In previous versions, the `icalvalue_compare()` function returned 0 if unknown or null value types
   were encountered; in this version, ICAL_XLICCOMPARETYPE_NONE is returned instead.
 
+* In previous versions, the `icalcomponent_get_status()` returned 0 if a problem parsing the status property
+  was detected; in this version, ICAL_STATUS_NONE is returned instead.
+
 ### New functions
 
 The following functions have been added:

--- a/src/libical-glib/api/i-cal-component.xml
+++ b/src/libical-glib/api/i-cal-component.xml
@@ -507,7 +507,7 @@
   <method name="i_cal_component_get_status" corresponds="icalcomponent_get_status" kind="get" since="1.0">
     <parameter type="ICalComponent *" name="comp" comment="A #ICalComponent"/>
     <returns type="ICalPropertyStatus" comment="A #ICalPropertyStatus."/>
-    <comment xml:space="preserve">Gets the status of the #ICalComponent.</comment>
+    <comment xml:space="preserve">Returns the property status of the #ICalComponent. ICAL_STATUS_NONE is returned if a problem parsing the component was detected.</comment>
   </method>
   <declaration position="header" content="typedef void (*ICalComponentForeachTZIDFunc)(ICalParameter *param, gpointer user_data);"/>
   <declaration position="body">

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -822,7 +822,7 @@ static bool icalcomponent_is_busy(icalcomponent *comp)
         }
     }
     status = icalcomponent_get_status(comp);
-    if (ret && status) {
+    if (ret && status != ICAL_STATUS_NONE) {
         switch (status) {
         case ICAL_STATUS_CANCELLED:
         case ICAL_STATUS_TENTATIVE:
@@ -1980,13 +1980,13 @@ enum icalproperty_status icalcomponent_get_status(icalcomponent *comp)
 
     if (inner == 0) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
-        return 0;
+        return ICAL_STATUS_NONE;
     }
 
     prop = icalcomponent_get_first_property(inner, ICAL_STATUS_PROPERTY);
 
     if (prop == 0) {
-        return 0;
+        return ICAL_STATUS_NONE;
     }
 
     return icalproperty_get_status(prop);

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -405,6 +405,12 @@ LIBICAL_ICAL_EXPORT int icalcomponent_get_sequence(icalcomponent *comp);
 
 LIBICAL_ICAL_EXPORT void icalcomponent_set_status(icalcomponent *comp, enum icalproperty_status v);
 
+/**
+ * Returns the status property of the icalcomponent.
+ *
+ * @param comp pointer to a valid icalcomponent
+ * @returns the status property or ICAL_STATUS_NONE if a problem parsing the status was detected.
+ */
 LIBICAL_ICAL_EXPORT enum icalproperty_status icalcomponent_get_status(icalcomponent *comp);
 
 /** @brief Calls the given function for each TZID parameter found in the

--- a/src/libical/vcomponent_cxx.h
+++ b/src/libical/vcomponent_cxx.h
@@ -172,6 +172,11 @@ public:
     int get_sequence() const;
     void set_sequence(const int &v);
 
+    /**
+     * Returns the status VComponent status.
+     *
+     * @returns the status property or ICAL_STATUS_NONE if a problem parsing the status was detected.
+     */
     int get_status() const;
     void set_status(const enum icalproperty_status &v);
 


### PR DESCRIPTION
Instead of returning 0 (not a legit icalproperty_status) return ICAL_STATUS_NONE if a failure (malformed data) is encountered.