### PR TITLE
CMakePresets: Add `configurePresets` `dev-windows`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,6 +39,19 @@
             }
         },
         {
+            "name": "dev-windows",
+            "description": "Development on Windows/MSVC toolchain",
+            "inherits": "dev",
+            "cacheVariables": {
+                "LIBICAL_GLIB_BUILD_DOCS": "False",
+                "LIBICAL_GLIB": "False",
+                "LIBICAL_GOBJECT_INTROSPECTION": "False",
+                "LIBICAL_GLIB_VAPI": "False",
+                "LIBICAL_JAVA_BINDINGS": "False",
+                "LIBICAL_STATIC": "True"
+            }
+        },
+        {
             "name": "release",
             "inherits": "base",
             "cacheVariables": {


### PR DESCRIPTION
Add CMake presets for development on windows using the MSVC toolchain. It is based on the settings used in the `build-windows` GitHub Workflow.
