### PR TITLE
icalvalue: avoid abs(INT_MIN) UB in utcoffset stringifier

### DIFF
--- a/src/libical/icalvalue.c
+++ b/src/libical/icalvalue.c
@@ -936,7 +936,7 @@ static char *icalvalue_utcoffset_as_ical_string_r(const icalvalue *value)
     str = (char *)icalmemory_new_buffer(9);
     data = icalvalue_get_utcoffset(value);
 
-    if (abs(data) == data) {
+    if (data >= 0) {
         sign = '+';
     } else {
         sign = '-';


### PR DESCRIPTION
### Bug

`src/libical/icalvalue.c:941` uses `abs(data) == data` to determine the sign of a UTC offset:

```c
data = icalvalue_get_utcoffset(value);
if (abs(data) == data) {
    sign = '+';
} else {
    sign = '-';
}
```

`abs(INT_MIN)` is undefined behavior (C99 7.20.6.1). Furthermore, on two's-complement systems, `abs(INT_MIN)` typically returns `INT_MIN`, making the comparison `true` and incorrectly assigning a `+` sign to a negative offset.

### Reproduction

Built with `gcc -fsanitize=undefined`:

```
runtime error: negation of -2147483648 cannot be represented in type 'int'
data=-2147483648 -> sign=+  (Wrong: should be negative)
```

### Fix

Replace `abs(data) == data` with `data >= 0`. This is well-defined for all `int` values and correctly handles `INT_MIN`.

### Verification

Verified with the patched PoC:

```
data=-2147483648 -> sign=-  (Correct)
```

No sanitizer errors triggered. other path values (positive/negative offsets) remain unchanged.