### PR TITLE
src/test/regression.c - remove the NO_DEPRECATION_WARNINGS setting

### DIFF
--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -11,7 +11,6 @@
 //Don't care about insecureAPI.strcpy issues in this test program
 //NOLINTBEGIN(clang-analyzer-security.insecureAPI.strcpy)
 
-#define NO_DEPRECATION_WARNINGS // do not complain about our own deprecated usage
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif


### PR DESCRIPTION
In master, we do want to know if our test program is using any deprecated function calls.