### PR TITLE
libical-glib: Preserve RRULE/EXRULE gettes behaviour with 3.x

### DIFF
--- a/src/libical-glib/api/i-cal-recurrence.xml
+++ b/src/libical-glib/api/i-cal-recurrence.xml
@@ -6,7 +6,7 @@
 
 
 -->
-<structure namespace="ICal" name="Recurrence" native="struct icalrecurrencetype" default_native="i_cal_recurrence_new_default ()" destroy_func="icalrecurrencetype_unref" new_full_extra_code="if (owner) { icalrecurrencetype_ref (native); owner = NULL; }">
+<structure namespace="ICal" name="Recurrence" native="struct icalrecurrencetype" default_native="i_cal_recurrence_new_default ()" destroy_func="icalrecurrencetype_unref" new_full_extra_code="if (owner) { native = icalrecurrencetype_clone (native); owner = NULL; }">
   <enum name="ICalRecurrenceFrequency" native_name="icalrecurrencetype_frequency" default_native="I_CAL_NO_RECURRENCE">
     <element name="ICAL_SECONDLY_RECURRENCE"/>
     <element name="ICAL_MINUTELY_RECURRENCE"/>

--- a/src/test/libical-glib/property.py
+++ b/src/test/libical-glib/property.py
@@ -91,3 +91,36 @@ string = 'This is a link'
 value_from_string = ICalGLib.Value.new_from_string(kind, string)
 value_from_string.set_parent(stringProperty)
 value_from_string.set_parent(None)
+
+# the RRULE and EXRULE returned by get_rrule/get_exrule should not influence
+# the component, to preserve the libical 3.x series behaviour
+comp = ICalGLib.Component.new_from_string(
+    'BEGIN:VEVENT\r\n'
+    'UID:recurring\r\n'
+    'DTSTAMP:20180403T101443Z\r\n'
+    'DTSTART:20180320T150000Z\r\n'
+    'DTEND:20180320T153000Z\r\n'
+    'SUMMARY:Recurring event\r\n'
+    'CREATED:20180403T113809Z\r\n'
+    'LAST-MODIFIED:20180403T113905Z\r\n'
+    'RRULE:FREQ=DAILY;COUNT=10;INTERVAL=1\r\n'
+    'EXRULE:FREQ=DAILY;COUNT=5;INTERVAL=2\r\n'
+    'END:VEVENT\r\n'
+)
+property = comp.get_first_property(ICalGLib.PropertyKind.RRULE_PROPERTY)
+rrule = property.get_rrule()
+assert rrule.get_count() == 10
+rrule.set_count(3)
+assert rrule.get_count() == 3
+property = comp.get_first_property(ICalGLib.PropertyKind.RRULE_PROPERTY)
+rrule = property.get_rrule()
+assert rrule.get_count() == 10
+
+property = comp.get_first_property(ICalGLib.PropertyKind.EXRULE_PROPERTY)
+exrule = property.get_exrule()
+assert exrule.get_count() == 5
+exrule.set_count(7)
+assert exrule.get_count() == 7
+property = comp.get_first_property(ICalGLib.PropertyKind.EXRULE_PROPERTY)
+exrule = property.get_exrule()
+assert exrule.get_count() == 5


### PR DESCRIPTION
The libical 3.x returned a bare structure for the RRULE/EXRULE properties, which had been independent from the property they had been read from, thus changing them did not influence the property itself.

Preserve this behaviour also in the libical 4.x.

Closes https://github.com/libical/libical/issues/1210