### PR TITLE
Build system - no need to check for stdbool.h

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -46,10 +46,6 @@ check_include_files(
   wctype.h
   HAVE_WCTYPE_H
 )
-check_include_files(
-  stdbool.h
-  HAVE_STDBOOL_H
-)
 
 include(CheckFunctionExists)
 if(WIN32 AND MSVC)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -38,9 +38,6 @@ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 /* Define to 1 if you have the <dirent.h> header file. */
 #cmakedefine HAVE_DIRENT_H 1
 
-/* Define to 1 if you have the <stdbool.h> header file. */
-#cmakedefine HAVE_STDBOOL_H 1
-
 /* Define if we have pthread. */
 #cmakedefine HAVE_PTHREAD_ATTR_GET_NP 1
 #cmakedefine HAVE_PTHREAD_GETATTR_NP 1

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -144,12 +144,7 @@ static ICAL_GLOBAL_VAR ical_invalid_rrule_handling invalidRruleHandling = ICAL_R
 #if defined(HAVE_LIBICU)
 #include <unicode/ucal.h>
 #include <unicode/ustring.h>
-#if defined(HAVE_STDBOOL_H)
 #include <stdbool.h>
-#else
-#define false 0
-#define true 1
-#endif
 #else
 
 /* The maximums below are based on Gregorian leap years */


### PR DESCRIPTION
we require C99 and therefore we must have stdbool.h