### PR TITLE
clang-tidy fixes bugprone-macro-parentheses

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -717,7 +717,7 @@ static void icalrecurrencetype_free(struct icalrecurrencetype *recur, int free_s
 #define SAFEFREE(p)                \
     if (p) {                       \
         icalmemory_free_buffer(p); \
-        p = 0;                     \
+        (p) = 0;                   \
     }
 
     SAFEFREE(recur->rscale);
@@ -1118,7 +1118,7 @@ char *icalrecurrencetype_as_string_r(struct icalrecurrencetype *recur)
 #define BITS_PER_LONG ((unsigned short)(8 * sizeof(unsigned long)))
 
 /* Number of longs in mask of n bits */
-#define LONGS_PER_BITS(n) ((n + BITS_PER_LONG - 1) / BITS_PER_LONG)
+#define LONGS_PER_BITS(n) (((n) + BITS_PER_LONG - 1) / BITS_PER_LONG)
 
 #define ICAL_YEARDAYS_MASK_SIZE (ICAL_BY_YEARDAY_SIZE + 7)
 #define ICAL_YEARDAYS_MASK_OFFSET 4
@@ -2265,7 +2265,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype *rule,
         return 0;
     }
 
-#define IN_RANGE(val, min, max) (val >= min && val <= max)
+#define IN_RANGE(val, min, max) ((val) >= (min) && (val) <= (max))
     /* Make sure that DTSTART is a sane value */
     if (!icaltime_is_valid_time(dtstart) ||
         !IN_RANGE(dtstart.year, 0, MAX_TIME_T_YEAR) ||

--- a/src/libical/icaltimezone_p.c
+++ b/src/libical/icaltimezone_p.c
@@ -91,12 +91,12 @@ typedef struct
     char charcnt[4];
 } tzinfo;
 
-#define EFREAD(buf, size, num, fs)                                     \
-    if (!ferror(fs) && !feof(fs) && fread(buf, size, num, fs) < num) { \
-        if (ferror(fs)) {                                              \
-            icalerror_set_errno(ICAL_FILE_ERROR);                      \
-            goto error;                                                \
-        }                                                              \
+#define EFREAD(buf, size, num, fs)                                       \
+    if (!ferror(fs) && !feof(fs) && fread(buf, size, num, fs) < (num)) { \
+        if (ferror(fs)) {                                                \
+            icalerror_set_errno(ICAL_FILE_ERROR);                        \
+            goto error;                                                  \
+        }                                                                \
     }
 
 typedef struct
@@ -229,7 +229,7 @@ static char *parse_posix_zone(char *p, ttinfo *type)
     return p;
 }
 
-#define nth_weekday(week, day) (icalrecurrencetype_encode_day((enum icalrecurrencetype_weekday)day, (short)week))
+#define nth_weekday(week, day) (icalrecurrencetype_encode_day((enum icalrecurrencetype_weekday)(day), (short)(week)))
 
 static bool icalrecur_set_single_by(icalrecurrence_by_data *by, short value)
 {

--- a/src/libical/qsort_gen.c
+++ b/src/libical/qsort_gen.c
@@ -50,10 +50,10 @@ void qsort_gen_memswap(void *m1, void *m2, size_t size)
     stackptr[0] = base;   \
     stackptr[1] = limit;  \
     stackptr += 2
-#define POP(base, limit) \
-    stackptr -= 2;       \
-    base = stackptr[0];  \
-    limit = stackptr[1]
+#define POP(base, limit)  \
+    stackptr -= 2;        \
+    (base) = stackptr[0]; \
+    (limit) = stackptr[1]
 /* TODO: Stack usage is log2(nmemb) (minus what T shaves off the worst case).
          Worst-case nmemb is platform dependent and should probably be
          configured.

--- a/src/libicalvcard/vcardparser.c
+++ b/src/libicalvcard/vcardparser.c
@@ -182,15 +182,15 @@ static void buf_vprintf(struct buf *buf, const char *fmt, va_list args)
 #define PUTC(C) buf_putc(&state->buf, C)
 #define INC(I) state->p += I
 #define IS_CTRL(ch) \
-    (ch > 0 && ch <= 0x1f && ch != '\r' && ch != '\n' && ch != '\t')
-#define HANDLECTRL(state)              \
-    {                                  \
-        if (IS_CTRL(*state->p)) {      \
-            while (IS_CTRL(*state->p)) \
-                state->p++;            \
-        }                              \
-        if ((*state->p) == 0)          \
-            break;                     \
+    ((ch) > 0 && (ch) <= 0x1f && (ch) != '\r' && (ch) != '\n' && (ch) != '\t')
+#define HANDLECTRL(state)                \
+    {                                    \
+        if (IS_CTRL(*(state)->p)) {      \
+            while (IS_CTRL(*(state)->p)) \
+                (state)->p++;            \
+        }                                \
+        if ((*(state)->p) == 0)          \
+            break;                       \
     }
 
 static int _parse_param_name(struct vcardparser_state *state)


### PR DESCRIPTION
Fixes:
```
warning: macro argument should be enclosed in parentheses
```