### PR TITLE
Use global enums rather than strings to identify structure types

### DIFF
--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -249,6 +249,7 @@ set(
   icalduration.c
   icalperiod.h
   icalperiod.c
+  icaltypes_p.h
   icaltypes.c
   icaltypes.h
   icalvalue.c

--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -25,13 +25,14 @@
 #include "icalrestriction.h"
 #include "icaltime_p.h"
 #include "icaltimezone.h"
+#include "icaltypes_p.h"
 
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>
 
 struct icalcomponent_impl {
-    char id[5];
+    icalstructuretype id;
     icalcomponent_kind kind;
     char *x_name; /* also used for ICAL_IANA_COMPONENT */
     icalpvl_list properties;
@@ -95,8 +96,7 @@ static icalcomponent *icalcomponent_new_impl(icalcomponent_kind kind)
 
     memset(comp, 0, sizeof(icalcomponent));
 
-    strcpy(comp->id, "comp");
-
+    comp->id = ICAL_STRUCTURE_TYPE_COMPONENT;
     comp->kind = kind;
     comp->properties = icalpvl_newlist();
     comp->components = icalpvl_newlist();
@@ -225,7 +225,7 @@ void icalcomponent_free(icalcomponent *c)
     c->components = 0;
     c->component_iterator = 0;
     c->x_name = 0;
-    c->id[0] = 'X';
+    c->id = ICAL_STRUCTURE_TYPE_COMPONENT_EMPTY;
     c->timezones = NULL;
 
     icalmemory_free_buffer(c);
@@ -314,7 +314,7 @@ char *icalcomponent_as_ical_string_r(const icalcomponent *component)
 bool icalcomponent_is_valid(const icalcomponent *component)
 {
     if (component) {
-        if ((strcmp(component->id, "comp") == 0) && component->kind != ICAL_NO_COMPONENT) {
+        if ((component->id == ICAL_STRUCTURE_TYPE_COMPONENT) && component->kind != ICAL_NO_COMPONENT) {
             return true;
         }
     }
@@ -334,11 +334,7 @@ bool icalcomponent_isa_component(const void *component)
 
     icalerror_check_arg_rz((component != 0), "component");
 
-    if (strcmp(impl->id, "comp") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_COMPONENT);
 }
 
 void icalcomponent_set_x_name(icalcomponent *comp, const char *name)

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -40,8 +40,7 @@ LIBICAL_ICAL_EXPORT struct icalparameter_impl *icalparameter_new_impl(icalparame
 
     memset(v, 0, sizeof(struct icalparameter_impl));
 
-    strcpy(v->id, "para");
-
+    v->id = ICAL_STRUCTURE_TYPE_PARAMETER;
     v->kind = kind;
     v->value_kind = icalparameter_kind_value_kind(kind, &v->is_multivalued);
 
@@ -80,7 +79,7 @@ void icalparameter_free(icalparameter *param)
     memset(param, 0, sizeof(icalparameter));
 
     param->parent = 0;
-    param->id[0] = 'X';
+    param->id = ICAL_STRUCTURE_TYPE_PARAMETER_EMPTY;
     icalmemory_free_buffer(param);
 }
 
@@ -294,11 +293,7 @@ bool icalparameter_isa_parameter(void *parameter)
         return false;
     }
 
-    if (strcmp(impl->id, "para") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_PARAMETER);
 }
 
 void icalparameter_set_xname(icalparameter *param, const char *v)

--- a/src/libical/icalparameterimpl.h
+++ b/src/libical/icalparameterimpl.h
@@ -15,10 +15,11 @@
 #define ICALPARAMETERIMPL_H
 
 #include "icalproperty.h"
+#include "icaltypes_p.h"
 
 struct icalparameter_impl {
     icalparameter_kind kind;
-    char id[5];
+    icalstructuretype id;
     int size;
     const char *string;
     const char *x_name;

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -24,11 +24,12 @@
 #include "icaltimezone.h"
 #include "icalvalue.h"
 #include "icalpvl_p.h"
+#include "icaltypes_p.h"
 
 #include <stdlib.h>
 
 struct icalproperty_impl {
-    char id[5];
+    icalstructuretype id;
     icalproperty_kind kind;
     char *x_name;
     icalpvl_list parameters;
@@ -53,8 +54,7 @@ LIBICAL_ICAL_EXPORT struct icalproperty_impl *icalproperty_new_impl(icalproperty
 
     memset(prop, 0, sizeof(icalproperty));
 
-    strcpy(prop->id, "prop");
-
+    prop->id = ICAL_STRUCTURE_TYPE_PROPERTY;
     prop->kind = kind;
     prop->parameters = icalpvl_newlist();
 
@@ -208,7 +208,7 @@ void icalproperty_free(icalproperty *p)
     p->parameter_iterator = 0;
     p->value = 0;
     p->x_name = 0;
-    p->id[0] = 'X';
+    p->id = ICAL_STRUCTURE_TYPE_PROPERTY_EMPTY;
 
     icalmemory_free_buffer(p);
 }
@@ -478,11 +478,7 @@ bool icalproperty_isa_property(void *property)
     const icalproperty *impl = (icalproperty *)property;
 
     icalerror_check_arg_rz((property != 0), "property");
-    if (strcmp(impl->id, "prop") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_PROPERTY);
 }
 
 void icalproperty_add_parameter(icalproperty *p, icalparameter *parameter)

--- a/src/libical/icaltypes_p.h
+++ b/src/libical/icaltypes_p.h
@@ -1,0 +1,32 @@
+/*======================================================================
+ FILE: icaltypes_p.h
+
+ SPDX-FileCopyrightText: Allen Winter <winter@kde.org>
+ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
+======================================================================*/
+
+/**
+ * @file icaltypes_p.h
+ * @brief Define private internal types.
+ */
+
+#ifndef ICALTYPES_P_H
+#define ICALTYPES_P_H
+
+/**
+ * Identifiers for structure types.
+ */
+typedef enum
+{
+    ICAL_STRUCTURE_TYPE_UNKNOWN,         /** Unknown structure type */
+    ICAL_STRUCTURE_TYPE_VALUE,           /** Populated value structure */
+    ICAL_STRUCTURE_TYPE_VALUE_EMPTY,     /** Empty value structure */
+    ICAL_STRUCTURE_TYPE_PARAMETER,       /** Populated parameter structure */
+    ICAL_STRUCTURE_TYPE_PARAMETER_EMPTY, /** Empty parameter structure */
+    ICAL_STRUCTURE_TYPE_PROPERTY,        /** Populated property structure */
+    ICAL_STRUCTURE_TYPE_PROPERTY_EMPTY,  /** Empty property structure */
+    ICAL_STRUCTURE_TYPE_COMPONENT,       /** Populated component structure */
+    ICAL_STRUCTURE_TYPE_COMPONENT_EMPTY, /** Empty component structure */
+} icalstructuretype;
+
+#endif /* !ICALTYPES_P_H */

--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -45,7 +45,7 @@ LIBICAL_ICAL_EXPORT struct icalvalue_impl *icalvalue_new_impl(icalvalue_kind kin
         return 0;
     }
 
-    strcpy(v->id, "val");
+    v->id = ICAL_STRUCTURE_TYPE_VALUE;
 
     v->kind = kind;
     v->size = 0;
@@ -71,9 +71,7 @@ icalvalue *icalvalue_clone(const icalvalue *old)
     if (clone == 0) {
         return 0;
     }
-    // id is a LIBICAL_ICALVALUE_ID_LENGTH-char string (see icalvalue_impl def)
-    memset(clone->id, 0, LIBICAL_ICALVALUE_ID_LENGTH);
-    strncpy(clone->id, old->id, LIBICAL_ICALVALUE_ID_LENGTH);
+    clone->id = old->id;
     clone->kind = old->kind;
     clone->size = old->size;
 
@@ -868,7 +866,7 @@ void icalvalue_free(icalvalue *v)
     v->size = 0;
     v->parent = 0;
     memset(&(v->data), 0, sizeof(v->data));
-    v->id[0] = 'X';
+    v->id = ICAL_STRUCTURE_TYPE_VALUE_EMPTY;
     icalmemory_free_buffer(v);
 }
 
@@ -1341,11 +1339,7 @@ bool icalvalue_isa_value(void *value)
 
     icalerror_check_arg_rz((value != 0), "value");
 
-    if (strcmp(impl->id, "val") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_VALUE);
 }
 
 static bool icalvalue_is_time(const icalvalue *a)

--- a/src/libical/icalvalueimpl.h
+++ b/src/libical/icalvalueimpl.h
@@ -13,12 +13,12 @@
 #define ICALVALUEIMPL_H
 
 #include "icalproperty.h"
+#include "icaltypes_p.h"
 
-#define LIBICAL_ICALVALUE_ID_LENGTH 5
 struct icalvalue_impl {
     icalvalue_kind kind; /*this is the kind that is visible from the outside */
 
-    char id[LIBICAL_ICALVALUE_ID_LENGTH];
+    icalstructuretype id;
     int size;
     icalproperty *parent;
     char *x_value;

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -24,6 +24,7 @@
 #include "icalerror_p.h"
 #include "icalerror.h"
 #include "icalmemory.h"
+#include "icaltypes_p.h"
 
 #include <assert.h>
 #include <stdlib.h>
@@ -31,7 +32,7 @@
 #include <ctype.h>
 
 struct vcardcomponent_impl {
-    char id[5];
+    icalstructuretype id;
     vcardcomponent_kind kind;
     vcardproperty *versionp;
     icalpvl_list properties;
@@ -67,8 +68,7 @@ static vcardcomponent *vcardcomponent_new_impl(vcardcomponent_kind kind)
 
     memset(comp, 0, sizeof(vcardcomponent));
 
-    strcpy(comp->id, "comp");
-
+    comp->id = ICAL_STRUCTURE_TYPE_COMPONENT;
     comp->kind = kind;
     comp->properties = icalpvl_newlist();
     comp->components = icalpvl_newlist();
@@ -163,7 +163,7 @@ void vcardcomponent_free(vcardcomponent *c)
     c->property_iterator = 0;
     c->components = 0;
     c->component_iterator = 0;
-    c->id[0] = 'X';
+    c->id = ICAL_STRUCTURE_TYPE_COMPONENT_EMPTY;
 
     icalmemory_free_buffer(c);
 }
@@ -249,7 +249,7 @@ char *vcardcomponent_as_vcard_string_r(vcardcomponent *comp)
 bool vcardcomponent_is_valid(const vcardcomponent *component)
 {
     if (component) {
-        if ((strcmp(component->id, "comp") == 0) && (component->kind != VCARD_NO_COMPONENT)) {
+        if ((component->id == ICAL_STRUCTURE_TYPE_COMPONENT) && (component->kind != VCARD_NO_COMPONENT)) {
             return true;
         }
     }
@@ -269,7 +269,7 @@ bool vcardcomponent_isa_component(const void *component)
 
     icalerror_check_arg_rz((component != 0), "component");
 
-    return (strcmp(impl->id, "comp") == 0);
+    return (impl->id == ICAL_STRUCTURE_TYPE_COMPONENT);
 }
 
 void vcardcomponent_add_property(vcardcomponent *comp, vcardproperty *property)

--- a/src/libicalvcard/vcardparameter.c
+++ b/src/libicalvcard/vcardparameter.c
@@ -34,8 +34,7 @@ LIBICAL_VCARD_EXPORT struct vcardparameter_impl *vcardparameter_new_impl(vcardpa
 
     memset(v, 0, sizeof(struct vcardparameter_impl));
 
-    strcpy(v->id, "para");
-
+    v->id = ICAL_STRUCTURE_TYPE_PARAMETER;
     v->kind = kind;
     v->value_kind = vcardparameter_kind_value_kind(kind, &v->is_multivalued);
 
@@ -74,7 +73,7 @@ void vcardparameter_free(vcardparameter *param)
     memset(param, 0, sizeof(vcardparameter));
 
     param->parent = 0;
-    param->id[0] = 'X';
+    param->id = ICAL_STRUCTURE_TYPE_PARAMETER_EMPTY;
     icalmemory_free_buffer(param);
 }
 
@@ -307,11 +306,7 @@ bool vcardparameter_isa_parameter(void *parameter)
         return false;
     }
 
-    if (strcmp(impl->id, "para") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_PARAMETER);
 }
 
 void vcardparameter_set_xname(vcardparameter *param, const char *v)

--- a/src/libicalvcard/vcardparameterimpl.h
+++ b/src/libicalvcard/vcardparameterimpl.h
@@ -12,10 +12,11 @@
 #include "vcardproperty.h"
 #include "vcardderivedvalue.h"
 #include "icalarray.h"
+#include "icaltypes_p.h"
 
 struct vcardparameter_impl {
     vcardparameter_kind kind;
-    char id[5];
+    icalstructuretype id;
     int size;
     const char *x_name;
     vcardproperty *parent;

--- a/src/libicalvcard/vcardproperty.c
+++ b/src/libicalvcard/vcardproperty.c
@@ -23,11 +23,12 @@
 #include "icalmemory.h"
 #include "icalproperty.h"
 #include "icalpvl_p.h"
+#include "icaltypes_p.h"
 
 #include <stdlib.h>
 
 struct vcardproperty_impl {
-    char id[5];
+    icalstructuretype id;
     vcardproperty_kind kind;
     char *x_name;
     char *group;
@@ -52,8 +53,7 @@ LIBICAL_VCARD_EXPORT struct vcardproperty_impl *vcardproperty_new_impl(vcardprop
 
     memset(prop, 0, sizeof(vcardproperty));
 
-    strcpy(prop->id, "prop");
-
+    prop->id = ICAL_STRUCTURE_TYPE_PROPERTY;
     prop->kind = kind;
     prop->parameters = icalpvl_newlist();
 
@@ -202,7 +202,7 @@ void vcardproperty_free(vcardproperty *p)
     p->parameter_iterator = 0;
     p->value = 0;
     p->x_name = 0;
-    p->id[0] = 'X';
+    p->id = ICAL_STRUCTURE_TYPE_PROPERTY_EMPTY;
 
     icalmemory_free_buffer(p);
 }
@@ -541,11 +541,7 @@ bool vcardproperty_isa_property(void *property)
     const vcardproperty *impl = (vcardproperty *)property;
 
     icalerror_check_arg_rz((property != 0), "property");
-    if (strcmp(impl->id, "prop") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_PROPERTY);
 }
 
 void vcardproperty_add_parameter(vcardproperty *p, vcardparameter *parameter)

--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -42,8 +42,7 @@ LIBICAL_VCARD_EXPORT struct vcardvalue_impl *vcardvalue_new_impl(vcardvalue_kind
         return 0;
     }
 
-    strcpy(v->id, "val");
-
+    v->id = ICAL_STRUCTURE_TYPE_VALUE;
     v->kind = kind;
     v->size = 0;
     v->parent = 0;
@@ -68,9 +67,7 @@ vcardvalue *vcardvalue_clone(const vcardvalue *old)
         return 0;
     }
 
-    // id is a LIBICAL_VCARDVALUE_ID_LENGTH-char string (see vcardvalue_impl def)
-    memset(clone->id, 0, LIBICAL_VCARDVALUE_ID_LENGTH);
-    strncpy(clone->id, old->id, LIBICAL_VCARDVALUE_ID_LENGTH);
+    clone->id = old->id;
     clone->kind = old->kind;
     clone->size = old->size;
 
@@ -624,7 +621,7 @@ void vcardvalue_free(vcardvalue *v)
     v->size = 0;
     v->parent = 0;
     memset(&(v->data), 0, sizeof(v->data));
-    v->id[0] = 'X';
+    v->id = ICAL_STRUCTURE_TYPE_VALUE_EMPTY;
     icalmemory_free_buffer(v);
 }
 
@@ -983,11 +980,7 @@ bool vcardvalue_isa_value(void *value)
 
     icalerror_check_arg_rz((value != 0), "value");
 
-    if (strcmp(impl->id, "val") == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return (impl->id == ICAL_STRUCTURE_TYPE_VALUE);
 }
 
 /** Examine the value and possibly change the kind to agree with the

--- a/src/libicalvcard/vcardvalueimpl.h
+++ b/src/libicalvcard/vcardvalueimpl.h
@@ -12,12 +12,12 @@
 #include "vcardderivedvalue.h"
 #include "vcardproperty.h"
 #include "vcardtime.h"
+#include "icaltypes_p.h"
 
-#define LIBICAL_VCARDVALUE_ID_LENGTH 5
 struct vcardvalue_impl {
     vcardvalue_kind kind; /* the kind that is visible from the outside */
 
-    char id[LIBICAL_VCARDVALUE_ID_LENGTH];
+    icalstructuretype id;
     int size;
     vcardproperty *parent;
     char *x_value;


### PR DESCRIPTION
also saves some memory

fixes: #1326
