### PR TITLE
Add new functions icalcompiter_is_valid() and icalpropiter_is_valid()

### DIFF
--- a/docs/MigrationGuide_to_4.md
+++ b/docs/MigrationGuide_to_4.md
@@ -182,6 +182,8 @@ The following functions have been added:
 * `icalparser_set_ctrl()`
 * `icaltimezone_tzid_prefix()`
 * `icaltimezone_set_system_zone_directory()`
+* `icalcompiter_is_valid()`
+* `icalpropiter_is_valid()`
 * and the new functions for the `icalstrarray` and `icalenumarray` data types
 
 ### Removed functions

--- a/src/libical-glib/api/i-cal-component.xml
+++ b/src/libical-glib/api/i-cal-component.xml
@@ -214,6 +214,10 @@
 
     return iter;</custom>
   </method>
+  <method name="i_cal_comp_iter_is_valid" corresponds="icalcompiter_is_valid" since="4.0">
+    <parameter type="ICalCompIter *" name="i" native_op="POINTER" comment="A #ICalCompIter"/>
+    <returns type="gboolean" comment="true if a valid iterator; false otherwise."/>
+  </method>
   <method name="i_cal_comp_iter_next" corresponds="icalcompiter_next" since="1.0">
     <parameter type="ICalCompIter *" name="i" native_op="POINTER" comment="A #ICalCompIter"/>
     <returns type="ICalComponent *" annotation="transfer full" comment="A #ICalComponent"/>
@@ -281,6 +285,10 @@
     }
 
     return iter;</custom>
+  </method>
+  <method name="i_cal_prop_iter_is_valid" corresponds="icalpropiter_is_valid" since="4.0">
+    <parameter type="ICalPropIter *" name="i" native_op="POINTER" comment="A #ICalPropIter"/>
+    <returns type="gboolean" comment="true if a valid iterator; false otherwise."/>
   </method>
   <method name="i_cal_prop_iter_next" corresponds="icalpropiter_next" since="4.0">
     <parameter type="ICalPropIter *" name="i" native_op="POINTER" comment="A #ICalPropIter"/>

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -1313,6 +1313,12 @@ icalcomponent_kind icalcomponent_string_to_kind(const char *string)
     return ICAL_NO_COMPONENT;
 }
 
+bool icalcompiter_is_valid(const icalcompiter *i)
+{
+    /* compare to icalcompiter_null */
+    return !((i->kind == ICAL_NO_COMPONENT) && (i->iter == 0));
+}
+
 icalcompiter icalcomponent_begin_component(icalcomponent *component, icalcomponent_kind kind)
 {
     icalcompiter itr;
@@ -1423,6 +1429,12 @@ icalpropiter icalcomponent_begin_property(icalcomponent *component, icalproperty
     }
 
     return icalpropiter_null;
+}
+
+bool icalpropiter_is_valid(const icalpropiter *i)
+{
+    /* compare to icalpropiter_null */
+    return !((i->kind == ICAL_NO_PROPERTY) && (i->iter == 0));
 }
 
 icalproperty *icalpropiter_next(icalpropiter *i)

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -162,12 +162,34 @@ LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_prior(icalcompiter *i);
 
 LIBICAL_ICAL_EXPORT icalcomponent *icalcompiter_deref(icalcompiter *i);
 
+/**
+ * Checks if the specified icalcompiter is valid.
+ *
+ * @param i a pointer to a possibly invalid icalcompiter
+ *
+ * @return true if @p i points to a valid icalcompiter; false otherwise.
+ *
+ * @since 4.0
+ */
+LIBICAL_ICAL_EXPORT bool icalcompiter_is_valid(const icalcompiter *i);
+
 LIBICAL_ICAL_EXPORT icalpropiter icalcomponent_begin_property(icalcomponent *component,
                                                               icalproperty_kind kind);
 
 LIBICAL_ICAL_EXPORT icalproperty *icalpropiter_next(icalpropiter *i);
 
 LIBICAL_ICAL_EXPORT icalproperty *icalpropiter_deref(icalpropiter *i);
+
+/**
+ * Checks if the specified icalpropiter is valid.
+ *
+ * @param i a pointer to a possibly invalid icalpropiter
+ *
+ * @return true if @p i points to a valid icalpropiter; false otherwise.
+ *
+ * @since 4.0
+ */
+LIBICAL_ICAL_EXPORT bool icalpropiter_is_valid(const icalpropiter *i);
 
 /***** Working with embedded error properties *****/
 

--- a/src/test/libical-glib/component.py
+++ b/src/test/libical-glib/component.py
@@ -197,6 +197,7 @@ def main():
 
     # Traverse with external API.
     iterator = parent.begin_component(ICalGLib.ComponentKind.VEVENT_COMPONENT)
+    assert iterator.is_valid()
     childComponent = iterator.deref()
     for i in range(0, count):
         prefix = 'test'
@@ -314,6 +315,7 @@ def main():
     # Test propiter and paramiter
     comp = ICalGLib.Component.new_from_string(eventStr1)
     iter = comp.begin_property(ICalGLib.PropertyKind.ANY_PROPERTY)
+    assert iter.is_valid()
     assert iter.deref().as_ical_string().split('\n', 1)[0] == 'UID:event-uid-123\r'
     iter.next()
     prop = iter.deref()

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -2415,6 +2415,9 @@ void test_iterators(void)
 
         strncat(vevent_list, s, sizeof(vevent_list) - strlen(vevent_list) - 1);
     }
+    /* at this point the icalcompiter should be invalid */
+    assert(icalcompiter_is_valid(&i));
+
     str_is("iterate through VEVENTS in a component", vevent_list, vevent_list_good);
 
     /* Delete all of the VEVENTS */
@@ -6333,6 +6336,7 @@ static void test_icalpropiter(void)
 
     // Iterate all properties.
     icalpropiter iter = icalcomponent_begin_property(comp, ICAL_ANY_PROPERTY);
+    assert(icalpropiter_is_valid(&iter));
     ok("iter at DTSTAMP",
        dtstamp == icalpropiter_deref(&iter));
     ok("iter at COMMENT (comment1)",
@@ -6353,6 +6357,7 @@ static void test_icalpropiter(void)
 
     // Iterate COMMENT property.
     iter = icalcomponent_begin_property(comp, ICAL_COMMENT_PROPERTY);
+    assert(icalpropiter_is_valid(&iter));
     ok("iter at COMMENT (comment1)",
        comment1 == icalpropiter_deref(&iter));
     ok("iter at COMMENT (comment2)",
@@ -6362,8 +6367,9 @@ static void test_icalpropiter(void)
        NULL == icalpropiter_next(&iter) &&
            NULL == icalpropiter_deref(&iter));
 
-    // Iterate in-existent property.
+    // Iterate non-existent property.
     iter = icalcomponent_begin_property(comp, ICAL_DESCRIPTION_PROPERTY);
+    assert(!icalpropiter_is_valid(&iter)); //will be invalid
     ok("iter at end", NULL == icalpropiter_deref(&iter));
 
     icalcomponent_free(comp);


### PR DESCRIPTION
Check for valid iterators for example when returning from icalcomponent_begin_component and icalcomponent_begin_property()