### PR TITLE
Rename C++ headers to have the .hpp extension

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -7,27 +7,27 @@ include(UseJava)
 
 set(
   ical_jni_LIB_SRCS
-  jlibical_consts_cxx.h
+  jlibical_consts_cxx.hpp
   jlibical_utils_cxx.cpp
-  jlibical_utils_cxx.h
+  jlibical_utils_cxx.hpp
   jniICalDurationType_cxx.cpp
-  jniICalDurationType_cxx.h
+  jniICalDurationType_cxx.hpp
   jniICalPeriodType_cxx.cpp
-  jniICalPeriodType_cxx.h
+  jniICalPeriodType_cxx.hpp
   jniICalRecurrenceType_cxx.cpp
-  jniICalRecurrenceType_cxx.h
+  jniICalRecurrenceType_cxx.hpp
   jniICalTimeType_cxx.cpp
-  jniICalTimeType_cxx.h
+  jniICalTimeType_cxx.hpp
   jniICalTriggerType_cxx.cpp
-  jniICalTriggerType_cxx.h
+  jniICalTriggerType_cxx.hpp
   net_cp_jlibical_ICalParameter_cxx.cpp
-  net_cp_jlibical_ICalParameter_cxx.h
+  net_cp_jlibical_ICalParameter_cxx.hpp
   net_cp_jlibical_ICalProperty_cxx.cpp
-  net_cp_jlibical_ICalProperty_cxx.h
+  net_cp_jlibical_ICalProperty_cxx.hpp
   net_cp_jlibical_ICalValue_cxx.cpp
-  net_cp_jlibical_ICalValue_cxx.h
+  net_cp_jlibical_ICalValue_cxx.hpp
   net_cp_jlibical_VComponent_cxx.cpp
-  net_cp_jlibical_VComponent_cxx.h
+  net_cp_jlibical_VComponent_cxx.hpp
 )
 
 add_library(

--- a/src/java/jlibical_consts_cxx.hpp
+++ b/src/java/jlibical_consts_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jlibical_consts_cxx.h
+ FILE: jlibical_consts_cxx.hpp
  CREATOR: Srinivasa Boppana/George Norman
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/jlibical_utils_cxx.cpp
+++ b/src/java/jlibical_utils_cxx.cpp
@@ -9,47 +9,47 @@
 ======================================================================*/
 
 #ifndef JLIBICAL_UTILS_CXX_H
-#include "jlibical_utils_cxx.h"
+#include "jlibical_utils_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_CONSTS_CXX_H
-#include "jlibical_consts_cxx.h"
+#include "jlibical_consts_cxx.hpp"
 #endif
 
 #ifndef ICALPARAMETER_CXX_H
-#include "icalparameter_cxx.h"
+#include "icalparameter_cxx.hpp"
 #endif
 
 #ifndef VCOMPONENT_CXX_H
-#include "vcomponent_cxx.h"
+#include "vcomponent_cxx.hpp"
 #endif
 
 #ifndef ICALPROPERTY_CXX_H
-#include "icalproperty_cxx.h"
+#include "icalproperty_cxx.hpp"
 #endif
 
 #ifndef ICALVALUE_CXX_H
-#include "icalvalue_cxx.h"
+#include "icalvalue_cxx.hpp"
 #endif
 
 #ifndef _jni_ICalTimeType_H
-#include "jniICalTimeType_cxx.h"
+#include "jniICalTimeType_cxx.hpp"
 #endif
 
 #ifndef _jni_ICalTriggerType_H
-#include "jniICalTriggerType_cxx.h"
+#include "jniICalTriggerType_cxx.hpp"
 #endif
 
 #ifndef _jni_ICalDurationType_H
-#include "jniICalDurationType_cxx.h"
+#include "jniICalDurationType_cxx.hpp"
 #endif
 
 #ifndef _jni_ICalRecurrenceType_H
-#include "jniICalRecurrenceType_cxx.h"
+#include "jniICalRecurrenceType_cxx.hpp"
 #endif
 
 #ifndef _jni_ICalPeriodType_H
-#include "jniICalPeriodType_cxx.h"
+#include "jniICalPeriodType_cxx.hpp"
 #endif
 
 using namespace LibICal;

--- a/src/java/jlibical_utils_cxx.hpp
+++ b/src/java/jlibical_utils_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jlibical_utils_cxx.h
+ FILE: jlibical_utils_cxx.hpp
  CREATOR: Srinivasa Boppana/George Norman
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/jniICalDurationType_cxx.cpp
+++ b/src/java/jniICalDurationType_cxx.cpp
@@ -9,7 +9,7 @@
 
 #include <jni.h>
 
-#include "jniICalDurationType_cxx.h"
+#include "jniICalDurationType_cxx.hpp"
 
 static jfieldID ICalDurationType_Is_neg_FID;
 static jfieldID ICalDurationType_Days_FID;

--- a/src/java/jniICalDurationType_cxx.hpp
+++ b/src/java/jniICalDurationType_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jniICalDurationType_cxx.h
+ FILE: jniICalDurationType_cxx.hpp
  CREATOR: structConverter
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/jniICalPeriodType_cxx.cpp
+++ b/src/java/jniICalPeriodType_cxx.cpp
@@ -10,9 +10,9 @@
 ======================================================================*/
 #include <jni.h>
 
-#include "jniICalPeriodType_cxx.h"
-#include "jniICalTimeType_cxx.h"
-#include "jniICalDurationType_cxx.h"
+#include "jniICalPeriodType_cxx.hpp"
+#include "jniICalTimeType_cxx.hpp"
+#include "jniICalDurationType_cxx.hpp"
 
 static jfieldID ICalPeriodType_Start_FID;
 static jfieldID ICalPeriodType_End_FID;

--- a/src/java/jniICalPeriodType_cxx.hpp
+++ b/src/java/jniICalPeriodType_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jniICalPeriodType_cxx.h
+ FILE: jniICalPeriodType_cxx.hpp
  CREATOR: structConverter
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/jniICalRecurrenceType_cxx.cpp
+++ b/src/java/jniICalRecurrenceType_cxx.cpp
@@ -7,8 +7,8 @@
 
 #include <jni.h>
 
-#include "jniICalRecurrenceType_cxx.h"
-#include "jniICalTimeType_cxx.h"
+#include "jniICalRecurrenceType_cxx.hpp"
+#include "jniICalTimeType_cxx.hpp"
 
 static jfieldID ICalRecurrenceType_Until_FID;
 static jfieldID ICalRecurrenceType_Freq_FID;

--- a/src/java/jniICalRecurrenceType_cxx.hpp
+++ b/src/java/jniICalRecurrenceType_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jniICalRecurrenceType_cxx.h
+ FILE: jniICalRecurrenceType_cxx.hpp
  CREATOR: structConverter
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/jniICalTimeType_cxx.cpp
+++ b/src/java/jniICalTimeType_cxx.cpp
@@ -10,7 +10,7 @@
 #include <jni.h>
 
 #ifndef _jni_ICalTimeType_H
-#include "jniICalTimeType_cxx.h"
+#include "jniICalTimeType_cxx.hpp"
 #endif
 
 static jfieldID ICalTimeType_Year_FID;

--- a/src/java/jniICalTimeType_cxx.hpp
+++ b/src/java/jniICalTimeType_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jniICalTimeType_cxx.h
+ FILE: jniICalTimeType_cxx.hpp
  CREATOR: structConverter
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/jniICalTriggerType_cxx.cpp
+++ b/src/java/jniICalTriggerType_cxx.cpp
@@ -9,9 +9,9 @@
 ======================================================================*/
 #include <jni.h>
 
-#include "jniICalTriggerType_cxx.h"
-#include "jniICalTimeType_cxx.h"
-#include "jniICalDurationType_cxx.h"
+#include "jniICalTriggerType_cxx.hpp"
+#include "jniICalTimeType_cxx.hpp"
+#include "jniICalDurationType_cxx.hpp"
 
 static jfieldID ICalTriggerType_Time_FID;
 static jfieldID ICalTriggerType_Duration_FID;

--- a/src/java/jniICalTriggerType_cxx.hpp
+++ b/src/java/jniICalTriggerType_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: jniICalTriggerType_cxx.h
+ FILE: jniICalTriggerType_cxx.hpp
  CREATOR: structConverter
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/net_cp_jlibical_ICalParameter_cxx.cpp
+++ b/src/java/net_cp_jlibical_ICalParameter_cxx.cpp
@@ -8,19 +8,19 @@
 ======================================================================*/
 
 #ifndef NET_CP_JLIBICAL_ICALPARAMETER_CXX_H
-#include "net_cp_jlibical_ICalParameter_cxx.h"
+#include "net_cp_jlibical_ICalParameter_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_CONSTS_CXX_H
-#include "jlibical_consts_cxx.h"
+#include "jlibical_consts_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_UTILS_CXX_H
-#include "jlibical_utils_cxx.h"
+#include "jlibical_utils_cxx.hpp"
 #endif
 
 #ifndef ICALPARAMETER_CXX_H
-#include "icalparameter_cxx.h"
+#include "icalparameter_cxx.hpp"
 #endif
 
 using namespace LibICal;

--- a/src/java/net_cp_jlibical_ICalParameter_cxx.hpp
+++ b/src/java/net_cp_jlibical_ICalParameter_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: net_cp_jlibical_ICalParameter_cxx.h
+ FILE: net_cp_jlibical_ICalParameter_cxx.hpp
  CREATOR: javah 1/11/02
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/net_cp_jlibical_ICalProperty_cxx.cpp
+++ b/src/java/net_cp_jlibical_ICalProperty_cxx.cpp
@@ -8,19 +8,19 @@
 ======================================================================*/
 
 #ifndef NET_CP_JLIBICAL_ICALPROPERTY_CXX_H
-#include "net_cp_jlibical_ICalProperty_cxx.h"
+#include "net_cp_jlibical_ICalProperty_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_CONSTS_CXX_H
-#include "jlibical_consts_cxx.h"
+#include "jlibical_consts_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_UTILS_CXX_H
-#include "jlibical_utils_cxx.h"
+#include "jlibical_utils_cxx.hpp"
 #endif
 
 #ifndef ICALPROPERTY_CXX_H
-#include "icalproperty_cxx.h"
+#include "icalproperty_cxx.hpp"
 #endif
 
 using namespace LibICal;

--- a/src/java/net_cp_jlibical_ICalProperty_cxx.hpp
+++ b/src/java/net_cp_jlibical_ICalProperty_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: net_cp_jlibical_ICalProperty_cxx.h
+ FILE: net_cp_jlibical_ICalProperty_cxx.hpp
  CREATOR: javah 1/11/02
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/net_cp_jlibical_ICalValue_cxx.cpp
+++ b/src/java/net_cp_jlibical_ICalValue_cxx.cpp
@@ -8,19 +8,19 @@
 ======================================================================*/
 
 #ifndef NET_CP_JLIBICAL_ICALVALUE_CXX_H
-#include "net_cp_jlibical_ICalValue_cxx.h"
+#include "net_cp_jlibical_ICalValue_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_CONSTS_CXX_H
-#include "jlibical_consts_cxx.h"
+#include "jlibical_consts_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_UTILS_CXX_H
-#include "jlibical_utils_cxx.h"
+#include "jlibical_utils_cxx.hpp"
 #endif
 
 #ifndef ICALVALUE_CXX_H
-#include "icalvalue_cxx.h"
+#include "icalvalue_cxx.hpp"
 #endif
 
 using namespace LibICal;

--- a/src/java/net_cp_jlibical_ICalValue_cxx.hpp
+++ b/src/java/net_cp_jlibical_ICalValue_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: net_cp_jlibical_ICalValue_cxx.h
+ FILE: net_cp_jlibical_ICalValue_cxx.hpp
  CREATOR: javah 1/11/02
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/java/net_cp_jlibical_VComponent_cxx.cpp
+++ b/src/java/net_cp_jlibical_VComponent_cxx.cpp
@@ -8,23 +8,23 @@
 ======================================================================*/
 
 #ifndef NET_CP_JLIBICAL_VCOMPONENT_CXX_H
-#include "net_cp_jlibical_VComponent_cxx.h"
+#include "net_cp_jlibical_VComponent_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_CONSTS_CXX_H
-#include "jlibical_consts_cxx.h"
+#include "jlibical_consts_cxx.hpp"
 #endif
 
 #ifndef JLIBICAL_UTILS_CXX_H
-#include "jlibical_utils_cxx.h"
+#include "jlibical_utils_cxx.hpp"
 #endif
 
 #ifndef VCOMPONENT_CXX_H
-#include "vcomponent_cxx.h"
+#include "vcomponent_cxx.hpp"
 #endif
 
 #ifndef ICALPROPERTY_CXX_H
-#include "icalproperty_cxx.h"
+#include "icalproperty_cxx.hpp"
 #endif
 
 using namespace LibICal;

--- a/src/java/net_cp_jlibical_VComponent_cxx.hpp
+++ b/src/java/net_cp_jlibical_VComponent_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: net_cp_jlibical_VComponent_cxx.h
+ FILE: net_cp_jlibical_VComponent_cxx.hpp
  CREATOR: javah 1/11/02
 
  SPDX-FileCopyrightText: 2002, Critical Path

--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -336,14 +336,14 @@ if(LIBICAL_CXX_BINDINGS)
   set(
     icalcxx_LIB_SRCS
     icalparameter_cxx.cpp
-    icalparameter_cxx.h
+    icalparameter_cxx.hpp
     icalproperty_cxx.cpp
-    icalproperty_cxx.h
+    icalproperty_cxx.hpp
     icalvalue_cxx.cpp
-    icalvalue_cxx.h
-    icptrholder_cxx.h
+    icalvalue_cxx.hpp
+    icptrholder_cxx.hpp
     vcomponent_cxx.cpp
-    vcomponent_cxx.h
+    vcomponent_cxx.hpp
   )
 
   add_definitions(-DBUILD_LIBICALDLL)
@@ -428,11 +428,11 @@ install(
 if(LIBICAL_CXX_BINDINGS)
   install(
     FILES
-      icalparameter_cxx.h
-      icalproperty_cxx.h
-      icalvalue_cxx.h
-      icptrholder_cxx.h
-      vcomponent_cxx.h
+      icalparameter_cxx.hpp
+      icalproperty_cxx.hpp
+      icalvalue_cxx.hpp
+      icptrholder_cxx.hpp
+      vcomponent_cxx.hpp
     DESTINATION ${INCLUDE_INSTALL_DIR}/libical
   )
 endif()

--- a/src/libical/icalparameter_cxx.cpp
+++ b/src/libical/icalparameter_cxx.cpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
  */
 
-#include "icalparameter_cxx.h"
+#include "icalparameter_cxx.hpp"
 using namespace LibICal;
 
 ICalParameter::ICalParameter()

--- a/src/libical/icalparameter_cxx.hpp
+++ b/src/libical/icalparameter_cxx.hpp
@@ -1,5 +1,5 @@
 /**
- * @file    icalparameter_cxx.h
+ * @file    icalparameter_cxx.hpp
  * @author  fnguyen (12/10/01)
  * @brief   Definition of C++ Wrapper for icalparameter.c
  *
@@ -11,7 +11,7 @@
 #define ICALPARAMETER_CXX_H
 
 #include "libical_ical_export.h"
-#include "icptrholder_cxx.h"
+#include "icptrholder_cxx.hpp"
 
 extern "C" {
 #include "icalerror.h"

--- a/src/libical/icalproperty_cxx.cpp
+++ b/src/libical/icalproperty_cxx.cpp
@@ -7,9 +7,9 @@
  * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
  */
 
-#include "icalproperty_cxx.h"
-#include "icalparameter_cxx.h"
-#include "icalvalue_cxx.h"
+#include "icalproperty_cxx.hpp"
+#include "icalparameter_cxx.hpp"
+#include "icalvalue_cxx.hpp"
 using namespace LibICal;
 
 ICalProperty::ICalProperty()

--- a/src/libical/icalproperty_cxx.hpp
+++ b/src/libical/icalproperty_cxx.hpp
@@ -1,5 +1,5 @@
 /**
- * @file    icalproperty_cxx.h
+ * @file    icalproperty_cxx.hpp
  * @author  fnguyen (12/10/01)
  * @brief   Definition of C++ Wrapper for icalproperty.c
  *
@@ -11,7 +11,7 @@
 #define ICALPROPERTY_CXX_H
 
 #include "libical_ical_export.h"
-#include "icptrholder_cxx.h"
+#include "icptrholder_cxx.hpp"
 
 extern "C" {
 #include "icalerror.h"

--- a/src/libical/icalvalue_cxx.cpp
+++ b/src/libical/icalvalue_cxx.cpp
@@ -10,7 +10,7 @@
 #include <config.h>
 #endif
 
-#include "icalvalue_cxx.h"
+#include "icalvalue_cxx.hpp"
 using namespace LibICal;
 
 ICalValue::ICalValue()

--- a/src/libical/icalvalue_cxx.hpp
+++ b/src/libical/icalvalue_cxx.hpp
@@ -1,5 +1,5 @@
 /*======================================================================
- FILE: icalvalue_cxx.h
+ FILE: icalvalue_cxx.hpp
  CREATOR: fnguyen 12/13/01
 
  SPDX-FileCopyrightText: 2001, Critical Path
@@ -10,7 +10,7 @@
 #define ICALVALUE_CXX_H
 
 #include "libical_ical_export.h"
-#include "icptrholder_cxx.h"
+#include "icptrholder_cxx.hpp"
 
 extern "C" {
 #include "icalerror.h"

--- a/src/libical/icptrholder_cxx.hpp
+++ b/src/libical/icptrholder_cxx.hpp
@@ -1,5 +1,5 @@
 /**
- * @file    icptrholder_cxx.h
+ * @file    icptrholder_cxx.hpp
  * @author  wyau (08/29/02)
  * @brief   C++ template classes for managing C++ pointers returned by
  *          VComponent::get_..._component, VComponent::get_..._property,

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -11,10 +11,10 @@
 #include <config.h>
 #endif
 
-#include "vcomponent_cxx.h"
-#include "icalparameter_cxx.h"
-#include "icalproperty_cxx.h"
-#include "icalvalue_cxx.h"
+#include "vcomponent_cxx.hpp"
+#include "icalparameter_cxx.hpp"
+#include "icalproperty_cxx.hpp"
+#include "icalvalue_cxx.hpp"
 using namespace LibICal;
 
 extern "C" {

--- a/src/libical/vcomponent_cxx.hpp
+++ b/src/libical/vcomponent_cxx.hpp
@@ -1,5 +1,5 @@
 /**
- * @file    vcomponent_cxx.h
+ * @file    vcomponent_cxx.hpp
  * @author  fnguyen (12/10/01)
  * @brief   C++ classes for the icalcomponent wrapper (VToDo VEvent, etc..).
  *
@@ -11,7 +11,7 @@
 #define ICAL_VCOMPONENT_CXX_H
 
 #include "libical_ical_export.h"
-#include "icptrholder_cxx.h"
+#include "icptrholder_cxx.hpp"
 
 extern "C" {
 #include "icalerror.h"

--- a/src/libicalss/CMakeLists.txt
+++ b/src/libicalss/CMakeLists.txt
@@ -142,7 +142,7 @@ if(LIBICAL_CXX_BINDINGS)
   set(
     icalsscxx_LIB_SRCS
     icalspanlist_cxx.cpp
-    icalspanlist_cxx.h
+    icalspanlist_cxx.hpp
   )
   add_library(
     icalss_cxx
@@ -215,5 +215,5 @@ install(
 )
 
 if(LIBICAL_CXX_BINDINGS)
-  install(FILES icalspanlist_cxx.h DESTINATION ${INCLUDE_INSTALL_DIR}/libical)
+  install(FILES icalspanlist_cxx.hpp DESTINATION ${INCLUDE_INSTALL_DIR}/libical)
 endif()

--- a/src/libicalss/icalspanlist_cxx.cpp
+++ b/src/libicalss/icalspanlist_cxx.cpp
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 */
 
-#include "icalspanlist_cxx.h"
-#include "vcomponent_cxx.h"
+#include "icalspanlist_cxx.hpp"
+#include "vcomponent_cxx.hpp"
 
 #include <cstdlib> // for free()
 

--- a/src/libicalss/icalspanlist_cxx.hpp
+++ b/src/libicalss/icalspanlist_cxx.hpp
@@ -1,5 +1,5 @@
 /**
- * @file     icalspanlist_cxx.h
+ * @file     icalspanlist_cxx.hpp
  * @author   Critical Path
  * @brief    C++ class wrapping the icalspanlist data structure
  *

--- a/src/test/regression-cxx.cpp
+++ b/src/test/regression-cxx.cpp
@@ -12,8 +12,8 @@ extern "C" {
 #include "libical/icalparser.h"
 }
 
-#include "icalproperty_cxx.h"
-#include "vcomponent_cxx.h"
+#include "icalproperty_cxx.hpp"
+#include "vcomponent_cxx.hpp"
 using namespace LibICal;
 
 #include <string>


### PR DESCRIPTION
Rename the C++ include files with the .hpp rather than .h extension. This helps tools (such as clangd) clearly identify the code as C++ rather than possibly confusing with C.