### PR TITLE
icaltimezone_fetch_timezone() - don't error on bad TZID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix 32-bit time_t upper bound off by two days
 - Buildsystem: fix libical_deprecated_option() writing the wrong cache value
+- Bogus TZIDs no longer cause an error
 
 ## [4.0.4] - 2026-07-25
 

--- a/src/libical/icaltimezone_p.c
+++ b/src/libical/icaltimezone_p.c
@@ -406,7 +406,8 @@ icalcomponent *icaltimezone_fetch_timezone(const char *location)
     }
     snprintf(full_path, size, "%s/%s", zonedir, location);
     if ((f = fopen(full_path, "rb")) == 0) {
-        icalerror_set_errno(ICAL_FILE_ERROR);
+        /* Don't error. Return a NULL pointer to indicate a bad TZID */
+        //icalerror_set_errno(ICAL_FILE_ERROR);
         goto error;
     }
 


### PR DESCRIPTION
In icaltimezone_fetch_timezone, if the specified TZID file cannot be
found (or the file open fails) we no longer produce an error; instead
we return a NULL pointer to indicate the specified TZID was bogus.
