### PR TITLE
icaltime: fix 32-bit time_t upper bound off by two days (3.0 backport)

### DIFF
--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -105,13 +105,17 @@ static int make_time(const struct tm *tm, int tzm, time_t *out_time_t)
     if (tm->tm_year > 138)
         return 0;
 
-    /* check for upper bound of Jan 17, 2038 (to avoid possibility of 32-bit arithmetic overflow) */
-    if (tm->tm_year == 138) {
-        if (tm->tm_mon > 0) {
-            return 0;
-        } else if (tm->tm_mday > 17) {
-            return 0;
-        }
+    /* 32-bit time_t cannot represent any instant after
+       2038-01-19T03:14:07 UTC (INT32_MAX seconds since the epoch). */
+    if (tm->tm_year == 138 &&
+        (tm->tm_mon > 0 ||
+         tm->tm_mday > 19 ||
+         (tm->tm_mday == 19 &&
+          (tm->tm_hour > 3 ||
+           (tm->tm_hour == 3 &&
+            (tm->tm_min > 14 ||
+             (tm->tm_min == 14 && tm->tm_sec > 7))))))) {
+        return 0;
     }
 #else
     /* We don't support years >= 10000, because the function has not been tested at this range. */

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -5253,7 +5253,8 @@ void test_icaltime_as_timet(void)
     icaltime_adjust(&tt, 0, 0, 0, 1);
     ok("icaltime_from_string translates 100000101T000000Z to -1", icaltime_as_timet(tt) == -1);
 #else
-    ok("icaltime_from_string translates 20380118T000000Z to -1", icaltime_as_timet(icaltime_from_string("20380118T000000Z")) == -1);
+    ok("icaltime_from_string translates 20380119T031407Z to 2147483647", icaltime_as_timet(icaltime_from_string("20380119T031407Z")) == 2147483647);
+    ok("icaltime_from_string translates 20380119T031408Z to -1", icaltime_as_timet(icaltime_from_string("20380119T031408Z")) == -1);
 #endif
 
     tt = icaltime_from_string("19020101T000000Z");
@@ -5263,7 +5264,7 @@ void test_icaltime_as_timet(void)
     // Going through each day until 10000 takes ~250ms on a reasonably powered year 2020 business laptop.
     while (tt.year < 10000)
 #else
-    while ((tt.year < 2038) || ((tt.year == 2038) && (tt.month == 1) && (tt.day <= 17)))
+    while ((tt.year < 2038) || ((tt.year == 2038) && (tt.month == 1) && (tt.day <= 19)))
 #endif
     {
         time_t actualTimeT = icaltime_as_timet(tt);


### PR DESCRIPTION
Backport of #1350 to the `3.0` branch, which is what several
distributions — notably Debian's `libical3` package — still ship.
Same problem, same fix; see #1350 for the full writeup (root cause,
history, and testing). Summary below.

## Problem

On 32-bit `time_t` builds, `make_time()` rejects any date after
**2038-01-17**, two days before the real limit of a signed 32-bit
`time_t` — **2038-01-19T03:14:07 UTC** (`INT32_MAX` seconds since the
epoch). Rejected values fall through `icaltime_timegm()` as a bare
`return 0`, so `icaltime_as_timet_with_zone()` silently returns
1970-01-01 instead of the correct time_t value *or* an explicit error.

Any caller using `INT_MAX` as an "unbounded end" sentinel (a common
calendar idiom) gets that sentinel silently collapsed to epoch.

## Real-world impact

Found via Debian bug [#1142273](https://bugs.debian.org/1142273)
(cyrus-imapd FTBFS on i386). cyrus's `icalrecurrenceset_get_utc_timespan()`
passes `INT_MAX` as the outer search bound to
`icalcomponent_foreach_recurrence()`; on i386 that collapses to epoch,
so the search window shrinks to nothing-after-1970 and every
occurrence gets silently excluded — verified with a plain
`FREQ=WEEKLY;COUNT=3` rule from 2016, nowhere near the 2038 boundary.

## Fix

Exact boundary check (year/month/day/hour/min/sec) instead of the
padded day-level approximation, no arbitrary margin needed since
`icaltime_as_timet_with_zone()` already normalizes to UTC before this
check runs. Updates the two regression tests that had the old,
incorrect cutoff baked in as expected behavior.

## Testing

Same as #1350: round-trip test confirms `INT_MAX` now correctly
returns `INT_MAX` instead of `0` on an i386 build; full regression
suite passes; cyrus-imapd's real, previously-failing cunit test now
passes unmodified against a patched i386 `libical.so`.

---

*Disclosure: I used Claude (Anthropic) to help find and trace the root
cause on the 4.0 branch (#1350); this is a straightforward backport of
that fix to 3.0, done and tested the same way.*
