### PR TITLE
Remove function icaltime_week_number()

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -176,6 +176,9 @@ The following functions have been added:
 
 * `icalmime_parse()` has been removed. Please use another library if you need a MIME parser.
 
+* `icaltime_week_number()` has been removed. (it never properly accounted for the
+   start day of the week in different locales).
+
 * `icalrecurrencetype_clear()` has been removed.
 
 * `icaltimezone_release_zone_tab()` has been removed.

--- a/docs/UsingLibical.md
+++ b/docs/UsingLibical.md
@@ -944,11 +944,6 @@ short icaltime_start_doy_week(
     struct icaltimetype t,
     int fdow);
 
-short icaltime_week_number(
-    short day_of_month,
-    short month,
-    short year);
-
 short icaltime_days_in_month(
     short month,
     short year);

--- a/src/Net-ICal-Libical/netical.i
+++ b/src/Net-ICal-Libical/netical.i
@@ -242,9 +242,6 @@ short icaltime_start_doy_week(struct icaltimetype t, int fdow);
 /* Returns a string with the time represented in the same format as ctime(). THe string is owned by libical */
 char* icaltime_as_ctime(struct icaltimetype);
 
-/* Returns the week number for the week the given time is within */
-short icaltime_week_number(struct icaltimetype t);
-
 /* Returns -1, 0, or 1 to indicate that a<b, a==b or a>b */
 int icaltime_compare(struct icaltimetype a,struct icaltimetype b);
 

--- a/src/Net-ICal-Libical/netical_wrap.c
+++ b/src/Net-ICal-Libical/netical_wrap.c
@@ -1766,26 +1766,6 @@ XS(_wrap_icaltime_as_ctime) {
     XSRETURN(argvi);
 }
 
-XS(_wrap_icaltime_week_number) {
-
-    short  _result;
-    struct icaltimetype * _arg0;
-    int argvi = 0;
-    dXSARGS ;
-
-    cv = cv;
-    if ((items < 1) || (items > 1))
-        croak("Usage: icaltime_week_number(t);");
-    if (SWIG_GetPtr(ST(0),(void **) &_arg0,"struct icaltimetypePtr")) {
-        croak("Type error in argument 1 of icaltime_week_number. Expected struct icaltimetypePtr.");
-        XSRETURN(1);
-    }
-    _result = (short )icaltime_week_number(*_arg0);
-    ST(argvi) = sv_newmortal();
-    sv_setiv(ST(argvi++),(IV) _result);
-    XSRETURN(argvi);
-}
-
 XS(_wrap_icaltime_compare) {
 
     int  _result;

--- a/src/Net-ICal-Libical/netical_wrap.doc
+++ b/src/Net-ICal-Libical/netical_wrap.doc
@@ -290,9 +290,6 @@ icaltime_start_doy_of_week(t);
 icaltime_as_ctime(struct icaltimetype *);
         [ returns char * ]
 
-icaltime_week_number(t);
-        [ returns short  ]
-
 icaltime_compare(a,b);
         [ returns int  ]
 

--- a/src/libical-glib/api/i-cal-time.xml
+++ b/src/libical-glib/api/i-cal-time.xml
@@ -109,11 +109,6 @@
     <returns type="gint" comment="The day of the year for the Sunday of the week that the given time is within."/>
     <comment xml:space="preserve">Returns the day of the year for the first day of the week that the given time is within.</comment>
   </method>
-  <method name="i_cal_time_week_number" corresponds="icaltime_week_number" since="1.0">
-    <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be queried"/>
-    <returns type="gint" comment="The week number for the week the given time is within."/>
-    <comment xml:space="preserve">Returns the week number for the week the given time is within.</comment>
-  </method>
   <method name="i_cal_time_is_null_time" corresponds="icaltime_is_null_time" since="1.0">
     <parameter type="const ICalTime *" name="tt" annotation="in, transfer none" comment="The #ICalTime to be checked"/>
     <returns type="gboolean" comment="Whether @tt is null_time. true if yes, false if not."/>

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -524,22 +524,6 @@ int icaltime_start_doy_week(const struct icaltimetype t, int fdow)
     return jt.day_of_year - delta;
 }
 
-int icaltime_week_number(const struct icaltimetype ictt)
-{
-    UTinstantInt jt;
-
-    memset(&jt, 0, sizeof(UTinstantInt));
-
-    jt.year = ictt.year;
-    jt.month = ictt.month;
-    jt.day = ictt.day;
-
-    ical_juldat(&jt);
-    ical_caldat(&jt);
-
-    return (jt.day_of_year - jt.weekday) / 7;
-}
-
 int icaltime_day_of_year(const struct icaltimetype t)
 {
     unsigned int is_leap = (unsigned int)icaltime_is_leap_year(t.year);

--- a/src/libical/icaltime.h.cmake
+++ b/src/libical/icaltime.h.cmake
@@ -46,7 +46,6 @@
  *      - icaltime_day_of_year(struct icaltimetype t)
  *      - icaltime_day_of_week(struct icaltimetype t)
  *      - icaltime_start_doy_week(struct icaltimetype t, int fdow)
- *      - icaltime_week_number(struct icaltimetype t)
  *
  *      Query methods include:
  *
@@ -269,13 +268,6 @@ LIBICAL_ICAL_EXPORT int icaltime_day_of_week(const struct icaltimetype t);
  *  day.
  */
 LIBICAL_ICAL_EXPORT int icaltime_start_doy_week(const struct icaltimetype t, int fdow);
-
-/** @brief Returns the week number for the week the given time is within.
- *
- * @todo Doesn't take into account the start day of the
- * week. strftime assumes that weeks start on Monday.
- */
-LIBICAL_ICAL_EXPORT int icaltime_week_number(const struct icaltimetype t);
 
 /** @brief Returns true if the time is null. */
 LIBICAL_ICAL_EXPORT bool icaltime_is_null_time(const struct icaltimetype t);

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -3095,10 +3095,6 @@ static int test_juldat_caldat_instance(long year, int month, int day)
         return -1;
     }
 
-    if (icaltime_week_number(t) != (originalInstant.day_of_year - originalInstant.weekday) / 7) {
-        return -1;
-    }
-
     return 0;
 }
 
@@ -3106,7 +3102,7 @@ static int test_juldat_caldat_instance(long year, int month, int day)
  * This test verifies the ical_caldat and ical_juldat functions. The functions are reworked versions
  * of the original ical_caldat and ical_juldat functions but avoid using floating point arithmetic. As the
  * new functions are not exported, the test cannot access them directly. It therefore checks the
- * output of the icaltime_day_of_week, icaltime_start_doy_week and icaltime_week_number functions
+ * output of the icaltime_day_of_week and icaltime_start_doy_week functions
  * which are based on the functions to be tested.
  */
 void test_juldat_caldat(void)


### PR DESCRIPTION
icaltime_week_number() is unused and was never properly implemented for week starting days in various locales.

fixes: #1117