### PR TITLE
Use the CMake variable CMAKE_C_BYTE_ORDER to detect ENDIANness

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -225,6 +225,10 @@ endif()
 
 include(CheckTypeSize)
 check_type_size(
+  int
+  SIZEOF_INT
+)
+check_type_size(
   intptr_t
   SIZEOF_INTPTR_T
 )
@@ -290,3 +294,12 @@ check_include_files(
   "pthread.h;pthread_np.h"
   HAVE_PTHREAD_NP_H
 )
+
+if(CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+  set(HAVE_WORDS_BIGENDIAN TRUE)
+elseif(CMAKE_C_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
+  set(HAVE_WORDS_BIGENDIAN FALSE)
+else()
+  set(HAVE_WORDS_BIGENDIAN FALSE)
+  message(WARNING "Endianness could not be determined.")
+endif()

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -194,6 +194,9 @@ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 /* whether we should bring our own TZ-Data */
 #cmakedefine USE_BUILTIN_TZDATA
 
+/* whether this is a big-endian system. */
+#cmakedefine HAVE_WORDS_BIGENDIAN
+
 /* Define to empty if `const' does not conform to ANSI C. */
 #cmakedefine const
 
@@ -233,6 +236,7 @@ typedef unsigned int wint_t;
 #endif
 #endif
 
+#cmakedefine SIZEOF_INT ${SIZEOF_INT}
 #cmakedefine SIZEOF_TIME_T ${SIZEOF_TIME_T}
 #cmakedefine SIZEOF_ICALTIME_T ${SIZEOF_ICALTIME_T}
 

--- a/src/libical/icaltimezone_p.c
+++ b/src/libical/icaltimezone_p.c
@@ -114,42 +114,35 @@ typedef struct
 
 static int decode(const void *ptr)
 {
-    // NOLINTBEGIN(misc-redundant-expression)
-    if ((BYTE_ORDER == BIG_ENDIAN) && sizeof(int) == 4) {
-        return *(const int *)ptr;
-    } else if (BYTE_ORDER == LITTLE_ENDIAN && sizeof(int) == 4) {
-#if !defined(__cppcheck__) && !defined(__clang_analyzer__) //core.CallAndMessage
-        /* stumped why cppcheck 2.16 has a syntax error on this line */
-        return (int)bswap_32(*(const unsigned int *)ptr);
+#if SIZEOF_INT == 4
+#if defined(HAVE_WORDS_BIGENDIAN)
+    return *(const int *)ptr;
 #else
-        return 1;
+    const unsigned int *p = (const unsigned int *)ptr;
+    return (int)bswap_32(*p);
 #endif
-        // NOLINTEND(misc-redundant-expression)
-    } else {
-        const unsigned char *p = ptr;
-        int result = (*p & (1 << (CHAR_BIT - 1))) ? ~0 : 0;
+#else
+    const unsigned char *p = ptr;
+    int result = (*p & (1 << (CHAR_BIT - 1))) ? ~0 : 0;
 
-        /* cppcheck-suppress shiftNegativeLHS */
-        result = (result << 8) | *p++;
-        result = (result << 8) | *p++;
-        result = (result << 8) | *p++;
-        result = (result << 8) | *p++;
+    /* cppcheck-suppress shiftNegativeLHS */
+    result = (result << 8) | *p++;
+    result = (result << 8) | *p++;
+    result = (result << 8) | *p++;
+    result = (result << 8) | *p++;
 
-        return result;
-    }
+    return result;
+#endif
 }
 
 static long long int decode64(const void *ptr)
 {
-    if ((BYTE_ORDER == BIG_ENDIAN)) {
-        return *(const long long int *)ptr;
-    } else {
-#if !defined(__clang_analyzer__) //core.CallAndMessage
-        return (const long long int)bswap_64(*(const unsigned long long int *)ptr);
+#if defined(HAVE_WORDS_BIGENDIAN)
+    return *(const long long int *)ptr;
 #else
-        return 0;
+    const unsigned long long int *p = (const unsigned long long int *)ptr;
+    return (long long int)bswap_64(*p);
 #endif
-    }
 }
 
 static char *zname_from_stridx(char *str, size_t len_str, size_t idx)


### PR DESCRIPTION
part of the fix to simplify the byte-swapping code in icaltimezone_p.c

GH:711