### PR TITLE
Regression testing - fix up the ADD_TESTS_BROKEN_BUILTIN_TZDATA tests

### DIFF
--- a/src/test/regression-component.c
+++ b/src/test/regression-component.c
@@ -340,7 +340,7 @@ void test_icalcomponent_get_span(void)
         print_span(tnum++, span);
     }
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     int_is("America/Los_Angeles", span.start, 973350000);
 #endif
 
@@ -381,7 +381,7 @@ void test_icalcomponent_get_span(void)
         print_span(tnum++, span);
     }
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     int_is("America/New_York", span.start, 973360800);
 #endif
 
@@ -405,7 +405,7 @@ void test_icalcomponent_get_span(void)
         print_span(tnum++, span);
     }
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     int_is("America/New_York", span.start, 973360800);
 #endif
 
@@ -429,7 +429,7 @@ void test_icalcomponent_get_span(void)
         print_span(tnum++, span);
     }
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     int_is("America/Los_Angeles w/ duration", span.end, 973351800);
 #endif
 

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -2237,21 +2237,15 @@ void do_test_time(const char *zone)
         printf("\n TimeZone Conversions \n");
     }
 
-    /*
-    icttla = ictt;
-    icaltimezone_convert_time(&icttla,
-                              icaltimezone_get_utc_timezone(),
-                              lazone);
-*/
     icttla = icaltime_convert_to_zone(ictt,
                                       icaltimezone_get_builtin_timezone("America/Los_Angeles"));
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     int_is("Converted hour in America/Los_Angeles is 10", icttla.hour, 10);
 #endif
     icttutc = icaltime_convert_to_zone(icttla, icaltimezone_get_utc_timezone());
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     ok("America/Los_Angeles local time is 2000-11-03 10:30:30",
        (strncmp(ictt_as_string(icttla), "2000-11-03 10:30:30", 19) == 0));
 #endif
@@ -2280,7 +2274,7 @@ void do_test_time(const char *zone)
         printf("Orig (ical) : %s\n", ictt_as_string(ictt));
         printf("NY          : %s\n", ictt_as_string(icttny));
     }
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     ok("Converted time in zone America/New_York is 2000-11-03 13:30:30",
        (strncmp(ictt_as_string(icttny), "2000-11-03 13:30:30", 19) == 0));
 #endif
@@ -2308,7 +2302,7 @@ void do_test_time(const char *zone)
         printf("Orig (ical) : %s\n", ictt_as_string(ictt));
         printf("LA          : %s\n", ictt_as_string(icttla));
     }
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
+#if !defined(USE_BUILTIN_TZDATA)
     ok("Converted time in zone America/Los_Angeles is 2000-11-03 10:30:30",
        (strncmp(ictt_as_string(icttla), "2000-11-03 10:30:30", 19) == 0));
 #endif
@@ -2936,14 +2930,12 @@ void test_convenience(void)
     icalcomponent_set_duration(c, icaldurationtype_from_string("PT1H30M"));
     duration = icaldurationtype_as_seconds(icalcomponent_get_duration(c)) / 60;
 
-#if ADD_TESTS_BROKEN_BUILTIN_TZDATA
     ok("Start is 1997-08-01 12:00:00 Europe/Rome",
        (0 == strcmp("1997-08-01 12:00:00 " TESTS_TZID_PREFIX "Europe/Rome",
                     ictt_as_string(icalcomponent_get_dtstart(c)))));
     ok("End is 1997-08-01 13:30:00 Europe/Rome",
        (0 == strcmp("1997-08-01 13:30:00 " TESTS_TZID_PREFIX "Europe/Rome",
                     ictt_as_string(icalcomponent_get_dtend(c)))));
-#endif
     ok("Duration is 90 m", (duration == 90));
 
     icalcomponent_free(c);

--- a/src/test/regression.h
+++ b/src/test/regression.h
@@ -14,8 +14,6 @@
 extern "C" {
 #endif
 
-#define ADD_TESTS_BROKEN_BUILTIN_TZDATA 0
-
 extern int VERBOSE;
 extern int QUIET;
 


### PR DESCRIPTION
Unleash and fix the tests hidden by ADD_TESTS_BROKEN_BUILTIN_TZDATA

some of them are for non-builtin timezones only