### PR TITLE
Remove conditional compile for ICAL_REMOVE_NONMEMBER_CARD_IS_ERROR

### DIFF
--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -298,14 +298,9 @@ void vcardcomponent_remove_property(vcardcomponent *comp, vcardproperty *propert
     icalerror_check_arg_rv((comp != 0), "component");
     icalerror_check_arg_rv((property != 0), "property");
 
-#if defined(ICAL_REMOVE_NONMEMBER_CARD_IS_ERROR)
-    icalerror_assert((vcardproperty_get_parent(property)),
-                     "The property is not a member of a card");
-#else
     if (vcardproperty_get_parent(property) == 0) {
         return;
     }
-#endif
 
     if (vcardproperty_isa(property) == VCARD_VERSION_PROPERTY) {
         comp->versionp = 0;


### PR DESCRIPTION
following f9f8586e48061bf5487e3639b725b74449398563: 

"Remove conditional compile for ICAL_REMOVE_NONMEMBER_COMPONENT_IS_ERROR
 15 years since I disabled this conditional compile.
 If someone still needs it then we can discuss.
"