### PR TITLE
initialize the errbuf so we don't write a null pointer

### DIFF
--- a/src/libicalvcard/vcardparser.c
+++ b/src/libicalvcard/vcardparser.c
@@ -912,6 +912,7 @@ static int vcardparser_parse(struct vcardparser_state *state, int only_one)
     state->p = state->base;
 
     buf_init(&state->buf, BUF_GROW);
+    buf_init(&state->errbuf, BUF_GROW);
 
     /* don't parse trailing non-whitespace */
     return _parse_vcard(state, state->root, only_one);


### PR DESCRIPTION
If there's a parsing error, _parse_error calls

    buf_vprintf(&state->errbuf, fmt, ap);

which attempts vsnprintf(buf->s... and buf->s is 0x0.

This fixes:

    The following tests FAILED:
        108 - vcfuzz1test480258833 (SEGFAULT)
        111 - vcfuzz1test485932113 (SEGFAULT)

when compiled with:

  cmake -B build --warn-uninitialized -Werror=dev -G Ninja -DLIBICAL_DEVMODE_MEMORY_CONSISTENCY=True -DCMAKE_BUILD_TYPE=Debug -DLIBICAL_DEVMODE=True -DLIBICAL_ENABLE_BUILTIN_TZDATA=True  -DLIBICAL_GLIB_BUILD_DOCS=False -DLIBICAL_GLIB=False -DLIBICAL_GOBJECT_INTROSPECTION=False -DLIBICAL_GLIB_VAPI=False -DLIBICAL_BUILD_TESTING_BIGFUZZ=True