### PR TITLE
clang-tidy fix bugprone-unhandled-self-assignment

### DIFF
--- a/src/libical/icptrholder_cxx.h
+++ b/src/libical/icptrholder_cxx.h
@@ -73,8 +73,11 @@ public:
         return *this;
     }
 
-    ICPointerHolder &operator=(ICPointerHolder &p)
+    ICPointerHolder &operator=(ICPointerHolder &p) //NOLINT(misc-unconventional-assign-operator)
     {
+        if (this == &p) {
+            return *this;
+        }
         this->release();
         ptr = p.ptr; // this transfer ownership of the pointer
         p.ptr = 0;   // set it to null so the pointer won't get delete twice.


### PR DESCRIPTION
in icptrholder_cxx.h

Fixes:
```
Operator=() does not handle self-assignment properly
```

also suppress misc-unconventional-assign-operator