### PR TITLE
enforce generated code to follow our coding standards

### DIFF
--- a/src/libical-glib/api/i-cal-enum-array.xml
+++ b/src/libical-glib/api/i-cal-enum-array.xml
@@ -68,8 +68,9 @@
     <custom>    const icalenumarray_element *elem;
     g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), 0);
     elem = icalenumarray_element_at((icalenumarray *)i_cal_object_get_native((ICalObject *)array), position);
-    if (elem == NULL)
+    if (elem == NULL) {
         return 0;
+    }
     return elem-&gt;val;</custom>
   </method>
   <method name="i_cal_enum_array_element_get_xvalue_at" corresponds="icalenumarray_element_at" annotation="skip" kind="custom" since="4.0">
@@ -80,8 +81,9 @@
     <custom>    const icalenumarray_element *elem;
     g_return_val_if_fail(I_CAL_IS_ENUM_ARRAY(array), NULL);
     elem = icalenumarray_element_at((icalenumarray *)i_cal_object_get_native((ICalObject *)array), position);
-    if (elem == NULL)
+    if (elem == NULL) {
         return NULL;
+    }
     return elem-&gt;xvalue;</custom>
   </method>
   <method name="i_cal_enum_array_size" corresponds="icalenumarray_size" kind="other" since="4.0">

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -186,8 +186,9 @@
     <custom xml:space="preserve">    icaltimetype *itt;
 
     g_return_if_fail(I_CAL_IS_TIME(tt));
-    if(zone)
+    if(zone) {
         g_return_if_fail(I_CAL_IS_TIMEZONE(zone));
+    }
 
     itt = i_cal_object_get_native(I_CAL_OBJECT(tt));
     g_return_if_fail(itt != NULL);
@@ -344,12 +345,16 @@
     g_return_if_fail(timetype != NULL);
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);
     g_return_if_fail(itt != NULL);
-    if(year)
+    if(year) {
         *year = itt-&gt;year;
-    if(month)
+    }
+    if(month) {
         *month = itt-&gt;month;
-    if(day)
-        *day = itt-&gt;day; </custom>
+    }
+    if(day) {
+        *day = itt-&gt;day;
+    }
+    </custom>
   </method>
   <method name="i_cal_time_set_date" corresponds="none" kind="set" since="1.0">
     <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set to"/>
@@ -375,12 +380,16 @@
     g_return_if_fail(timetype != NULL);
     itt = (struct icaltimetype *)i_cal_object_get_native ((ICalObject *)timetype);
     g_return_if_fail(itt != NULL);
-    if(hour)
+    if(hour) {
         *hour = itt-&gt;hour;
-    if(minute)
+    }
+    if(minute) {
         *minute = itt-&gt;minute;
-    if(second)
-        *second = itt-&gt;second; </custom>
+    }
+    if(second) {
+        *second = itt-&gt;second;
+    }
+    </custom>
   </method>
   <method name="i_cal_time_set_time" corresponds="none" kind="set" since="1.0">
     <parameter type="ICalTime *" name="timetype" comment="The #ICalTime to be set to"/>

--- a/src/libical-glib/api/i-cal-value.xml
+++ b/src/libical-glib/api/i-cal-value.xml
@@ -83,8 +83,9 @@
     szEncText = g_new0(gchar, bufSize);
 
     result = icalvalue_encode_ical_string(szText, szEncText, bufSize);
-    if (result)
+    if (result) {
         buffer = g_strdup(szEncText);
+    }
     g_free(szEncText);
 
     return buffer;</custom>
@@ -104,8 +105,9 @@
     szDecText = g_new0(gchar, bufSize);
 
     result = icalvalue_decode_ical_string(szText, szDecText, bufSize);
-    if (result)
+    if (result) {
         buffer = g_strdup(szDecText);
+    }
     g_free (szDecText);
 
     return buffer;</custom>

--- a/src/libical-glib/api/i-cal-vcard-derived-value.xml
+++ b/src/libical-glib/api/i-cal-vcard-derived-value.xml
@@ -55,8 +55,9 @@
     <returns type="vcardstructuredtype *" annotation="transfer full" comment="The newly created vcardstructuredtype"/>
     <custom>    guint ii;
     vcardstructuredtype *res;
-    if (src == NULL)
+    if (src == NULL) {
         return NULL;
+    }
     res = vcardstructured_new();
     res-&gt;num_fields = src-&gt;num_fields;
     for (ii = 0; ii &lt; src-&gt;num_fields; ii++) {

--- a/src/libical-glib/api/i-cal-vcard-enum-array.xml
+++ b/src/libical-glib/api/i-cal-vcard-enum-array.xml
@@ -18,8 +18,9 @@
     <custom>    const vcardenumarray_element *elem;
     g_return_val_if_fail(I_CAL_VCARD_IS_ENUM_ARRAY(array), 0);
     elem = vcardenumarray_element_at((vcardenumarray *)i_cal_object_get_native((ICalObject *)array), position);
-    if (elem == NULL)
+    if (elem == NULL) {
         return 0;
+    }
     return elem-&gt;val;</custom>
   </method>
   <method name="i_cal_vcard_enum_array_get_xvalue_at" corresponds="vcardenumarray_element_at" annotation="skip" kind="other" since="4.0">
@@ -30,8 +31,9 @@
     <custom>    const vcardenumarray_element *elem;
     g_return_val_if_fail(I_CAL_VCARD_IS_ENUM_ARRAY(array), 0);
     elem = vcardenumarray_element_at((vcardenumarray *)i_cal_object_get_native((ICalObject *)array), position);
-    if (elem == NULL)
+    if (elem == NULL) {
         return 0;
+    }
     return elem-&gt;xvalue;</custom>
   </method>
   <method name="i_cal_vcard_enum_array_size" corresponds="vcardenumarray_size" kind="other" since="4.0">

--- a/src/libical-glib/api/i-cal-vcard-geo.xml
+++ b/src/libical-glib/api/i-cal-vcard-geo.xml
@@ -103,10 +103,13 @@
     <custom>    vcardgeotype *geo;
     g_return_if_fail(I_CAL_VCARD_IS_GEO((ICalVcardGeo *)self));
     geo = ((vcardgeotype *)i_cal_object_get_native((ICalObject *)self));
-    if (out_lat)
+    if (out_lat) {
         *out_lat = geo-&gt;coords.lat;
-    if (out_lon)
-        *out_lon = geo-&gt;coords.lon;</custom>
+    }
+    if (out_lon) {
+        *out_lon = geo-&gt;coords.lon;
+    }
+    </custom>
   </method>
   <method name="i_cal_vcard_geo_get_coord_lat" corresponds="none" kind="get" since="4.0">
     <parameter type="const ICalVcardGeo *" name="self" comment="an #ICalVcardGeo"/>

--- a/src/libical-glib/api/i-cal-vcard-value.xml
+++ b/src/libical-glib/api/i-cal-vcard-value.xml
@@ -69,8 +69,9 @@
     g_return_val_if_fail(text != NULL, NULL);
 
     dequoted = vcardvalue_strdup_and_dequote_text(text, separators);
-    if(!dequoted)
+    if(!dequoted) {
         return NULL;
+    }
     res = g_strdup(dequoted);
     icalmemory_free_buffer(dequoted);
 

--- a/src/libical-glib/tools/api-templates.xml
+++ b/src/libical-glib/tools/api-templates.xml
@@ -31,8 +31,9 @@
       <custom>    vcardstructuredtype *val;
     g_return_val_if_fail(value != NULL, NULL);
     val = (vcardstructuredtype *)i_cal_object_get_native((ICalObject *)value);
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-prefix}_new_full(${native-prefix}_new_${suffix}(priv_i_cal_vcardstructuredtype_clone(val)), NULL);</custom>
     </method>
     <method name="${binding-prefix}_get_${suffix}" corresponds="${native-prefix}_get_${suffix}" kind="get">
@@ -44,8 +45,9 @@
       <custom>    vcardstructuredtype *val;
     g_return_val_if_fail(self != NULL, NULL);
     val = ${native-prefix}_get_${suffix}((${native-type} *)i_cal_object_get_native((ICalObject *)self));
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return i_cal_vcard_structured_new_full(priv_i_cal_vcardstructuredtype_clone(val), NULL);</custom>
     </method>
     <method name="${binding-prefix}_set_${suffix}" corresponds="${native-prefix}_set_${suffix}" kind="set">
@@ -72,8 +74,9 @@
       <custom>    ${native-array-type} *val;
     g_return_val_if_fail(value != NULL, NULL);
     val = (${native-array-type} *)i_cal_object_get_native((ICalObject *)value);
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-prefix}_new_full(${native-prefix}_new_${suffix}_list(${native-array-type}_clone(val)), NULL);</custom>
     </method>
     <method name="${binding-prefix}_get_${suffix}${binding-get-set-suffix}" corresponds="${native-prefix}_get_${suffix}" kind="get">
@@ -85,8 +88,9 @@
       <custom>    ${native-array-type} *val;
     g_return_val_if_fail(self != NULL, NULL);
     val = ${native-prefix}_get_${suffix}((${native-prefix} *)i_cal_object_get_native((ICalObject *)self));
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-array-new-prefix}_new_full(${native-array-type}_clone(val), NULL);</custom>
     </method>
     <method name="${binding-prefix}_set_${suffix}${binding-get-set-suffix}" corresponds="${native-prefix}_set_${suffix}" kind="set">
@@ -148,8 +152,9 @@
       <custom>    ${native-array-type} *val;
     g_return_val_if_fail(value != NULL, NULL);
     val = (${native-array-type} *)i_cal_object_get_native((ICalObject *)value);
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-prefix}_new_full(${native-prefix}_new_${suffix}_list(${native-array-type}_clone(val)), NULL);</custom>
     </method>
     <method name="${binding-prefix}_get_${suffix}${binding-get-set-suffix}" corresponds="${native-prefix}_get_${suffix}" kind="get">
@@ -161,8 +166,9 @@
       <custom>    ${native-array-type} *val;
     g_return_val_if_fail(self != NULL, NULL);
     val = ${native-prefix}_get_${suffix}((${native-type} *)i_cal_object_get_native((ICalObject *)self));
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-array-new-prefix}_new_full(${native-array-type}_clone(val), NULL);</custom>
     </method>
     <method name="${binding-prefix}_set_${suffix}${binding-get-set-suffix}" corresponds="${native-prefix}_set_${suffix}" kind="set">
@@ -207,8 +213,9 @@
       <custom>    ${native-array-type} *val;
     g_return_val_if_fail(value != NULL, NULL);
     val = (${native-array-type} *)i_cal_object_get_native((ICalObject *)value);
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-prefix}_new_full(${native-prefix}_new_${suffix}(${native-array-type}_clone(val)), NULL);</custom>
     </method>
     <method name="${binding-prefix}_get_${suffix}${binding-get-set-suffix}" corresponds="${native-prefix}_get_${suffix}" kind="get">
@@ -220,8 +227,9 @@
       <custom>    ${native-array-type} *val;
     g_return_val_if_fail(self != NULL, NULL);
     val = ${native-prefix}_get_${suffix}((${native-type} *)i_cal_object_get_native((ICalObject *)self));
-    if (val == NULL)
+    if (val == NULL) {
         return NULL;
+    }
     return ${binding-array-new-prefix}_new_full(${native-array-type}_clone(val), NULL);</custom>
     </method>
     <method name="${binding-prefix}_set_${suffix}${binding-get-set-suffix}" corresponds="${native-prefix}_set_${suffix}" kind="set">

--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -213,10 +213,11 @@ static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind
         int i;
         int num_params = (int)(sizeof(icalparameter_map) / sizeof(icalparameter_map[0]));
         for (i = 0; i < num_params && !enum_end; i++) {
-            if (kind == icalparameter_map[i].kind && !enum_start)
+            if (kind == icalparameter_map[i].kind && !enum_start) {
                 enum_start = i;
-            else if (kind != icalparameter_map[i].kind && enum_start)
+            } else if (kind != icalparameter_map[i].kind && enum_start) {
                 enum_end = i;
+            }
         }
     }
 
@@ -229,21 +230,26 @@ static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind
         icalenumarray_element elem;
         if (val[0] == '"') {
             end = strchr(val + 1, '"');
-            if (end) val++;
-        }
-        else {
+            if (end) {
+                val++;
+            }
+        } else {
             end = strchr(val, ',');
         }
         val_len = end ? (size_t)(end - val) : strlen(val);
 
-        if (!val_len) break;
+        if (!val_len) {
+            break;
+        }
 
         next_val = end;
-        if (next_val && next_val[0] == '"')
+        if (next_val && next_val[0] == '"') {
             next_val = strchr(next_val, ',');
+        }
 
-        if (next_val && next_val[0] == ',')
+        if (next_val && next_val[0] == ',') {
             next_val++;
+        }
 
         tmpbuf = icalmemory_new_buffer(val_len + 1);
         strncpy(tmpbuf, val, val_len);
@@ -260,7 +266,9 @@ static icalarray *icalparameter_values_from_value_string(icalparameter_kind kind
                 }
             }
 
-            if (!elem.val) elem.xvalue = tmpbuf;
+            if (!elem.val) {
+                elem.xvalue = tmpbuf;
+            }
             icalenumarray_append(values, &elem);
         }
 

--- a/src/libical/icalderivedproperty.c.in
+++ b/src/libical/icalderivedproperty.c.in
@@ -27,7 +27,7 @@
    - a bitmask of flags that further describe the property
 */
 
-struct icalproperty_map
+struct icalproperty_map // NOLINT(clang-analyzer-optin.performance.Padding)
 {
     icalproperty_kind kind;
     const char *name;
@@ -151,11 +151,13 @@ bool icalproperty_value_kind_is_valid(icalproperty_kind pkind, icalvalue_kind vk
     int i, j;
     int num_props;
 
-    if (vkind == ICAL_NO_VALUE)
+    if (vkind == ICAL_NO_VALUE) {
         return false;
+    }
 
-    if (pkind == ICAL_X_PROPERTY)
+    if (pkind == ICAL_X_PROPERTY) {
         return true;
+    }
 
     num_props = (int)(sizeof(property_map) / sizeof(property_map[0]));
     for (i = 0; i < num_props; i++) {
@@ -257,19 +259,22 @@ int icalproperty_kind_and_string_to_enum(const int kind, const char *str)
 
     icalerror_check_arg_rz(str != 0, "str");
 
-    if ((pkind = icalproperty_value_kind_to_kind((enum icalvalue_kind)kind)) == ICAL_NO_PROPERTY)
+    if ((pkind = icalproperty_value_kind_to_kind((enum icalvalue_kind)kind)) == ICAL_NO_PROPERTY) {
         return 0;
+     }
 
     while (*str == ' ') {
         str++;
     }
 
     for (i = ICALPROPERTY_FIRST_ENUM; i != ICALPROPERTY_LAST_ENUM; i++) {
-        if (enum_map[i - ICALPROPERTY_FIRST_ENUM].prop == pkind)
+        if (enum_map[i - ICALPROPERTY_FIRST_ENUM].prop == pkind) {
             break;
+        }
     }
-    if (i == ICALPROPERTY_LAST_ENUM)
+    if (i == ICALPROPERTY_LAST_ENUM) {
         return 0;
+    }
 
     for (; i != ICALPROPERTY_LAST_ENUM; i++) {
         if (enum_map[i - ICALPROPERTY_FIRST_ENUM].prop == pkind &&

--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -152,8 +152,9 @@ void icalvalue_set_recur(icalvalue *value, struct icalrecurrencetype *recur)
 
     icalrecurrencetype_ref(recur);
 
-    if (impl->data.v_recur)
+    if (impl->data.v_recur) {
         icalrecurrencetype_unref(impl->data.v_recur);
+    }
 
     impl->data.v_recur = recur;
 }
@@ -460,8 +461,9 @@ void icalvalue_set_attach(icalvalue *value, icalattach *attach)
 
     icalattach_ref(attach);
 
-    if (impl->data.v_attach)
+    if (impl->data.v_attach) {
         icalattach_unref(impl->data.v_attach);
+    }
 
     impl->data.v_attach = attach;
 }

--- a/src/libicalvcard/vcardderivedproperty.c.in
+++ b/src/libicalvcard/vcardderivedproperty.c.in
@@ -26,7 +26,7 @@
    - a bitmask of flags that further describe the property
 */
 
-struct vcardproperty_map
+struct vcardproperty_map // NOLINT(clang-analyzer-optin.performance.Padding)
 {
     vcardproperty_kind kind;
     const char *name;
@@ -158,11 +158,13 @@ bool vcardproperty_value_kind_is_valid(vcardproperty_kind pkind,
     int i, j;
     int num_props;
 
-    if (vkind == VCARD_NO_VALUE)
+    if (vkind == VCARD_NO_VALUE) {
         return false;
+    }
 
-    if (pkind == VCARD_X_PROPERTY)
+    if (pkind == VCARD_X_PROPERTY) {
         return true;
+    }
 
     num_props = (int)(sizeof(property_map) / sizeof(property_map[0]));
     for (i = 0; i < num_props; i++) {
@@ -253,19 +255,22 @@ int vcardproperty_kind_and_string_to_enum(const int kind, const char *str)
 
     icalerror_check_arg_rz(str != 0, "str");
 
-    if ((pkind = vcardproperty_value_kind_to_kind((vcardvalue_kind)kind)) == VCARD_NO_PROPERTY)
+    if ((pkind = vcardproperty_value_kind_to_kind((vcardvalue_kind)kind)) == VCARD_NO_PROPERTY) {
         return 0;
+    }
 
     while (*str == ' ') {
         str++;
     }
 
     for (i = VCARDPROPERTY_FIRST_ENUM; i != VCARDPROPERTY_LAST_ENUM; i++) {
-        if (enum_map[i - VCARDPROPERTY_FIRST_ENUM].prop == pkind)
+        if (enum_map[i - VCARDPROPERTY_FIRST_ENUM].prop == pkind) {
             break;
+        }
     }
-    if (i == VCARDPROPERTY_LAST_ENUM)
+    if (i == VCARDPROPERTY_LAST_ENUM) {
         return 0;
+    }
 
     for (; i != VCARDPROPERTY_LAST_ENUM; i++) {
         if (enum_map[i - VCARDPROPERTY_FIRST_ENUM].prop == pkind &&

--- a/src/libicalvcard/vcardrestriction.c.in
+++ b/src/libicalvcard/vcardrestriction.c.in
@@ -98,8 +98,9 @@ static const char *vcardrestriction_validate_datetime_value(
     vcardtimetype t = vcardproperty_get_bday(prop);
     static char buf[TMP_BUF_SIZE];
 
-    if (vcardtime_is_null_datetime(t))
+    if (vcardtime_is_null_datetime(t)) {
         return 0;
+    }
 
     if (comp && vcardcomponent_get_version(comp) != VCARD_VERSION_40) {
         unsigned missing_time_parts = (unsigned)((t.hour < 0) + (t.minute < 0) + (t.second < 0));
@@ -135,8 +136,9 @@ static const char *vcardrestriction_validate_timestamp_value(
     vcardtimetype t = vcardproperty_get_rev(prop);
     static char buf[TMP_BUF_SIZE];
 
-    if (vcardtime_is_null_datetime(t))
+    if (vcardtime_is_null_datetime(t)) {
         return 0;
+    }
 
     if (!vcardtime_is_timestamp(t) || !vcardtime_is_valid_time(t)) {
         snprintf(buf, TMP_BUF_SIZE,


### PR DESCRIPTION
readability-braces-around-statements

not all fixed since there is some generated code in libical-glib that I don't know how to fix yet.