### PR TITLE
icalcomponent.h - add missing icalcomponent_new_vreply

### DIFF
--- a/src/libical-glib/api/i-cal-component.xml
+++ b/src/libical-glib/api/i-cal-component.xml
@@ -666,6 +666,10 @@ static void foreach_recurrence_cb(const icalcomponent *in_comp, const struct ica
     <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
     <comment xml:space="preserve">Creates a #ICalComponent with the type to be vavailability.</comment>
   </method>
+  <method name="i_cal_component_new_vreply" corresponds="icalcomponent_new_vreply" kind="constructor" since="1.0">
+    <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
+    <comment xml:space="preserve">Creates a #ICalComponent with the type to be vreply.</comment>
+  </method>
   <method name="i_cal_component_new_xavailable" corresponds="icalcomponent_new_xavailable" kind="constructor" since="1.0">
     <returns type="ICalComponent *" annotation="transfer full" comment="The newly created #ICalComponent."/>
     <comment xml:space="preserve">Creates a #ICalComponent with the type to be xavailable.</comment>

--- a/src/libical/icalcomponent.h
+++ b/src/libical/icalcomponent.h
@@ -544,6 +544,8 @@ LIBICAL_ICAL_EXPORT icalcomponent *icalcomponent_new_vagenda(void);
 
 LIBICAL_ICAL_EXPORT icalcomponent *icalcomponent_new_vquery(void);
 
+LIBICAL_ICAL_EXPORT icalcomponent *icalcomponent_new_vreply(void);
+
 LIBICAL_ICAL_EXPORT icalcomponent *icalcomponent_new_vavailability(void);
 
 LIBICAL_ICAL_EXPORT icalcomponent *icalcomponent_new_xavailable(void);


### PR DESCRIPTION
icalcomponent_new_vreply() was not defined although it was implemented in icalcomponent.c