### PR TITLE
icaltime: bounds-check month in icaltime_day_of_year 

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -534,6 +534,10 @@ int icaltime_day_of_year(const struct icaltimetype t)
 {
     unsigned int is_leap = (icaltime_is_leap_year(t.year) ? 1 : 0);
 
+    if (t.month < 1 || t.month > 12) {
+        return 0;
+    }
+
     return days_in_year_passed_month[is_leap][t.month - 1] + t.day;
 }
 


### PR DESCRIPTION
Fixes #1331 

## Bug

`icaltime_day_of_year` (src/libical/icaltime.c:533) reads the static `days_in_year_passed_month[is_leap][t.month - 1]` lookup table with no range check on `t.month`. For `t.month = 0` the index is `-1`; for `t.month >= 14` the index falls past the 13-element row.

The sister helper `icaltime_days_in_month` in the same file already has this guard (lines ~470-480, with a comment block explaining the GIGO rationale: "Modern applications cannot tolerate crashing. ... apply the GIGO principle"). `icaltime_day_of_year` was the only remaining date helper in `icaltime.c` without it.

PR #1058 (merged 2025-10-03) added a caller-side guard at `expand_year_days` after oss-fuzz testcase 5651102642274304 hit the OOB through `BYMONTH=4000`. That fix covered one of three internal callers. Still unguarded:

- `get_week_number` (icalrecur.c:2089) — `week = (icaltime_day_of_year(tt) - dow + 10) / 7;`
- `get_day_of_year` (icalrecur.c:2134) — `return icaltime_day_of_year(get_dtstart_adjusted(impl, year, month, day));`
- Any external caller of the exported symbol (`icaltime.h:311 LIBICAL_ICAL_EXPORT`)

## Reproduction

Standalone extract of the function (only the table + the buggy function, no libical dependency) built with `gcc -O1 -g -fsanitize=undefined,bounds`:

```c
struct icaltimetype cases[] = {
    {2026, 1,   1},  // valid
    {2026, 12, 31},  // valid
    {2026, 0,   1},  // OOB: index -1
    {2026, 13,  1},  // index 12 (in-row but semantically wrong: returns end-of-year sentinel)
    {2026, 14,  1},  // OOB: index 13 (past the row)
    {2026, 255, 1},  // OOB: far past
};
```

Unpatched output:
```
runtime error: index -1 out of bounds for type 'int [13]'
runtime error: load of address 0x... with insufficient space for an object of type 'const int'

year=2026 month=1   day=1  -> day_of_year=1
year=2026 month=12  day=31 -> day_of_year=365
year=2026 month=0   day=1  -> day_of_year=1     // OOB
year=2026 month=13  day=1  -> day_of_year=366   // in-row but wrong: reads days_in_year_passed_month[1][12] = end-of-leap-year
year=2026 month=14  day=1  -> day_of_year=1     // OOB into next row's [0]
year=2026 month=255 day=1  -> day_of_year=1     // far OOB
```

The `month=14` case is the classic OOB. The `month=13` case is more interesting: it reads in-bounds at index 12 but that table slot holds 365 (or 366 for leap) — meant as a sentinel for "all days of December passed". A caller asking "what's the day-of-year of month 13" gets back 366, a plausibly-valid day-of-year value, and cannot detect the silent corruption.

## Fix

```diff
 int icaltime_day_of_year(const struct icaltimetype t)
 {
     unsigned int is_leap = (icaltime_is_leap_year(t.year) ? 1 : 0);

+    if (t.month < 1 || t.month > 12) {
+        return 0;
+    }
+
     return days_in_year_passed_month[is_leap][t.month - 1] + t.day;
 }
```

Returns 0 for invalid month. 0 is outside the valid day-of-year range (1..366), and `get_week_number` at icalrecur.c:2092 already handles a result `< 1` by falling back to `weeks_in_year(tt.year - 1)`. Mirrors the existing `icaltime_days_in_month` pattern (which returns 30 for the same condition).

## Verification

Same PoC built against the patched function:
```
year=2026 month=1   day=1  -> day_of_year=1
year=2026 month=12  day=31 -> day_of_year=365
year=2026 month=0   day=1  -> day_of_year=0
year=2026 month=13  day=1  -> day_of_year=0
year=2026 month=14  day=1  -> day_of_year=0
year=2026 month=255 day=1  -> day_of_year=0
```

No sanitizer error. All in-range inputs return identical values to the unpatched version (the guard is before the existing return path, so the happy path is unchanged).

Did not run the full libical test suite in this engagement (`libical_xxx.a` build did not complete cleanly in my environment). Patch is additive in front of existing code — any test exercising a valid month is unaffected by construction.

## Open question

Function-level guard (this patch) vs per-caller fixes at `get_week_number` and `get_day_of_year`. I went with function-level because:
- it matches the existing `icaltime_days_in_month` pattern in the same file,
- it protects external API users too.

Happy to switch to caller-side fixes if you'd prefer the same shape as #1058.

