### PR TITLE
Fix invoking bsearch through an incompatible function pointer

### DIFF
--- a/src/libical/icalderivedparameter.c.in
+++ b/src/libical/icalderivedparameter.c.in
@@ -117,10 +117,18 @@ const char *icalparameter_kind_to_string(icalparameter_kind kind)
     return 0;
 }
 
+/** DO NOT USE. RETAINED FOR BC in 4.0. Remove in 4.1 and above */
 int icalparameter_compare_kind_map(const struct icalparameter_kind_map *a,
                                    const struct icalparameter_kind_map *b)
 {
     return strcasecmp(a->name, b->name);
+}
+
+static int s_icalparameter_compare_kind_map(const void *a, const void *b)
+{
+    const struct icalparameter_kind_map *amap = (struct icalparameter_kind_map *)a;
+    const struct icalparameter_kind_map *bmap = (struct icalparameter_kind_map *)b;
+    return strcasecmp(amap->name, bmap->name);
 }
 
 icalparameter_kind icalparameter_string_to_kind(const char *string)
@@ -139,7 +147,7 @@ icalparameter_kind icalparameter_string_to_kind(const char *string)
     result =
         (struct icalparameter_kind_map *)bsearch(&key, parameter_map, sizeof(parameter_map) / sizeof(struct icalparameter_kind_map),
                 sizeof(struct icalparameter_kind_map),
-                (int (*)(const void *, const void *))icalparameter_compare_kind_map);
+                s_icalparameter_compare_kind_map);
 
     if (result) {
         return result->kind;

--- a/src/libicalvcard/vcardderivedparameter.c.in
+++ b/src/libicalvcard/vcardderivedparameter.c.in
@@ -116,10 +116,18 @@ const char *vcardparameter_kind_to_string(vcardparameter_kind kind)
     return 0;
 }
 
+/** DO NOT USE. RETAINED FOR BC in 4.0. Remove in 4.1 and above */
 int vcardparameter_compare_kind_map(const struct vcardparameter_kind_map *a,
-                                   const struct vcardparameter_kind_map *b)
+                                    const struct vcardparameter_kind_map *b)
 {
     return strcasecmp(a->name, b->name);
+}
+
+static int s_vcardparameter_compare_kind_map(const void *a, const void *b)
+{
+    const struct vcardparameter_kind_map *amap = (struct vcardparameter_kind_map *)a;
+    const struct vcardparameter_kind_map *bmap = (struct vcardparameter_kind_map *)b;
+    return strcasecmp(amap->name, bmap->name);
 }
 
 vcardparameter_kind vcardparameter_string_to_kind(const char *string)
@@ -136,7 +144,7 @@ vcardparameter_kind vcardparameter_string_to_kind(const char *string)
     result =
         (struct vcardparameter_kind_map *)bsearch(&key, parameter_map, sizeof(parameter_map) / sizeof(struct vcardparameter_kind_map),
                 sizeof(struct vcardparameter_kind_map),
-                (int (*)(const void *, const void *))vcardparameter_compare_kind_map);
+                s_vcardparameter_compare_kind_map);
 
     if (result) {
         return result->kind;


### PR DESCRIPTION
Ensure binary compatibility with a symbol change (low risk).
i.e avoid "replacement of parameter data type may indicate a change
in its semantic meaning."

fixes: #1361
