### PR TITLE
Move icalvalue_reset_kind() and vcardvalue_reset_kind() to public header

### DIFF
--- a/src/libical-glib/api/i-cal-derived-value.xml
+++ b/src/libical-glib/api/i-cal-derived-value.xml
@@ -240,10 +240,6 @@
   <method-from-template name="simple-new-get-set" obj-type="ICalValue" value-name="DATETIMEPERIOD" since="1.0" value-get-type="ICalDatetimeperiod *" value-set-type="const ICalDatetimeperiod *" value-set-type-ref="#ICalDatetimeperiod" value-get-annotation="transfer full" binding-prefix="i_cal_value" native-prefix="icalvalue" suffix="datetimeperiod"/>
   <method-from-template name="simple-new-get-set" obj-type="ICalValue" value-name="GEO" since="1.0" value-get-type="ICalGeo *" value-set-type="const ICalGeo *" value-set-type-ref="#ICalGeo" value-get-annotation="transfer full" binding-prefix="i_cal_value" native-prefix="icalvalue" suffix="geo"/>
   <method-from-template name="simple-new-get-set" obj-type="ICalValue" value-name="ATTACH" since="1.0" value-get-type="ICalAttach *" value-set-type="const ICalAttach *" value-set-type-ref="#ICalAttach" value-get-annotation="transfer full" binding-prefix="i_cal_value" native-prefix="icalvalue" suffix="attach"/>
-  <method name="i_cal_value_reset_kind" corresponds="icalvalue_reset_kind" kind="other" since="1.0">
-    <parameter type="ICalValue *" name="value" comment="The #ICalValue's kind to be reset"/>
-    <comment>Resets the kind of #ICalValue.</comment>
-  </method>
   <method-from-template name="simple-new-get-set" obj-type="ICalValue" value-name="XLICCLASS" since="1.0" value-get-type="ICalPropertyXlicclass" value-set-type="ICalPropertyXlicclass" value-set-type-ref="#ICalPropertyXlicclass" binding-prefix="i_cal_value" native-prefix="icalvalue" suffix="xlicclass"/>
   <method-from-template name="simple-new-get-set" obj-type="ICalValue" value-name="BOOLEAN" since="1.0" value-get-type="gboolean" value-set-type="gboolean" value-set-type-ref="boolean" binding-prefix="i_cal_value" native-prefix="icalvalue" suffix="boolean"/>
   <method-from-template name="simple-new-get-set" obj-type="ICalValue" value-name="BUSYTYPE" since="2.0" value-get-type="ICalPropertyBusytype" value-set-type="ICalPropertyBusytype" value-set-type-ref="#ICalPropertyBusytype" binding-prefix="i_cal_value" native-prefix="icalvalue" suffix="busytype"/>

--- a/src/libical-glib/api/i-cal-value.xml
+++ b/src/libical-glib/api/i-cal-value.xml
@@ -68,6 +68,10 @@
     <returns type="gboolean" comment="true if yes, false if not."/>
     <comment xml:space="preserve">Checks whether the #ICalValueKind is valid.</comment>
   </method>
+  <method name="i_cal_value_reset_kind" corresponds="icalvalue_reset_kind" kind="other" since="1.0">
+    <parameter type="ICalValue *" name="value" comment="The #ICalValue's kind to be reset"/>
+    <comment>Resets the kind of #ICalValue.</comment>
+  </method>
   <method name="i_cal_value_encode_ical_string" corresponds="icalvalue_encode_ical_string" kind="custom" since="1.0">
     <parameter type="const gchar *" name="szText" comment="A string"/>
     <returns type="gchar *" annotation="nullable, transfer full" comment="The encoded string. NULL if fail."/>

--- a/src/libical-glib/api/i-cal-vcard-derived-value.xml
+++ b/src/libical-glib/api/i-cal-vcard-derived-value.xml
@@ -46,10 +46,6 @@
     <element name="VCARD_NUM_CLIENTPIDMAP_FIELDS"/>
   </enum>
   <method-from-template name="simple-new-get-set" obj-type="ICalVcardValue" value-name="X" since="4.0" value-get-type="const gchar *" value-set-type="const gchar *" value-set-type-ref="text" binding-prefix="i_cal_vcard_value" native-prefix="vcardvalue" suffix="x"/>
-  <method name="i_cal_vcard_value_reset_kind" corresponds="vcardvalue_reset_kind" kind="other" since="4.0">
-    <parameter type="ICalVcardValue *" name="value" comment="The #ICalVcardValue to be queried"/>
-    <comment>Reset's the value's kind.</comment>
-  </method>
   <method-from-template name="vcardstructured" obj-type="ICalVcardValue" native-type="vcardvalue" value-name="STRUCTURED" since="4.0" binding-prefix="i_cal_vcard_value" native-prefix="vcardvalue" suffix="structured"/>
   <method-from-template name="simple-new-get-set" obj-type="ICalVcardValue" value-name="GEO" since="4.0" value-get-type="ICalVcardGeo *" value-set-type="const ICalVcardGeo *" value-set-type-ref="#ICalVcardGeo" value-get-annotation="transfer full" binding-prefix="i_cal_vcard_value" native-prefix="vcardvalue" suffix="geo"/>
   <method-from-template name="simple-new-get-set" obj-type="ICalVcardValue" value-name="TZ" since="4.0" value-get-type="ICalVcardTz *" value-set-type="const ICalVcardTz *" value-set-type-ref="#ICalVcardTz" value-get-annotation="transfer full" binding-prefix="i_cal_vcard_value" native-prefix="vcardvalue" suffix="tz"/>

--- a/src/libical-glib/api/i-cal-vcard-value.xml
+++ b/src/libical-glib/api/i-cal-vcard-value.xml
@@ -59,6 +59,10 @@
     <returns type="gboolean" comment="true if yes, false if not."/>
     <comment xml:space="preserve">Checks whether the @kind is a valid #ICalVcardValueKind.</comment>
   </method>
+  <method name="i_cal_vcard_value_reset_kind" corresponds="vcardvalue_reset_kind" kind="other" since="4.0">
+    <parameter type="ICalVcardValue *" name="value" comment="The #ICalVcardValue to be queried"/>
+    <comment>Reset's the value's kind.</comment>
+  </method>
   <method name="i_cal_vcard_value_dequote_text" corresponds="vcardvalue_strdup_and_dequote_text" annotation="skip" since="4.0">
     <parameter type="const gchar **" name="text" annotation="inout" comment="pointer to a string to dequote"/>
     <parameter type="const gchar *" name="separators" annotation="nullable" comment="a string with separators, or %NULL"/>

--- a/src/libical/icalderivedvalue.h.in
+++ b/src/libical/icalderivedvalue.h.in
@@ -77,8 +77,6 @@ LIBICAL_ICAL_EXPORT icalvalue *icalvalue_new_binary(const char *v);
 LIBICAL_ICAL_EXPORT void icalvalue_set_binary(icalvalue *value, const char *v);
 LIBICAL_ICAL_EXPORT const char *icalvalue_get_binary(const icalvalue *value);
 
-LIBICAL_ICAL_EXPORT void icalvalue_reset_kind(icalvalue *value);
-
 #define icalvalue_new_link icalvalue_new_uri
 #define icalvalue_set_link icalvalue_set_uri
 #define icalvalue_get_link icalvalue_get_uri

--- a/src/libical/icalvalue.h
+++ b/src/libical/icalvalue.h
@@ -77,6 +77,13 @@ LIBICAL_ICAL_EXPORT const char *icalvalue_kind_to_string(const icalvalue_kind ki
 /** Check validity of a specific icalvalue_kind **/
 LIBICAL_ICAL_EXPORT bool icalvalue_kind_is_valid(const icalvalue_kind kind);
 
+/**
+ * Resets the icalvalue_kind of the specified icalvalue.
+ *
+ * @param value a pointer to a valid icalvalue
+ */
+LIBICAL_ICAL_EXPORT void icalvalue_reset_kind(icalvalue *value);
+
 /** Encode a character string in ical format, escape certain characters, etc. */
 LIBICAL_ICAL_EXPORT bool icalvalue_encode_ical_string(const char *szText,
                                                       char *szEncText, int MaxBufferLen);

--- a/src/libicalvcard/vcardderivedvalue.h.in
+++ b/src/libicalvcard/vcardderivedvalue.h.in
@@ -70,8 +70,6 @@ LIBICAL_VCARD_EXPORT void vcardvalue_set_x(vcardvalue *value, const char *v);
 LIBICAL_VCARD_EXPORT vcardvalue *vcardvalue_new_x(const char *v);
 LIBICAL_VCARD_EXPORT const char *vcardvalue_get_x(const vcardvalue *value);
 
-LIBICAL_VCARD_EXPORT void vcardvalue_reset_kind(vcardvalue *value);
-
 LIBICAL_VCARD_EXPORT vcardvalue *vcardvalue_new_structured(vcardstructuredtype *v);
 LIBICAL_VCARD_EXPORT void vcardvalue_set_structured(vcardvalue *value,
                                                     vcardstructuredtype *v);

--- a/src/libicalvcard/vcardvalue.h
+++ b/src/libicalvcard/vcardvalue.h
@@ -40,6 +40,13 @@ LIBICAL_VCARD_EXPORT const char *vcardvalue_kind_to_string(const vcardvalue_kind
 /** Check validity of a specific vcardvalue_kind **/
 LIBICAL_VCARD_EXPORT bool vcardvalue_kind_is_valid(const vcardvalue_kind kind);
 
+/**
+ * Resets the vcardvalue_kind of the specified vcardvalue.
+ *
+ * @param value a pointer to a valid vcardvalue
+ */
+LIBICAL_VCARD_EXPORT void vcardvalue_reset_kind(vcardvalue *value);
+
 /* Duplicate and dequote a TEXT value */
 LIBICAL_VCARD_EXPORT char *vcardvalue_strdup_and_dequote_text(const char **str,
                                                               const char *sep);


### PR DESCRIPTION
since they are used outside of the generated source.