### PR TITLE
src/libical/icalproperty_cxx.h - remove unused function def

### DIFF
--- a/src/libical/icalproperty_cxx.h
+++ b/src/libical/icalproperty_cxx.h
@@ -37,7 +37,6 @@ public:
     explicit ICalProperty(icalproperty *v);
     explicit ICalProperty(const std::string &str);
     explicit ICalProperty(icalproperty_kind kind);
-    ICalProperty(icalproperty_kind kind, std::string str);
 
     operator icalproperty *()
     {


### PR DESCRIPTION
remove definition ICalProperty(icalproperty_kind kind, std::string str) as it isn't used anywhere.

(found in mcrha's todo cleaning patch)