### PR TITLE
cppcheck fixes

### DIFF
--- a/src/java/net_cp_jlibical_VComponent_cxx.cpp
+++ b/src/java/net_cp_jlibical_VComponent_cxx.cpp
@@ -78,7 +78,7 @@ JNIEXPORT jboolean JNICALL Java_net_cp_jlibical_VComponent_isa_1component(JNIEnv
     // get the VComponent c++ object from jobj
     VComponent *cObj = (VComponent *)getSubjectAsVComponent(env, jobj, JLIBICAL_ERR_CLIENT_INTERNAL);
     if (cObj != NULL) {
-        void *candidateValue = 0;
+        const void *candidateValue = 0;
 
         if (candidateObj != NULL) {
             // get the c++ object from candidateObj (as long)

--- a/src/libical-glib/tools/generator.c
+++ b/src/libical-glib/tools/generator.c
@@ -41,11 +41,6 @@ gchar *get_source_method_comment(Method *method)
     gchar *buffer;
     gchar *res;
     guint iter;
-    guint len;
-    gint count;
-    gint cursor;
-    guint full_flag_len;
-    guint comment_len;
 
     g_return_val_if_fail(method != NULL, NULL);
 
@@ -65,13 +60,13 @@ gchar *get_source_method_comment(Method *method)
     /* Processing the parameters */
     if (method->parameters != NULL) {
         gchar *full_flag = g_strdup("FULL:");
-        full_flag_len = (guint)strlen(full_flag);
+        guint full_flag_len = (guint)strlen(full_flag);
 
         for (iter_list = g_list_first(method->parameters); iter_list != NULL;
              iter_list = g_list_next(iter_list)) {
             Parameter *para = (Parameter *)iter_list->data;
             if (para) {
-                comment_len = 0;
+                guint comment_len = 0;
                 if (para->comment) {
                     comment_len = (guint)strlen(para->comment);
                 }
@@ -126,8 +121,8 @@ gchar *get_source_method_comment(Method *method)
     if (method->comment != NULL) {
         gchar *comment_line = g_new(gchar, BUFFER_SIZE);
         *comment_line = '\0';
-        len = (guint)strlen(method->comment);
-        count = 0;
+        guint len = (guint)strlen(method->comment);
+        int count = 0;
         (void)g_stpcpy(comment_line, "\n *\n * ");
         for (iter = 0; iter < len; iter++) {
             if (count >= COMMENT_LINE_LENGTH && method->comment[iter] == ' ') {
@@ -135,7 +130,7 @@ gchar *get_source_method_comment(Method *method)
                 count = -1;
             }
 
-            cursor = (gint)strlen(comment_line);
+            gint cursor = (gint)strlen(comment_line);
             comment_line[cursor] = method->comment[iter];
             comment_line[cursor + 1] = '\0';
 
@@ -1263,9 +1258,7 @@ void generate_conditional(FILE *out, Structure *structure, gchar *statement, GHa
     gboolean isTrue;
     gchar *condition;
     gchar *expression;
-    gint count;
     gint len;
-    gchar c;
     gchar *var;
     guint statement_len;
     guint expression_len;
@@ -1319,7 +1312,7 @@ void generate_conditional(FILE *out, Structure *structure, gchar *statement, GHa
                 gchar *buffer;
 
                 iter += 2;
-                count = 1;
+                gint count = 1;
                 buffer = g_new(gchar, BUFFER_SIZE);
                 *buffer = '\0';
                 while (iter < expression_len) {
@@ -1345,7 +1338,7 @@ void generate_conditional(FILE *out, Structure *structure, gchar *statement, GHa
                 }
                 g_free(buffer);
             } else {
-                c = expression[iter];
+                gchar c = expression[iter];
                 if (c == '$') {
                     if (expression[++iter] != '{') {
                         g_warning("The following char is not {");

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -308,7 +308,7 @@ icalcomponent_kind icalcomponent_isa(const icalcomponent *component)
     return component->kind;
 }
 
-bool icalcomponent_isa_component(void *component)
+bool icalcomponent_isa_component(const void *component)
 {
     const icalcomponent *impl = component;
 
@@ -749,12 +749,10 @@ bool icalproperty_recurrence_is_excluded(icalcomponent *comp,
         struct icalrecurrencetype *recur = icalproperty_get_exrule(exrule);
         if (recur) {
             icalrecur_iterator *exrule_itr = icalrecur_iterator_new(recur, *dtstart);
-            struct icaltimetype exrule_time;
-
             while (exrule_itr) {
                 int result;
 
-                exrule_time = icalrecur_iterator_next(exrule_itr);
+                struct icaltimetype exrule_time = icalrecur_iterator_next(exrule_itr);
 
                 if (icaltime_is_null_time(exrule_time)) {
                     break;
@@ -2365,14 +2363,13 @@ void icalcomponent_foreach_tzid(icalcomponent *comp,
                                 void *callback_data)
 {
     icalproperty *prop;
-    icalproperty_kind kind;
     icalparameter *param;
     icalcomponent *subcomp;
 
     /* First look for any TZID parameters used in this component itself. */
     prop = icalcomponent_get_first_property(comp, ICAL_ANY_PROPERTY);
     while (prop) {
-        kind = icalproperty_isa(prop);
+        icalproperty_kind kind = icalproperty_isa(prop);
 
         /* These are the only properties that can have a TZID. Note that
            COMPLETED, CREATED, DTSTAMP & LASTMODIFIED must be in UTC. */

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -70,7 +70,7 @@ LIBICAL_ICAL_EXPORT bool icalcomponent_is_valid(const icalcomponent *component);
 
 LIBICAL_ICAL_EXPORT icalcomponent_kind icalcomponent_isa(const icalcomponent *component);
 
-LIBICAL_ICAL_EXPORT bool icalcomponent_isa_component(void *component);
+LIBICAL_ICAL_EXPORT bool icalcomponent_isa_component(const void *component);
 
 /* Deal with X components */
 

--- a/src/libical/icalparameter_cxx.cpp
+++ b/src/libical/icalparameter_cxx.cpp
@@ -109,6 +109,7 @@ icalparameter_kind ICalParameter::isa()
     return icalparameter_isa(imp);
 }
 
+/* cppcheck-suppress functionStatic */
 bool ICalParameter::isa_parameter(void *param) //NOLINT(readability-convert-member-functions-to-static)
 {
     return icalparameter_isa_parameter(param);

--- a/src/libical/icalproperty_cxx.cpp
+++ b/src/libical/icalproperty_cxx.cpp
@@ -80,6 +80,7 @@ icalproperty_kind ICalProperty::isa()
     return icalproperty_isa(imp);
 }
 
+/* cppcheck-suppress functionStatic */
 bool ICalProperty::isa_property(void *property) //NOLINT(readability-convert-member-functions-to-static)
 {
     return icalproperty_isa_property(property);

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -4142,8 +4142,7 @@ bool icalrecur_expand_recurrence(const char *rule,
 {
     struct icalrecurrencetype *recur;
     icalrecur_iterator *ritr;
-    icaltime_t tt;
-    struct icaltimetype icstart, next;
+    struct icaltimetype icstart;
 
     memset(array, 0, (size_t)count * sizeof(icaltime_t));
 
@@ -4157,10 +4156,10 @@ bool icalrecur_expand_recurrence(const char *rule,
     ritr = icalrecur_iterator_new(recur, icstart);
     if (ritr) {
         int i = 0;
-        for (next = icalrecur_iterator_next(ritr);
+        for (struct icaltimetype next = icalrecur_iterator_next(ritr);
              !icaltime_is_null_time(next) && i < count;
              next = icalrecur_iterator_next(ritr)) {
-            tt = icaltime_as_timet(next);
+            icaltime_t tt = icaltime_as_timet(next);
 
             if (tt >= start) {
                 array[i++] = tt;

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -834,7 +834,7 @@ void icaltimezone_convert_time(struct icaltimetype *tt,
 int icaltimezone_get_utc_offset(icaltimezone *zone, const struct icaltimetype *tt, int *is_daylight)
 {
     const icaltimezonechange *zone_change;
-    icaltimezonechange *prev_zone_change;
+    const icaltimezonechange *prev_zone_change;
     icaltimezonechange tt_change = {0}, tmp_change;
     size_t change_num, change_num_to_use;
     int found_change;

--- a/src/libical/icalvalue_cxx.cpp
+++ b/src/libical/icalvalue_cxx.cpp
@@ -93,6 +93,7 @@ icalvalue_kind ICalValue::isa()
     return icalvalue_isa(imp);
 }
 
+/* cppcheck-suppress functionStatic */
 bool ICalValue::isa_value(void *value) //NOLINT(readability-convert-member-functions-to-static)
 {
     return icalvalue_isa_value(value);
@@ -109,6 +110,7 @@ struct icalrecurrencetype *ICalValue::get_recur()
     return icalvalue_get_recur(imp);
 }
 
+/* cppcheck-suppress functionStatic */
 void ICalValue::set_trigger(const struct icaltriggertype &v) //NOLINT(readability-convert-member-functions-to-static)
 {
     _unused(v);
@@ -141,6 +143,7 @@ icalvalue_kind ICalValue::string_to_kind(const std::string &str)
     return icalvalue_string_to_kind(str.c_str());
 }
 
+/* cppcheck-suppress functionStatic */
 std::string ICalValue::kind_to_string(const icalvalue_kind &kind) //NOLINT(readability-convert-member-functions-to-static)
 {
     return static_cast<std::string>(icalvalue_kind_to_string(kind));

--- a/src/libical/vcomponent_cxx.cpp
+++ b/src/libical/vcomponent_cxx.cpp
@@ -123,7 +123,8 @@ icalcomponent_kind VComponent::isa()
     return icalcomponent_isa(imp);
 }
 
-bool VComponent::isa_component(void *component) //NOLINT(readability-convert-member-functions-to-static)
+/* cppcheck-suppress functionStatic */
+bool VComponent::isa_component(const void *component) //NOLINT(readability-convert-member-functions-to-static)
 {
     return icalcomponent_isa_component(component);
 }

--- a/src/libical/vcomponent_cxx.hpp
+++ b/src/libical/vcomponent_cxx.hpp
@@ -59,7 +59,7 @@ public:
     std::string as_ical_string();
     bool is_valid();
     icalcomponent_kind isa();
-    bool isa_component(void *component);
+    bool isa_component(const void *component);
 
     /// Working with properties
     void add_property(ICalProperty *property);

--- a/src/libicalss/icalclassify.c
+++ b/src/libicalss/icalclassify.c
@@ -59,7 +59,7 @@ icalcomponent *icalclassify_find_overlaps(icalset *set, icalcomponent *comp)
 {
     icalcomponent *return_set;
     icalcomponent *c;
-    struct icaltime_span span, compspan;
+    struct icaltime_span compspan;
 
     icalerror_clear_errno();
     compspan = icalcomponent_get_span(comp);
@@ -73,7 +73,7 @@ icalcomponent *icalclassify_find_overlaps(icalset *set, icalcomponent *comp)
     for (c = icalset_get_first_component(set); c != 0; c = icalset_get_next_component(set)) {
         icalerror_clear_errno();
 
-        span = icalcomponent_get_span(c);
+        struct icaltime_span span = icalcomponent_get_span(c);
 
         if (icalerrno != ICAL_NO_ERROR) {
             continue;

--- a/src/libicalss/icaldirset.c
+++ b/src/libicalss/icaldirset.c
@@ -135,6 +135,7 @@ static icalerrorenum icaldirset_read_directory(icaldirset *dset)
     return ICAL_NO_ERROR;
 }
 
+/* cppcheck-suppress constParameterPointer */
 icalset *icaldirset_init(icalset *set, const char *dir, void *options_in)
 {
     icaldirset *dset;

--- a/src/libicalss/icalgauge.c
+++ b/src/libicalss/icalgauge.c
@@ -166,8 +166,6 @@ int icalgauge_compare_recurse(icalcomponent *comp, icalcomponent *gauge)
         icalproperty *targetprop;
         icalparameter *compareparam;
         icalparameter_xliccomparetype compare;
-        icalparameter_xliccomparetype rel; /* The relationship between the gauge
-                                                and target values. */
 
         /* Extract the comparison type from the gauge. If there is no
            comparison type, assume that it is "EQUAL" */
@@ -191,7 +189,8 @@ int icalgauge_compare_recurse(icalcomponent *comp, icalcomponent *gauge)
             /* Compare the values of the gauge property and the target
                property */
 
-            rel = icalvalue_compare(icalproperty_get_value(p), icalproperty_get_value(targetprop));
+            /* The relationship between the gauge and target values */
+            icalparameter_xliccomparetype rel = icalvalue_compare(icalproperty_get_value(p), icalproperty_get_value(targetprop));
 
             /* Now see if the comparison is equivalent to the comparison
                specified in the gauge */

--- a/src/libicalss/icalspanlist.c
+++ b/src/libicalss/icalspanlist.c
@@ -366,10 +366,10 @@ icalcomponent *icalspanlist_as_vfreebusy(icalspanlist *sl,
     /* now add the freebusy sections.. */
 
     for (itr = icalpvl_head(sl->spans); itr != 0; itr = icalpvl_next(itr)) {
-        struct icalperiodtype period;
         struct icaltime_span *s = (struct icaltime_span *)icalpvl_data(itr);
 
         if (s && s->is_busy == 1) {
+            struct icalperiodtype period;
             period.start = icaltime_from_timet_with_zone(s->start, 0, utc_zone);
             period.end = icaltime_from_timet_with_zone(s->end, 0, utc_zone);
             period.duration = icaldurationtype_null_duration();

--- a/src/libicalvcal/icalvcal.c
+++ b/src/libicalvcal/icalvcal.c
@@ -634,7 +634,6 @@ static void *multivalued_prop(int icaltype, VObject *object, const icalcomponent
 {
     icalproperty_kind kind = (icalproperty_kind)icaltype;
     icalproperty *prop = NULL;
-    icalvalue_kind value_kind;
     const char *s;
     char *tmp_copy;
     int free_string;
@@ -653,7 +652,7 @@ static void *multivalued_prop(int icaltype, VObject *object, const icalcomponent
     if (tmp_copy) {
         prop = icalproperty_new(kind);
 
-        value_kind = icalproperty_kind_to_value_kind(icalproperty_isa(prop));
+        icalvalue_kind value_kind = icalproperty_kind_to_value_kind(icalproperty_isa(prop));
 
         for (char *p = tmp_copy; *p; p++) {
             if (*p == ';') {

--- a/src/libicalvcal/vobject.c
+++ b/src/libicalvcal/vobject.c
@@ -374,7 +374,8 @@ VObject* addGroup(VObject *o, const char *g)
     char *dot = strrchr(g,'.');
     if (dot) {
         VObject *p, *t;
-        char *gs, *n = dot+1;
+        char *gs;
+        const char *n = dot+1;
         gs = dupStr(g,0);       /* so we can write to it. */
         /* used to be
         * t = p = addProp_(o,lookupProp_(n));

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -263,7 +263,7 @@ vcardcomponent_kind vcardcomponent_isa(const vcardcomponent *component)
     return component->kind;
 }
 
-bool vcardcomponent_isa_component(void *component)
+bool vcardcomponent_isa_component(const void *component)
 {
     const vcardcomponent *impl = component;
 

--- a/src/libicalvcard/vcardcomponent.h
+++ b/src/libicalvcard/vcardcomponent.h
@@ -58,7 +58,7 @@ LIBICAL_VCARD_EXPORT bool vcardcomponent_is_valid(const vcardcomponent *comp);
 
 LIBICAL_VCARD_EXPORT vcardcomponent_kind vcardcomponent_isa(const vcardcomponent *comp);
 
-LIBICAL_VCARD_EXPORT bool vcardcomponent_isa_component(void *comp);
+LIBICAL_VCARD_EXPORT bool vcardcomponent_isa_component(const void *comp);
 
 /***** Working with Properties *****/
 

--- a/src/test/builtin_timezones.c
+++ b/src/test/builtin_timezones.c
@@ -29,7 +29,7 @@ static const void *thread_comp = NULL;
 static void *thread_func(void *user_data)
 {
     icaltimezone *zone = user_data;
-    icalcomponent *icalcomp;
+    const icalcomponent *icalcomp;
 
     if (!zone) {
         return NULL;

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -3155,7 +3155,6 @@ char *ical_strstr(const char *haystack, const char *needle)
 
 void test_start_of_week(void)
 {
-    struct icaltimetype tt2;
     struct icaltimetype tt1 = icaltime_from_string("19900110");
 
     do {
@@ -3164,7 +3163,7 @@ void test_start_of_week(void)
         int doy = icaltime_start_doy_week(tt1, 1);
         int dow = icaltime_day_of_week(tt1);
 
-        tt2 = icaltime_from_day_of_year(doy, tt1.year);
+        struct icaltimetype tt2 = icaltime_from_day_of_year(doy, tt1.year);
         int start_dow = icaltime_day_of_week(tt2);
 
         if (doy == 1) {
@@ -5230,7 +5229,6 @@ void test_timezone_from_builtin(void)
         "END:VCALENDAR\r\n";
     icalcomponent *comp;
     icaltimezone *zone;
-    struct icaltimetype dtstart, dtend, due;
     char *strcomp, *tzidprefix, *prevslash = NULL, *prevprevslash = NULL, *p;
     size_t len;
 
@@ -5265,9 +5263,9 @@ void test_timezone_from_builtin(void)
         icalcomponent *subcomp = icalcomponent_get_first_component(comp, ICAL_VEVENT_COMPONENT);
         ok("get subcomp", (subcomp != NULL));
 
-        dtstart = icalcomponent_get_dtstart(subcomp);
-        dtend = icalcomponent_get_dtend(subcomp);
-        due = icalcomponent_get_due(subcomp);
+        struct icaltimetype dtstart = icalcomponent_get_dtstart(subcomp);
+        struct icaltimetype dtend = icalcomponent_get_dtend(subcomp);
+        struct icaltimetype due = icalcomponent_get_due(subcomp);
 
         ok("DTSTART is my_zone", (strcmp(icaltimezone_get_tzid((icaltimezone *)dtstart.zone), "my_zone") == 0));
         ok("DTEND is America/New_York", (strcmp(icaltimezone_get_location((icaltimezone *)dtend.zone), "America/New_York") == 0));
@@ -5454,7 +5452,7 @@ void test_icalcomponent_normalize_missing_mandatory_props(void)
     // component has the property set and the other does not, then
     // the component having the property sorts first.
 
-    struct testcase {
+    const struct testcase {
         const char *calStr;
         const char *expect;
     } tests[] = {{.calStr =


### PR DESCRIPTION
newly discovered with cppcheck 2.19.1

constParameterPointer and variableScope issues