### PR TITLE
clang-tidy fixes misc-const-correctness

### DIFF
--- a/src/java/jlibical_utils_cxx.cpp
+++ b/src/java/jlibical_utils_cxx.cpp
@@ -57,9 +57,9 @@ using namespace LibICal;
 //-------------------------------------------------------
 // Returns a pointer to the subject (a c++ object) for the given surrogate (a java object)
 //-------------------------------------------------------
-void *getCObjectPtr(JNIEnv *env, jobject surrogate)
+const void *getCObjectPtr(JNIEnv *env, jobject surrogate)
 {
-    void *result = 0;
+    const void *result = 0;
     jclass jcls = env->GetObjectClass(surrogate);
     jfieldID fid = env->GetFieldID(jcls, "m_Obj", "J");
 
@@ -100,9 +100,9 @@ void setCObjectPtr(JNIEnv *env, jobject surrogate, void *subject)
 // Return the pointer to the subject (as a VComponent*) from the given surrogate.
 // If the subject is not a VComponent type, or if the subject is NULL, then return NULL.
 //-------------------------------------------------------
-VComponent *getSubjectAsVComponent(JNIEnv *env, jobject surrogateComponent, int exceptionType)
+const VComponent *getSubjectAsVComponent(JNIEnv *env, jobject surrogateComponent, int exceptionType)
 {
-    VComponent *result = (VComponent *)(getCObjectPtr(env, surrogateComponent));
+    const VComponent *result = (VComponent *)(getCObjectPtr(env, surrogateComponent));
 
     if (result == NULL) {
         throwException(env, exceptionType);
@@ -115,9 +115,9 @@ VComponent *getSubjectAsVComponent(JNIEnv *env, jobject surrogateComponent, int 
 // Return the pointer to the subject (as an ICalProperty*) from the given surrogate.
 // If the subject is not an ICalProperty type, or if the subject is NULL, then return NULL.
 //-------------------------------------------------------
-ICalProperty *getSubjectAsICalProperty(JNIEnv *env, jobject surrogateProperty, int exceptionType)
+const ICalProperty *getSubjectAsICalProperty(JNIEnv *env, jobject surrogateProperty, int exceptionType)
 {
-    ICalProperty *result = (ICalProperty *)(getCObjectPtr(env, surrogateProperty));
+    const ICalProperty *result = (ICalProperty *)(getCObjectPtr(env, surrogateProperty));
 
     if (result == NULL) {
         throwException(env, exceptionType);
@@ -130,9 +130,9 @@ ICalProperty *getSubjectAsICalProperty(JNIEnv *env, jobject surrogateProperty, i
 // Return the pointer to the subject (as an ICalValue*) from the given surrogate.
 // If the subject is not an ICalValue type, or if the subject is NULL, then return NULL.
 //-------------------------------------------------------
-ICalValue *getSubjectAsICalValue(JNIEnv *env, jobject surrogateValue, int exceptionType)
+const ICalValue *getSubjectAsICalValue(JNIEnv *env, jobject surrogateValue, int exceptionType)
 {
-    ICalValue *result = (ICalValue *)(getCObjectPtr(env, surrogateValue));
+    const ICalValue *result = (ICalValue *)(getCObjectPtr(env, surrogateValue));
 
     if (result == NULL) {
         throwException(env, exceptionType);
@@ -145,9 +145,9 @@ ICalValue *getSubjectAsICalValue(JNIEnv *env, jobject surrogateValue, int except
 // Return the pointer to the subject (as an ICalParameter*) from the given surrogate.
 // If the subject is not an ICalParameter type, or if the subject is NULL, then return NULL.
 //-------------------------------------------------------
-ICalParameter *getSubjectAsICalParameter(JNIEnv *env, jobject surrogateParameter, int exceptionType)
+const ICalParameter *getSubjectAsICalParameter(JNIEnv *env, jobject surrogateParameter, int exceptionType)
 {
-    ICalParameter *result = (ICalParameter *)(getCObjectPtr(env, surrogateParameter));
+    const ICalParameter *result = (ICalParameter *)(getCObjectPtr(env, surrogateParameter));
 
     if (result == NULL) {
         throwException(env, exceptionType);

--- a/src/java/jlibical_utils_cxx.h
+++ b/src/java/jlibical_utils_cxx.h
@@ -30,14 +30,14 @@ struct icalrecurrencetype;
 struct icalperiodtype;
 
 // get & set
-void *getCObjectPtr(JNIEnv *env, jobject surrogate);
+const void *getCObjectPtr(JNIEnv *env, jobject surrogate);
 void setCObjectPtr(JNIEnv *env, jobject surrogate, void *subject);
 
 // type-safe getters
-LibICal::VComponent *getSubjectAsVComponent(JNIEnv *env, jobject surrogateComponent, int exceptionType);
-LibICal::ICalProperty *getSubjectAsICalProperty(JNIEnv *env, jobject surrogateProperty, int exceptionType);
-LibICal::ICalValue *getSubjectAsICalValue(JNIEnv *env, jobject surrogateValue, int exceptionType);
-LibICal::ICalParameter *getSubjectAsICalParameter(JNIEnv *env, jobject surrogateParameter, int exceptionType);
+const LibICal::VComponent *getSubjectAsVComponent(JNIEnv *env, jobject surrogateComponent, int exceptionType);
+const LibICal::ICalProperty *getSubjectAsICalProperty(JNIEnv *env, jobject surrogateProperty, int exceptionType);
+const LibICal::ICalValue *getSubjectAsICalValue(JNIEnv *env, jobject surrogateValue, int exceptionType);
+const LibICal::ICalParameter *getSubjectAsICalParameter(JNIEnv *env, jobject surrogateParameter, int exceptionType);
 
 bool copyObjToicaltimetype(JNIEnv *env, jobject src, icaltimetype *dest);
 bool copyObjToicaltriggertype(JNIEnv *env, jobject src, icaltriggertype *dest);

--- a/src/java/net_cp_jlibical_ICalParameter_cxx.cpp
+++ b/src/java/net_cp_jlibical_ICalParameter_cxx.cpp
@@ -33,7 +33,7 @@ using namespace LibICal;
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalParameter_as_1ical_1string(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->as_ical_string();
@@ -51,7 +51,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalParameter_as_1ical_1string(JN
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_isa(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->isa();
@@ -70,13 +70,13 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_ICalParameter_isa_1parameter(JNI
     jboolean result = 0;
 
     // get the c++ object from the jobj
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         // get the c++ object from the arg
         void *argObjPtr = 0;
 
         if (arg != NULL) {
-            argObjPtr = getCObjectPtr(env, arg);
+            argObjPtr = (void *)getCObjectPtr(env, arg);
         }
 
         // get the result from the c++ object (candidateValue can be 0, it's cObj's responsibility to handle this if an error).
@@ -94,7 +94,7 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_ICalParameter_isa_1parameter(JNI
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalParameter_get_1language(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_language();
@@ -111,7 +111,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalParameter_get_1language(JNIEn
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1language(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -129,7 +129,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1language(JNIEnv *
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_get_1encoding(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_encoding();
@@ -145,7 +145,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_get_1encoding(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1encoding(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_encoding((icalparameter_encoding)value);
@@ -160,7 +160,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1encoding(JNIEnv *
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_get_1role(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_role();
@@ -176,7 +176,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_get_1role(JNIEnv *env,
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1role(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_role((icalparameter_role)value);
@@ -191,7 +191,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1role(JNIEnv *env,
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_get_1partstat(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_partstat();
@@ -207,7 +207,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalParameter_get_1partstat(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalParameter_set_1partstat(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalParameter *cObj = getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalParameter *cObj = (ICalParameter *)getSubjectAsICalParameter(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_partstat((icalparameter_partstat)value);

--- a/src/java/net_cp_jlibical_ICalProperty_cxx.cpp
+++ b/src/java/net_cp_jlibical_ICalProperty_cxx.cpp
@@ -33,7 +33,7 @@ using namespace LibICal;
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_as_1ical_1string(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->as_ical_string();
@@ -51,7 +51,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_as_1ical_1string(JNI
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_isa(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->isa();
@@ -68,13 +68,13 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_isa(JNIEnv *env, jobjec
 JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_ICalProperty_isa_1property(JNIEnv *env, jobject jobj, jobject arg)
 {
     jboolean result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         void *argObjPtr = 0;
 
         if (arg != NULL) {
-            argObjPtr = getCObjectPtr(env, arg);
+            argObjPtr = (void *)getCObjectPtr(env, arg);
         }
 
         // get the result from the c++ object (argObjPtr can be 0, it's cObj's responsibility to handle this if an error).
@@ -91,10 +91,10 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_ICalProperty_isa_1property(JNIEn
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_add_1parameter(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
-        ICalParameter *icalparameter = getSubjectAsICalParameter(env, arg, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        ICalParameter *icalparameter = (ICalParameter *)getSubjectAsICalParameter(env, arg, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
 
         if (icalparameter != NULL) {
             cObj->add_parameter(*icalparameter);
@@ -109,10 +109,10 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_add_1parameter(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1parameter(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
-        ICalParameter *icalparameter = getSubjectAsICalParameter(env, arg, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        ICalParameter *icalparameter = (ICalParameter *)getSubjectAsICalParameter(env, arg, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
 
         if (icalparameter != NULL) {
             cObj->set_parameter(*icalparameter);
@@ -127,7 +127,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1parameter(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1parameter_1from_1string(JNIEnv *env, jobject jobj, jstring name, jstring value)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szName = env->GetStringUTFChars(name, NULL);
@@ -147,7 +147,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1parameter_1from_1s
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1parameter_1as_1string(JNIEnv *env, jobject jobj, jstring name)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szName = env->GetStringUTFChars(name, NULL);
@@ -168,7 +168,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1parameter_1as_1
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_remove_1parameter_by_kind(JNIEnv *env, jobject jobj, jint kind)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->remove_parameter_by_kind((icalparameter_kind)kind);
@@ -183,7 +183,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_remove_1parameter_by_ki
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_count_1parameters(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->count_parameters();
@@ -200,7 +200,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_count_1parameters(JNIEn
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1first_1parameter(JNIEnv *env, jobject jobj, jint kind)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first parameter from CObj
@@ -221,7 +221,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1first_1paramete
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1next_1parameter(JNIEnv *env, jobject jobj, jint kind)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first parameter from CObj
@@ -241,10 +241,10 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1next_1parameter
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1value(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
-        ICalValue *aValue = getSubjectAsICalValue(env, arg, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        const ICalValue *aValue = getSubjectAsICalValue(env, arg, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
         cObj->set_value(*aValue);
     }
 }
@@ -256,7 +256,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1value(JNIEnv *env,
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1value_1from_1string(JNIEnv *env, jobject jobj, jstring name, jstring value)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szName = env->GetStringUTFChars(name, NULL);
@@ -276,7 +276,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1value_1from_1strin
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1value(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first value from CObj
@@ -297,7 +297,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1value(JNIEnv *e
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1value_1as_1string(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_value_as_string();
@@ -315,7 +315,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1value_1as_1stri
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1name(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_name();
@@ -332,7 +332,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1name(JNIEnv *en
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1action(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_action((icalproperty_action)value);
@@ -347,7 +347,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1action(JNIEnv *env
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1action(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_action();
@@ -363,7 +363,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1action(JNIEnv *env
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1attendee(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -381,7 +381,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1attendee(JNIEnv *e
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1attendee(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_attendee();
@@ -398,7 +398,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1attendee(JNIEnv
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1comment(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -416,7 +416,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1comment(JNIEnv *en
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1comment(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const std::string commentStr = cObj->get_comment();
@@ -432,7 +432,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1comment(JNIEnv 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1description(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -450,7 +450,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1description(JNIEnv
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1description(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_description();
@@ -467,7 +467,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1description(JNI
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1dtend(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aTime;
@@ -486,7 +486,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1dtend(JNIEnv *env,
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1dtend(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtend time from CObj
@@ -506,7 +506,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1dtend(JNIEnv *e
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1dtstamp(JNIEnv *env, jobject jobj, jobject dtstamp)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aDTStamp;
@@ -525,7 +525,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1dtstamp(JNIEnv *en
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1dtstamp(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtstamp time from CObj
@@ -545,7 +545,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1dtstamp(JNIEnv 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1dtstart(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aTime;
@@ -564,7 +564,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1dtstart(JNIEnv *en
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1dtstart(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtend time from CObj
@@ -584,7 +584,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1dtstart(JNIEnv 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1due(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aTime;
@@ -603,7 +603,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1due(JNIEnv *env, j
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1due(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtend time from CObj
@@ -623,7 +623,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1due(JNIEnv *env
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1duration(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaldurationtype aDuration;
@@ -642,7 +642,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1duration(JNIEnv *e
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1duration(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtend time from CObj
@@ -662,7 +662,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1duration(JNIEnv
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1location(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -680,7 +680,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1location(JNIEnv *e
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1location(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_location();
@@ -697,7 +697,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1location(JNIEnv
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1method(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_method((icalproperty_method)value);
@@ -712,7 +712,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1method(JNIEnv *env
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1method(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_method();
@@ -728,7 +728,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1method(JNIEnv *env
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1organizer(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -746,7 +746,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1organizer(JNIEnv *
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1organizer(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const std::string organizerStr = cObj->get_organizer();
@@ -762,7 +762,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1organizer(JNIEn
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1owner(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -780,7 +780,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1owner(JNIEnv *env,
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1owner(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_owner();
@@ -797,7 +797,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1owner(JNIEnv *e
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1prodid(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -815,7 +815,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1prodid(JNIEnv *env
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1prodid(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_prodid();
@@ -832,7 +832,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1prodid(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1query(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -850,7 +850,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1query(JNIEnv *env,
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1query(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_query();
@@ -867,7 +867,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1query(JNIEnv *e
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1queryname(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -885,7 +885,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1queryname(JNIEnv *
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1queryname(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_queryname();
@@ -902,7 +902,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1queryname(JNIEn
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1repeat(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_repeat(value);
@@ -917,7 +917,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1repeat(JNIEnv *env
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1repeat(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_repeat();
@@ -933,7 +933,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1repeat(JNIEnv *env
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1summary(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -951,7 +951,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1summary(JNIEnv *en
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1summary(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_summary();
@@ -968,7 +968,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1summary(JNIEnv 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1target(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -986,7 +986,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1target(JNIEnv *env
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1target(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_target();
@@ -1003,7 +1003,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1target(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1trigger(JNIEnv *env, jobject jobj, jobject arg)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltriggertype aTrigger;
@@ -1022,7 +1022,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1trigger(JNIEnv *en
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1trigger(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtend time from CObj
@@ -1042,7 +1042,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1trigger(JNIEnv 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1tzid(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -1060,7 +1060,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1tzid(JNIEnv *env, 
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1tzid(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_tzid();
@@ -1077,7 +1077,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1tzid(JNIEnv *en
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1uid(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -1095,7 +1095,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1uid(JNIEnv *env, j
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1uid(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_uid();
@@ -1150,7 +1150,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_init__I(JNIEnv *env, jo
 
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1status(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_status((icalproperty_status)value);
@@ -1165,7 +1165,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1status(JNIEnv *env
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1status(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_status();
@@ -1181,7 +1181,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalProperty_get_1status(JNIEnv *env
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1relcalid(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -1200,7 +1200,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1relcalid(JNIEnv *e
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1relcalid(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_relcalid();
@@ -1218,7 +1218,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalProperty_get_1relcalid(JNIEnv
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1exdate(JNIEnv *env, jobject jobj, jobject exdate)
 {
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aExDate;
@@ -1238,7 +1238,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1exdate(JNIEnv *
 {
     jobject result = 0;
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the exdate from CObj
@@ -1259,7 +1259,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1exdate(JNIEnv *
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1exrule(JNIEnv *env, jobject jobj, jobject exrule)
 {
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         auto aExRule = icalrecurrencetype_new();
         if (copyObjToicalrecurrencetype(env, exrule, aExRule)) {
@@ -1277,7 +1277,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1exrule(JNIEnv *
 {
     jobject result = 0;
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the exrule from CObj
@@ -1298,7 +1298,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1exrule(JNIEnv *
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1freebusy(JNIEnv *env, jobject jobj, jobject period)
 {
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icalperiodtype aPeriod;
@@ -1318,7 +1318,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1freebusy(JNIEnv
 {
     jobject result = 0;
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the period from CObj
@@ -1339,7 +1339,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1freebusy(JNIEnv
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1recurrenceid(JNIEnv *env, jobject jobj, jobject recurrenceid)
 {
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aRecurrenceId;
@@ -1359,7 +1359,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1recurrenceid(JN
 {
     jobject result = 0;
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the exdate from CObj
@@ -1380,7 +1380,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1recurrenceid(JN
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalProperty_set_1rrule(JNIEnv *env, jobject jobj, jobject rrule)
 {
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalProperty *cObj = (ICalProperty *)getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto aRRule = icalrecurrencetype_new();
@@ -1400,7 +1400,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalProperty_get_1rrule(JNIEnv *e
 {
     jobject result = 0;
     // get the ICalProperty c++ object from jobj
-    ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalProperty *cObj = getSubjectAsICalProperty(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the rrule from CObj

--- a/src/java/net_cp_jlibical_ICalValue_cxx.cpp
+++ b/src/java/net_cp_jlibical_ICalValue_cxx.cpp
@@ -33,10 +33,10 @@ using namespace LibICal;
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalValue_as_1ical_1string(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
-        auto icalStr = cObj->as_ical_string();
+        const std::string icalStr = cObj->as_ical_string();
         result = env->NewStringUTF(icalStr.empty() ? "" : icalStr.c_str());
     }
 
@@ -51,7 +51,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalValue_as_1ical_1string(JNIEnv
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalValue_isa(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->isa();
@@ -70,13 +70,13 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_ICalValue_isa_1value(JNIEnv *env
     jboolean result = 0;
 
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         // get the c++ object from arg
         void *argObjPtr = 0;
 
         if (arg != NULL) {
-            argObjPtr = getCObjectPtr(env, jobj);
+            argObjPtr = (void *)getCObjectPtr(env, jobj);
         }
 
         // get the result from the c++ object
@@ -94,7 +94,7 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_ICalValue_isa_1value(JNIEnv *env
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1trigger(JNIEnv *env, jobject jobj, jobject arg)
 {
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         icaltriggertype aTrigger;
 
@@ -114,7 +114,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalValue_get_1trigger(JNIEnv *en
     jobject result = 0;
 
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the trigger from CObj
@@ -135,7 +135,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalValue_get_1trigger(JNIEnv *en
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalValue_get_1method(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_method();
@@ -151,7 +151,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalValue_get_1method(JNIEnv *env, j
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1method(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_method((icalproperty_method)value);
@@ -166,7 +166,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1method(JNIEnv *env, j
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalValue_get_1text(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_text();
@@ -183,7 +183,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalValue_get_1text(JNIEnv *env, 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1text(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -203,7 +203,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalValue_get_1duration(JNIEnv *e
     jobject result = 0;
 
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the duration from CObj
@@ -224,7 +224,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalValue_get_1duration(JNIEnv *e
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1duration(JNIEnv *env, jobject jobj, jobject arg)
 {
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaldurationtype aDuration;
@@ -243,7 +243,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1duration(JNIEnv *env,
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalValue_get_1query(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_query();
@@ -260,7 +260,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_ICalValue_get_1query(JNIEnv *env,
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1query(JNIEnv *env, jobject jobj, jstring str)
 {
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -280,7 +280,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalValue_get_1datetime(JNIEnv *e
     jobject result = NULL;
 
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aTime = cObj->get_datetime();
@@ -298,7 +298,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_ICalValue_get_1datetime(JNIEnv *e
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1datetime(JNIEnv *env, jobject jobj, jobject arg)
 {
     // get the c++ object from the jobj
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aTime;
@@ -317,7 +317,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1datetime(JNIEnv *env,
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalValue_get_1action(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_action();
@@ -333,7 +333,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_ICalValue_get_1action(JNIEnv *env, j
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_ICalValue_set_1action(JNIEnv *env, jobject jobj, jint value)
 {
-    ICalValue *cObj = getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    ICalValue *cObj = (ICalValue *)getSubjectAsICalValue(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_action((icalproperty_action)value);

--- a/src/java/net_cp_jlibical_VComponent_cxx.cpp
+++ b/src/java/net_cp_jlibical_VComponent_cxx.cpp
@@ -38,7 +38,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_as_1ical_1string(JNIEn
 {
     jstring result = NULL;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->as_ical_string();
@@ -57,7 +57,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_VComponent_isa(JNIEnv *env, jobject 
 {
     jint result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->isa();
@@ -76,13 +76,13 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_VComponent_isa_1component(JNIEnv
     jboolean result = 0;
 
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         void *candidateValue = 0;
 
         if (candidateObj != NULL) {
             // get the c++ object from candidateObj (as long)
-            candidateValue = getCObjectPtr(env, candidateObj);
+            candidateValue = (void *)getCObjectPtr(env, candidateObj);
         }
 
         // get the result from the c++ object (candidateValue can be 0, it's cObj's responsibility to handle this if an error).
@@ -100,13 +100,13 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_VComponent_isa_1component(JNIEnv
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_add_1property(JNIEnv *env, jobject jobj, jobject jprop)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         // get the ICalProperty c++ object from jprop
-        ICalProperty *icalProperty = getSubjectAsICalProperty(env, jprop, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        const ICalProperty *icalProperty = getSubjectAsICalProperty(env, jprop, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
 
         if (icalProperty != NULL) {
-            cObj->add_property(icalProperty);
+            cObj->add_property((ICalProperty *)icalProperty);
         }
     }
 }
@@ -119,13 +119,13 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_add_1property(JNIEnv *env
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_remove_1property(JNIEnv *env, jobject jobj, jobject jprop)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         // get the ICalProperty c++ object from jprop
-        ICalProperty *icalProperty = getSubjectAsICalProperty(env, jprop, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        const ICalProperty *icalProperty = getSubjectAsICalProperty(env, jprop, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
 
         if (icalProperty != NULL) {
-            cObj->remove_property(icalProperty);
+            cObj->remove_property((ICalProperty *)icalProperty);
         }
     }
 }
@@ -140,7 +140,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_VComponent_count_1properties(JNIEnv 
     jint result = 0;
 
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         result = cObj->count_properties((icalproperty_kind)kind);
     }
@@ -157,7 +157,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1current_1property
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the current property from CObj
@@ -179,7 +179,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1first_1property(J
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first property from CObj
@@ -200,7 +200,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1first_1property(J
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1next_1property(JNIEnv *env, jobject jobj, jint kind)
 {
     jobject result = 0;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the next property from CObj
@@ -221,7 +221,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1next_1property(JN
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1inner(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the next property from CObj
@@ -242,10 +242,10 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1inner(JNIEnv *env
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_add_1component(JNIEnv *env, jobject jobj, jobject jcomp)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         // get the VComponent c++ object from jcomp
-        VComponent *aComponent = getSubjectAsVComponent(env, jcomp, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        VComponent *aComponent = (VComponent *)getSubjectAsVComponent(env, jcomp, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
 
         if (aComponent != NULL) {
             cObj->add_component(aComponent);
@@ -261,10 +261,10 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_add_1component(JNIEnv *en
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_remove_1component(JNIEnv *env, jobject jobj, jobject jcomp)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         // get the VComponent c++ object from jcomp
-        VComponent *aComponent = getSubjectAsVComponent(env, jcomp, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
+        VComponent *aComponent = (VComponent *)getSubjectAsVComponent(env, jcomp, JLIBICAL_ERR_ILLEGAL_ARGUMENT);
 
         if (aComponent != NULL) {
             cObj->remove_component(aComponent);
@@ -282,7 +282,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_VComponent_count_1components(JNIEnv 
     jint result = 0;
 
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
         result = cObj->count_components((icalcomponent_kind)kind);
     }
@@ -298,7 +298,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_VComponent_count_1components(JNIEnv 
 JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1current_1component(JNIEnv *env, jobject jobj)
 {
     jobject result = 0;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the next property from CObj
@@ -320,7 +320,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1first_1component(
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first component from CObj
@@ -342,7 +342,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1next_1component(J
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first component from CObj
@@ -364,7 +364,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1dtstart(JNIEnv *e
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtstart time from CObj
@@ -385,7 +385,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1dtstart(JNIEnv *e
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1dtstart(JNIEnv *env, jobject jobj, jobject dtstart)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aStartTime;
@@ -405,7 +405,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1dtend(JNIEnv *env
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the dtend time from CObj
@@ -426,7 +426,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1dtend(JNIEnv *env
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1dtend(JNIEnv *env, jobject jobj, jobject dtend)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype anEndTime;
@@ -446,7 +446,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1duration(JNIEnv *
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the duration time from CObj
@@ -467,7 +467,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1duration(JNIEnv *
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1duration(JNIEnv *env, jobject jobj, jobject duration)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaldurationtype aDuration;
@@ -486,7 +486,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1duration(JNIEnv *env
 JNIEXPORT jint JNICALL Java_net_cp_jlibical_VComponent_get_1method(JNIEnv *env, jobject jobj)
 {
     jint result = 0;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         result = cObj->get_method();
@@ -502,7 +502,7 @@ JNIEXPORT jint JNICALL Java_net_cp_jlibical_VComponent_get_1method(JNIEnv *env, 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1method(JNIEnv *env, jobject jobj, jint value)
 {
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         cObj->set_method((icalproperty_method)value);
@@ -517,7 +517,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1method(JNIEnv *env, 
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1summary(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_summary();
@@ -534,7 +534,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1summary(JNIEnv *e
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1summary(JNIEnv *env, jobject jobj, jstring str)
 {
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -553,7 +553,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1dtstamp(JNIEnv *e
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the recurrenceid from CObj
@@ -574,7 +574,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1dtstamp(JNIEnv *e
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1dtstamp(JNIEnv *env, jobject jobj, jobject dtstamp)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aDTStamp;
@@ -593,7 +593,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1dtstamp(JNIEnv *env,
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1location(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_location();
@@ -610,7 +610,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1location(JNIEnv *
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1location(JNIEnv *env, jobject jobj, jstring str)
 {
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -628,7 +628,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1location(JNIEnv *env
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1description(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_description();
@@ -645,7 +645,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1description(JNIEn
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1description(JNIEnv *env, jobject jobj, jstring str)
 {
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto szTemp = env->GetStringUTFChars(str, NULL);
@@ -662,7 +662,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1description(JNIEnv *
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1uid(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_uid();
@@ -679,7 +679,7 @@ JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1uid(JNIEnv *env, 
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1uid(JNIEnv *env, jobject jobj, jstring str)
 {
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -698,7 +698,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1first_1real_1comp
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the first component from CObj
@@ -755,7 +755,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_init__I(JNIEnv *env, jobj
  */
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1relcalid(JNIEnv *env, jobject jobj, jstring str)
 {
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         const char *szTemp = env->GetStringUTFChars(str, NULL);
@@ -773,7 +773,7 @@ JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1relcalid(JNIEnv *env
 JNIEXPORT jstring JNICALL Java_net_cp_jlibical_VComponent_get_1relcalid(JNIEnv *env, jobject jobj)
 {
     jstring result = NULL;
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         auto icalStr = cObj->get_relcalid();
@@ -792,7 +792,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1recurrenceid(JNIE
 {
     jobject result = 0;
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    const VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         // get the recurrenceid from CObj
@@ -813,7 +813,7 @@ JNIEXPORT jobject JNICALL Java_net_cp_jlibical_VComponent_get_1recurrenceid(JNIE
 JNIEXPORT void JNICALL Java_net_cp_jlibical_VComponent_set_1recurrenceid(JNIEnv *env, jobject jobj, jobject recurrenceid)
 {
     // get the VComponent c++ object from jobj
-    VComponent *cObj = getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
+    VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
 
     if (cObj != NULL) {
         icaltimetype aRecurrenceId;

--- a/src/libical/icalparameter_cxx.cpp
+++ b/src/libical/icalparameter_cxx.cpp
@@ -83,7 +83,7 @@ ICalParameter::ICalParameter(const icalparameter_kind &kind)
 
 std::string ICalParameter::as_ical_string()
 {
-    char *str = icalparameter_as_ical_string(imp);
+    const char *str = icalparameter_as_ical_string(imp);
 
     if (str == NULL) {
         throw icalerrno;

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -100,7 +100,7 @@ VComponent::VComponent(const icalcomponent_kind &kind)
 
 std::string VComponent::as_ical_string()
 {
-    char *str = icalcomponent_as_ical_string(imp);
+    const char *str = icalcomponent_as_ical_string(imp);
 
     if (str == NULL) {
         throw icalerrno;
@@ -207,7 +207,7 @@ VComponent *VComponent::get_current_component()
 
 VComponent *VComponent::get_first_component(const icalcomponent_kind &kind)
 {
-    VComponent *result = NULL;
+    VComponent *result = NULL; // NOLINT(misc-const-correctness)
     icalcomponent *t = icalcomponent_get_first_component(imp, kind);
     if (t != NULL) {
         switch (kind) {
@@ -239,7 +239,7 @@ VComponent *VComponent::get_first_component(const icalcomponent_kind &kind)
 
 VComponent *VComponent::get_next_component(const icalcomponent_kind &kind)
 {
-    VComponent *result = NULL;
+    VComponent *result = NULL; // NOLINT(misc-const-correctness)
     icalcomponent *t = icalcomponent_get_next_component(imp, kind);
     if (t != NULL) {
         switch (kind) {
@@ -577,8 +577,8 @@ bool VComponent::update(VComponent &fromC, bool removeMissing)
             thisProp = new ICalProperty(prop->isa());
             this->add_property(thisProp);
         }
-        ICalValue *tempValue = prop->get_value();
-        ICalValue *value = new ICalValue(*tempValue); // clone the value
+        const ICalValue *tempValue = prop->get_value();
+        const ICalValue *value = new ICalValue(*tempValue); // clone the value
         thisProp->set_value(*value);
         delete tempValue;
         delete value;


### PR DESCRIPTION
mostly in the java source