### PR TITLE
icalrecur_test: Extend test execution to attempt every test recurrence instance as DTSTART

### DIFF
--- a/src/test/icalrecur_test.c
+++ b/src/test/icalrecur_test.c
@@ -171,7 +171,6 @@ static int run_testcase(struct recur *r, bool verbose, bool forward, int proceed
     const char *sep = "";
     char actual_instances[2048];
     int actual_instances_len = 0;
-    struct icaltimetype start = icaltime_null_time();
     int test_error = 0;
 
     if (verbose) {
@@ -223,7 +222,7 @@ static int run_testcase(struct recur *r, bool verbose, bool forward, int proceed
                  " *** %s", icalerror_strerror(icalerrno));
     } else {
         if (r->start_at[0]) {
-            start = icaltime_from_string(r->start_at);
+            struct icaltimetype start = icaltime_from_string(r->start_at);
 
             if (forward) {
                 icalrecur_iterator_set_start(ritr, start);


### PR DESCRIPTION
It should be possible for any RRULE, to specify any recurrence instance as DTSTART and get that exact DTSTART as well as all following ones as recurrence instances.

This PR extends `icalrecur_test` to run the individual test cases from the `icalrecur_test.txt` file with each of the expected recurrence instances as DTSTART to cover the above expectation.

The branch finds two (related) test cases that violate that assumption, which is documented in #1223.

This PR should be considered for merging after #1223 was fixed.