### PR TITLE
icalparser.c - remove spurious icalvalue_new_From_string_with_error()

### DIFF
--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -124,9 +124,6 @@ void icalparser_set_gen_data(icalparser *parser, void *data)
     parser->line_gen_data = data;
 }
 
-icalvalue *icalvalue_new_From_string_with_error(icalvalue_kind kind,
-                                                char *str, icalproperty **error);
-
 static char *parser_get_next_char(char c, char *str, int qm)
 {
     int quote_mode = 0;


### PR DESCRIPTION
looks like I added this 10 years ago for some unknown reason. it doesn't do anything and it was never included in any header. shrug.

e Please enter the commit message for your changes. Lines starting