### PR TITLE
clang-tidy fixes readability-redundant-access-specifier

### DIFF
--- a/src/libical/icalparameter_cxx.h
+++ b/src/libical/icalparameter_cxx.h
@@ -48,13 +48,11 @@ public:
 
     void detach();
 
-public:
     std::string as_ical_string();
     bool is_valid();
     icalparameter_kind isa();
     int isa_parameter(void *param);
 
-public:
     /* Access the name of an X parameter */
     static void set_xname(ICalParameter &param, const std::string &v);
     static std::string get_xname(ICalParameter &param);
@@ -65,7 +63,6 @@ public:
     static std::string kind_to_string(const icalparameter_kind &kind);
     static icalparameter_kind string_to_kind(const std::string &str);
 
-public:
     /* DELEGATED-FROM */
     std::vector<std::string> get_delegatedfrom() const;
     void set_delegatedfrom(const std::vector<std::string> &v);

--- a/src/libical/icalproperty_cxx.h
+++ b/src/libical/icalproperty_cxx.h
@@ -47,7 +47,6 @@ public:
 
     void detach();
 
-public:
     std::string as_ical_string();
     icalproperty_kind isa();
     int isa_property(void *property);
@@ -76,7 +75,6 @@ public:
      */
     std::string get_name() const;
 
-public:
     /* Deal with X properties */
     static void set_x_name(ICalProperty &prop, const std::string &name);
     static std::string get_x_name(ICalProperty &prop);
@@ -100,7 +98,6 @@ public:
 
     static bool enum_belongs_to_property(const icalproperty_kind &kind, const int &e);
 
-public:
     /* ACTION */
     void set_action(const enum icalproperty_action &val);
     enum icalproperty_action get_action();

--- a/src/libical/icalvalue_cxx.h
+++ b/src/libical/icalvalue_cxx.h
@@ -41,7 +41,6 @@ public:
 
     void detach();
 
-public:
     std::string as_ical_string();
     bool is_valid();
     icalvalue_kind isa();
@@ -57,14 +56,12 @@ public:
     void set_datetimeperiod(const struct icaldatetimeperiodtype &v);
     struct icaldatetimeperiodtype get_datetimeperiod();
 
-public:
     static icalparameter_xliccomparetype compare(ICalValue &a, ICalValue &b);
 
     /* Convert enumerations */
     static icalvalue_kind string_to_kind(const std::string &str);
     std::string kind_to_string(const icalvalue_kind &kind);
 
-public:
     /* BOOLEAN */
     int get_boolean() const;
     void set_boolean(const int &v);

--- a/src/libical/vcomponent_cxx.h
+++ b/src/libical/vcomponent_cxx.h
@@ -56,7 +56,6 @@ public:
     // memory leak if you are not careful.
     void detach();
 
-public:
     std::string as_ical_string();
     bool is_valid();
     icalcomponent_kind isa();
@@ -118,7 +117,6 @@ public:
     static icalcomponent_kind string_to_kind(const std::string &str);
     static std::string kind_to_string(const icalcomponent_kind &kind);
 
-public:
     struct icaltimetype get_dtstart() const;
     void set_dtstart(const struct icaltimetype &v);
 
@@ -180,7 +178,6 @@ public:
     int get_status() const;
     void set_status(const enum icalproperty_status &v);
 
-public:
     /**
      * For VCOMPONENT: Return a reference to the first VEVENT,
      * VTODO, or VJOURNAL
@@ -195,7 +192,6 @@ public:
 
     int recurrence_is_excluded(struct icaltimetype *dtstart, struct icaltimetype *recurtime);
 
-public:
     /* helper functions for adding/removing/updating property and sub-components */
 
     /// Note: the VComponent kind have to be the same


### PR DESCRIPTION
Fixes:
```
Redundant access specifier has the same accessibility as the previous
access specifier.
```