### PR TITLE
icaltime: fix 32-bit time_t upper bound off by two days

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -104,14 +104,19 @@ static bool make_time(const struct tm *tm, int tzm, icaltime_t *out_time_t)
         return false;
     }
 
-    /* check for upper bound of Jan 17, 2038 (to avoid possibility of 32-bit arithmetic overflow) */
-    if (tm->tm_year == 138) {
-        if (tm->tm_mon > 0) {
-            return false;
-        } else if (tm->tm_mday > 17) {
-            return false;
-        }
+    /* 32-bit time_t cannot represent any instant after
+       2038-01-19T03:14:07 UTC (INT32_MAX seconds since the epoch). */
+    if (tm->tm_year == 138 &&
+        (tm->tm_mon > 0 ||
+         tm->tm_mday > 19 ||
+         (tm->tm_mday == 19 &&
+          (tm->tm_hour > 3 ||
+           (tm->tm_hour == 3 &&
+            (tm->tm_min > 14 ||
+             (tm->tm_min == 14 && tm->tm_sec > 7))))))) {
+        return false;
     }
+
 #else
     /* We don't support years >= 10000, because the function has not been tested at this range. */
     if (tm->tm_year >= 8100) {

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -6071,7 +6071,8 @@ void test_icaltime_as_timet(void)
     icaltime_adjust(&tt, 0, 0, 0, 1);
     ok("icaltime_from_string translates 100000101T000000Z to -1", icaltime_as_timet(tt) == -1);
 #else
-    ok("icaltime_from_string translates 20380118T000000Z to -1", icaltime_as_timet(icaltime_from_string("20380118T000000Z")) == -1);
+    ok("icaltime_from_string translates 20380119T031407Z to 2147483647", icaltime_as_timet(icaltime_from_string("20380119T031407Z")) == 2147483647);
+    ok("icaltime_from_string translates 20380119T031408Z to -1", icaltime_as_timet(icaltime_from_string("20380119T031408Z")) == -1);
 #endif
 
     tt = icaltime_from_string("19020101T000000Z");
@@ -6081,7 +6082,7 @@ void test_icaltime_as_timet(void)
     // Going through each day until 10000 takes ~250ms on a reasonably powered year 2020 business laptop.
     while (tt.year < 10000)
 #else
-    while ((tt.year < 2038) || ((tt.year == 2038) && (tt.month == 1) && (tt.day <= 17)))
+    while ((tt.year < 2038) || ((tt.year == 2038) && (tt.month == 1) && (tt.day <= 19)))
 #endif
     {
         time_t actualTimeT = icaltime_as_timet(tt);


### PR DESCRIPTION
## Problem

On 32-bit `time_t` builds, `make_time()` rejects any date after
**2038-01-17**, two days before the real limit of a signed 32-bit
`time_t` — **2038-01-19T03:14:07 UTC** (`INT32_MAX` seconds since the
epoch). Rejected values fall through `icaltime_timegm()` as a bare
`return 0`, so `icaltime_as_timet_with_zone()` silently returns
1970-01-01 instead of the correct time_t value *or* an explicit error.

This is easy to trigger by accident: any caller using `INT_MAX` (or a
similarly derived value) as an "unbounded end" sentinel — a common
pattern for "search forever" / "no upper bound" — gets that sentinel
silently collapsed to epoch. That corrupts the bounding window rather
than leaving it unbounded.

## Real-world impact

Found via Debian bug [#1142273](https://bugs.debian.org/1142273)
(cyrus-imapd FTBFS on i386). cyrus's `icalrecurrenceset_get_utc_timespan()`
passes `INT_MAX` as the outer search bound to
`icalcomponent_foreach_recurrence()`. On i386, that bound collapses to
epoch, so the search window shrinks to nothing-after-1970 and *every*
occurrence gets silently excluded — even for events with no relation
to the 2038 boundary at all (verified with a plain `FREQ=WEEKLY;COUNT=3`
rule from 2016).

## History

The check has been wrong since introduction, in 72330c96 (2001-2002),
with no explanation for the specific constant. Five months later, the
same author hit the consequence and wrote, in ef907061: *"we simply
don't handle recurrences after 2038. This is arguably a bug, but let
the regression test follow the code."* — and adjusted a test to match
the bug rather than fix it. It's been carried forward unchanged
through several later refactors of this file.

## Fix

Replace the padded, day-level approximation with an exact check
against the true boundary, down to the second. No arbitrary margin
needed — `SIZEOF_ICALTIME_T==4` callers already receive UTC-normalized
input by the time this check runs (`icaltime_as_timet_with_zone()`
converts to UTC before calling into `icaltime_timegm()`), so there's
no timezone ambiguity to hedge against.

Also updates the two existing regression tests that had baked in the
old, incorrect cutoff as the expected result.

## Testing

- Round-trip test: `INT_MAX` → date → `time_t` now correctly returns
  `INT_MAX` instead of `0`, on an i386 build.
- Full `ctest` regression suite: 47/47 pass on i386.
- Rebuilt cyrus-imapd's actual failing cunit test (`ical_support`,
  unmodified) against a patched i386 `libical.so`: now passes (was
  failing before the fix, matching the Debian buildd failure exactly).
- Change is entirely inside `#if (SIZEOF_ICALTIME_T == 4)` — provably
  a no-op on 64-bit builds, not just untested.

## Note for reviewers

I haven't audited downstream consumers (evolution-data-server,
KCalendarCore, etc.) for code that might treat
`icaltime_as_timet() == 0` as a deliberate "invalid" sentinel rather
than genuine epoch. I think that's unlikely and fragile if it exists,
but flagging it as an open question rather than asserting it away.

---

*Disclosure: I used Claude (Anthropic) to help find and trace the root
cause — reading through the code, building instrumented i386 binaries,
and stepping through with gdb to isolate exactly where the boundary
value got corrupted. The fix, its exact shape, and all testing here
are mine.*
