### PR TITLE
Increase the RRULE_SEARCH limit to 500

### DIFF
--- a/docs/InternalLimits.md
+++ b/docs/InternalLimits.md
@@ -54,4 +54,4 @@ The internal limits and their default values are shown here:
 * Maximum number of times to search vtimezone rrules for an occurrence before the specified end year
 
       Kind = ICAL_LIMIT_RRULE_SEARCH
-      Default = 100 (one hundred)
+      Default = 500 (five hundred)

--- a/src/libical/icallimits.c
+++ b/src/libical/icallimits.c
@@ -24,7 +24,7 @@ static ICAL_GLOBAL_VAR size_t _MAX_VALUE_CHARS = 10485760;
 static ICAL_GLOBAL_VAR size_t _MAX_PROPERTY_VALUES = 500;
 static ICAL_GLOBAL_VAR size_t _MAX_RECURRENCE_SEARCH = 100000;
 static ICAL_GLOBAL_VAR size_t _MAX_RECURRENCE_TIME_STANDING_STILL = 50;
-static ICAL_GLOBAL_VAR size_t _MAX_RRULE_SEARCH = 100;
+static ICAL_GLOBAL_VAR size_t _MAX_RRULE_SEARCH = 500;
 
 size_t icallimit_get(icallimits_kind kind)
 {

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6901,7 +6901,7 @@ static void test_internal_limits(void)
     int_is("max prop values", (int)icallimit_get(ICAL_LIMIT_PROPERTY_VALUES), 500);
     int_is("max recurrence search", (int)icallimit_get(ICAL_LIMIT_RECURRENCE_SEARCH), 100000);
     int_is("time standing still", (int)icallimit_get(ICAL_LIMIT_RECURRENCE_TIME_STANDING_STILL), 50);
-    int_is("max rrule search", (int)icallimit_get(ICAL_LIMIT_RRULE_SEARCH), 100);
+    int_is("max rrule search", (int)icallimit_get(ICAL_LIMIT_RRULE_SEARCH), 500);
 
     icallimit_set(ICAL_LIMIT_PROPERTIES, 10);
     int_is("properties limit", (int)icallimit_get(ICAL_LIMIT_PROPERTIES), 10);


### PR DESCRIPTION
To fix the isdaylight test failure in the gnome-calendar test suite.

Fixes: #1317 
