### PR TITLE
clang-tidy fixes bugprone-multi-level-implicit-pointer-conversion

### DIFF
--- a/src/libical-glib/tools/xml-parser.c
+++ b/src/libical-glib/tools/xml-parser.c
@@ -367,7 +367,7 @@ GList *get_list_from_string(const gchar *str)
         list = g_list_append(list, ret[iter]);
     }
 
-    g_free(ret);
+    g_free((void *)ret);
     return list;
 }
 

--- a/src/libical/icalarray.c
+++ b/src/libical/icalarray.c
@@ -65,7 +65,7 @@ icalarray *icalarray_copy(const icalarray *originalarray)
         return NULL;
     }
 
-    array->chunks = icalmemory_new_buffer(chunks * sizeof(void *));
+    array->chunks = (void **)icalmemory_new_buffer(chunks * sizeof(void **));
     if (array->chunks) {
         for (size_t chunk = 0; chunk < chunks; chunk++) {
             array->chunks[chunk] = icalarray_alloc_chunk(array);
@@ -101,7 +101,7 @@ void icalarray_free(icalarray *array)
         for (chunk = 0; chunk < chunks; chunk++) {
             icalmemory_free_buffer(array->chunks[chunk]);
         }
-        icalmemory_free_buffer(array->chunks);
+        icalmemory_free_buffer((void *)array->chunks);
         array->chunks = 0;
     }
     icalmemory_free_buffer(array);
@@ -194,11 +194,11 @@ static void icalarray_expand(icalarray *array, size_t space_needed)
         num_new_chunks = 1;
     }
 
-    new_chunks = icalmemory_new_buffer((num_chunks + num_new_chunks) * sizeof(void *));
+    new_chunks = (void **)icalmemory_new_buffer((num_chunks + num_new_chunks) * sizeof(void **));
 
     if (new_chunks) {
         if (array->chunks && num_chunks) {
-            memcpy(new_chunks, array->chunks, num_chunks * sizeof(void *));
+            memcpy((void *)new_chunks, (void *)array->chunks, num_chunks * sizeof(void *));
         }
         for (size_t c = 0; c < num_new_chunks; c++) {
             new_chunks[c + num_chunks] = icalarray_alloc_chunk(array);
@@ -208,7 +208,7 @@ static void icalarray_expand(icalarray *array, size_t space_needed)
             }
         }
         if (array->chunks) {
-            icalmemory_free_buffer(array->chunks);
+            icalmemory_free_buffer((void *)array->chunks);
         }
         array->chunks = new_chunks;
         array->space_allocated = array->space_allocated + num_new_chunks * array->increment_size;

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -263,6 +263,6 @@ void ical_bt(void)
             icalerrprintf("%p\n", stack_frames[i]);
         }
     }
-    free(strings); /* Not icalmemory_free_buffer(), allocated by backtrace_symbols() */
+    free((void *)strings); /* Not icalmemory_free_buffer(), allocated by backtrace_symbols() */
 #endif
 }

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -1359,7 +1359,7 @@ icalarray *icalrecurrencetype_rscale_supported_calendars(void)
     en = ucal_getKeywordValuesForLocale("calendar", "", false, &status);
     while ((cal = uenum_next(en, NULL, &status))) {
         cal = icalmemory_tmp_copy(cal);
-        icalarray_append(calendars, &cal);
+        icalarray_append(calendars, (const void *)&cal);
     }
     uenum_close(en);
 

--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -59,7 +59,7 @@ void icalstrarray_append(icalstrarray *array, const char *elem)
 
     char *copy = icalmemory_strdup(elem);
 
-    icalarray_append(array, &copy);
+    icalarray_append(array, (const void *)&copy);
 }
 
 void icalstrarray_add(icalstrarray *array, const char *elem)
@@ -79,7 +79,7 @@ void icalstrarray_remove_element_at(icalstrarray *array, size_t position)
         return;
     }
 
-    char **del = icalarray_element_at(array, position);
+    char **del = (char **)icalarray_element_at(array, position);
 
     if (del && *del) {
         icalmemory_free_buffer(*del);
@@ -96,9 +96,9 @@ void icalstrarray_remove(icalstrarray *array, const char *del)
     size_t j = 0;
 
     for (size_t i = 0; i < array->num_elements; i++) {
-        char **elem = icalarray_element_at(array, i);
+        char **elem = (char **)icalarray_element_at(array, i);
         if (strcmp(*elem, del) != 0) {
-            icalarray_set_element_at(array, elem, j++);
+            (void)icalarray_set_element_at(array, (const void *)elem, j++);
         } else {
             icalmemory_free_buffer(*elem);
         }
@@ -114,7 +114,7 @@ void icalstrarray_free(icalstrarray *array)
     }
 
     for (size_t i = 0; i < array->num_elements; i++) {
-        char **del = icalarray_element_at(array, i);
+        char **del = (char **)icalarray_element_at(array, i);
         if (del && *del) {
             icalmemory_free_buffer(*del);
         }

--- a/src/libicalss/icalbdbset.c
+++ b/src/libicalss/icalbdbset.c
@@ -118,7 +118,7 @@ void icalbdbset_rmdbLog(void)
                 (void)unlink(listp[ii]);
                 ii++;
             }
-            free(listp);
+            free((void *)listp);
         }
     }
 }


### PR DESCRIPTION
Fixes, for example:
```
multilevel pointer conversion from 'void *' to 'void **'
multilevel pointer conversion from 'void **' to 'void *'
etc
```