### PR TITLE
RRULE parsing: Be more strict against overflows and empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ for details about API changes since libical 3.x.
   are parsed as X kind.
 - The `icalproperty_remove_parameter_by_(kind|name)` functions now remove all matching parameters.
   Before, they only removed the first matching parameter contrary to their documentation.
+- `icalrecurrencetype_new_from_string()` is more strict against overflows and empty rule parts.
+  E.g. it now rejects RRULE parts like `BYDAY=255SU` (which used to be interpreted as `BYDAY=-1SU`).
 
 ### Deprecated
 

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -547,7 +547,20 @@ static int icalrecur_add_byrules(const struct icalrecur_parser *parser, icalrecu
             n++;
         }
 
-        int v = strtol(t, &t, 10);
+        // empty string is not allowed here
+        if (!*t) {
+            return -1;
+        }
+
+        char *t_end;
+        int v = strtol(t, &t_end, 10);
+
+        // We check for parsing errors later, but not if the string ends with 'L',
+        // so explicitly check the value here.
+        if (t == t_end) {
+            return -1;
+        }
+        t = t_end;
 
         /* Sanity check value */
         if (v < 0) {
@@ -668,8 +681,15 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
             n++;
         }
 
+        // empty string is not allowed here
+        if (!t[0]) {
+            icalmemory_free_buffer(vals_copy);
+            return -1;
+        }
+
         /* Get Optional weekno */
-        long tmpl = strtol(t, &t, 10);
+        char *t_end;
+        long tmpl = strtol(t, &t_end, 10);
         weekno = (signed char)tmpl;
 
         // overflow?
@@ -678,6 +698,14 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
             icalmemory_free_buffer(vals_copy);
             return -1;
         }
+
+        // WeekNo 0 doesn't exist
+        if ((weekno == 0) && (t != t_end)) {
+            icalmemory_free_buffer(vals_copy);
+            return -1;
+        }
+        t = t_end;
+
         if (weekno < 0) {
             weekno = -weekno;
             sign = -1;
@@ -933,7 +961,15 @@ struct icalrecurrencetype *icalrecurrencetype_new_from_string(const char *str)
                 /* Don't allow multiple INTERVALs */
                 r = -1;
             } else {
-                parser.rt->interval = (short)atoi(value);
+                int tmp = atoi(value);
+                parser.rt->interval = (short)tmp;
+
+                // overflow?
+                /* cppcheck-suppress knownConditionTrueFalse */
+                if (parser.rt->interval != tmp) {
+                    r = -1;
+                }
+
                 /* don't allow an interval to be less than 1
                    (RFC specifies an interval must be a positive integer) */
                 if (parser.rt->interval < 1) {

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -651,8 +651,7 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
 
     while (n != 0) {
         int sign = 1;
-        signed char weekno; /* note: Novell/Groupwise sends BYDAY=255SU,
-                                so we fit in a signed char to get -1 SU for last Sun */
+        signed char weekno;
         icalrecurrencetype_weekday wd;
 
         if (idx >= by->size) {
@@ -670,7 +669,15 @@ static int icalrecur_add_bydayrules(struct icalrecur_parser *parser,
         }
 
         /* Get Optional weekno */
-        weekno = (signed char)strtol(t, &t, 10);
+        long tmpl = strtol(t, &t, 10);
+        weekno = (signed char)tmpl;
+
+        // overflow?
+        /* cppcheck-suppress knownConditionTrueFalse */
+        if (weekno != tmpl) {
+            icalmemory_free_buffer(vals_copy);
+            return -1;
+        }
         if (weekno < 0) {
             weekno = -weekno;
             sign = -1;

--- a/src/test/icalrecur_test.c
+++ b/src/test/icalrecur_test.c
@@ -183,7 +183,7 @@ static int run_testcase(struct recur *r, bool verbose, bool forward, int proceed
 
     rrule = icalrecurrencetype_new_from_string(r->rrule);
     if (!rrule) {
-        return test_error;
+        return -1;
     }
     if (has_skip) {
         *has_skip = (rrule->skip == ICAL_SKIP_FORWARD) || (rrule->skip == ICAL_SKIP_BACKWARD);


### PR DESCRIPTION
So far the RRULE parser didn't check for overflows when parsing `BYDAY` integers. This was partly intentional to support rule parts like `BYDAY=255SU`,  (which used to be sent by Novell/GroupWise instead of `BYDAY=-1SU`). As these clearly violates the RFC and don't seem to too relevant these days, this PR updates the parser to consider such overflows as errors.

It also is more strict against empty strings when parsing `BY` rule parts, which previously interpreted empty strings as 0.
