### PR TITLE
vcardcomponent_get_version() - return VCARD_VERSION_NONE on failure

### DIFF
--- a/src/libical-glib/api/i-cal-vcard-component.xml
+++ b/src/libical-glib/api/i-cal-vcard-component.xml
@@ -189,7 +189,7 @@
   </method>
   <method name="i_cal_vcard_component_get_version" corresponds="vcardcomponent_get_version" since="4.0">
     <parameter type="ICalVcardComponent *" name="comp" comment="An #ICalVcardComponent"/>
-    <returns type="ICalVcardPropertyVersion" comment="Current vCard version of the @comp."/>
+    <returns type="ICalVcardPropertyVersion" comment="Current vCard version of the @comp. VCARD_VERSION_NONE is returned if the version property is empty or @comp is null."/>
     <comment xml:space="preserve">Returns the current vCard version of th @comp as #ICalVcardPropertyVersion.</comment>
   </method>
   <method name="i_cal_vcard_component_get_uid" corresponds="vcardcomponent_get_uid" kind="get" since="4.0">

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -1253,7 +1253,7 @@ void vcardcomponent_transform(vcardcomponent *impl,
 
 enum vcardproperty_version vcardcomponent_get_version(vcardcomponent *card)
 {
-    icalerror_check_arg_rz(card != 0, "card");
+    icalerror_check_arg_rx(card != 0, "card", VCARD_VERSION_NONE);
 
     if (card->versionp == 0) {
         card->versionp =


### PR DESCRIPTION
Instead of returning 0 (not a legit vcardproperty_version) return VCARD_VERSION_NONE if a null card pointer is provided.