### PR TITLE
icalparser.c - limit iterations in in icalparser_parse

### DIFF
--- a/scripts/buildtests.sh
+++ b/scripts/buildtests.sh
@@ -312,9 +312,13 @@ ASAN_BUILD() {
   echo "===== START ASAN BUILD: $1 ======"
   FILEPATTERN_EXISTS "/usr/lib64/libasan.so" "-a"
   SET_GCC
+  ulimit -S -t 60      # oss-fuzz uses 60 seconds
+  ulimit -S -m 2621440 # oss-fuzz uses 2560Mb (many systems do not honor this limit)
   #asan also does leak detection. do that in the specific leak sanitizer
   export ASAN_OPTIONS="detect_leaks=0:verify_asan_link_order=0" #link_order is needed with different ld on Fedora (like gold)
   BUILD "$name" "-DLIBICAL_DEVMODE_ADDRESS_SANITIZER=True $2"
+  ulimit -S -t unlimited
+  ulimit -S -m unlimited
   echo "===== END ASAN BUILD: $1 ======"
 }
 #function LSAN_BUILD:
@@ -380,8 +384,8 @@ UBSAN_BUILD() {
   echo "===== START UBSAN BUILD: $1 ======"
   FILEPATTERN_EXISTS "/usr/lib64/libubsan.so" "-a"
   SET_GCC
-  ulimit -S -t 180     # oss-fuzz uses 60 seconds which is too low for us
-  ulimit -S -m 2621440 # oss-fuzz uses 2560Mb
+  ulimit -S -t 60      # oss-fuzz uses 60 seconds
+  ulimit -S -m 2621440 # oss-fuzz uses 2560Mb (many systems do not honor this limit)
   export UBSAN_OPTIONS=allocator_release_to_os_interval_ms=500:halt_on_error=1:handle_abort=2:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:handle_sigill=2:print_stacktrace=1:print_summary=1:print_suppressions=0:silence_unsigned_overflow=1:symbolize=1:use_sigaltstack=1
   export CFLAGS="-g -fno-omit-frame-pointer"
   BUILD "$name" "-DLIBICAL_DEVMODE_UNDEFINED_SANITIZER=True $2"

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -586,12 +586,13 @@ icalcomponent *icalparser_parse(icalparser *parser,
     icalcomponent *c;
     icalcomponent *root = 0;
     icalerrorstate es = icalerror_get_error_state(ICAL_MALFORMEDDATA_ERROR);
-    int cont;
+    bool cont = false;
 
     icalerror_check_arg_rz((parser != 0), "parser");
 
     icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, ICAL_ERROR_NONFATAL);
 
+    size_t bad_lines = 0;
     do {
         line = icalparser_get_line(parser, line_gen_func);
 
@@ -623,13 +624,15 @@ icalcomponent *icalparser_parse(icalparser *parser,
                 /* Badness */
                 icalassert(0);
             }
+        } else {
+            bad_lines++; // track the number of possibly bogus data lines
         }
-        cont = 0;
+        cont = false;
         if (line != 0) {
             icalmemory_free_buffer(line);
-            cont = 1;
+            cont = true;
         }
-    } while (cont);
+    } while (cont && bad_lines < 10000); // limit the number of possibly bogus data lines
 
     icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, es);
 


### PR DESCRIPTION
In the case of fuzzy data with a lot of bad lines (END before BEGIN) we limit the number of iterations in the icalparser_get_line() loop to keep the cpu time down.

This is mostly about keeping the fuzzer cpu limit happy.

For example: https://oss-fuzz.com/testcase-detail/5202939296153600