### PR TITLE
tests/ - cleaning, clang-tidy fixes, add commented-tests

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,7 @@ Checks: -*,
         -readability-use-std-min-max,
         -readability-use-concise-preprocessor-directives,
 
+HeaderFilterRegex: '/libical/src/\|libical/vzic/'
 CheckOptions:
     - key: bugprone-reserved-identifier.AllowedIdentifiers
       value: '__ICalTriggerType_;__ICalTimeType_;__ICalRecurrenceType_;__ICalPeriodType_;__ICalDurationType_'

--- a/src/libicalss/icalclassify.c
+++ b/src/libicalss/icalclassify.c
@@ -108,7 +108,7 @@ icalproperty *icalclassify_find_attendee(const icalcomponent *c, const char *att
     char *lattendee;
     const char *upn;
 
-    if (attendee == 0) {
+    if (!c || !attendee) {
         return 0;
     }
 
@@ -187,12 +187,11 @@ void icalssutil_get_parts(icalcomponent *c, struct icalclassify_parts *parts)
     parts->method = ICAL_METHOD_NONE;
     parts->sequence = 0;
     parts->reply_partstat = ICAL_PARTSTAT_NONE;
+    parts->c = c;
 
     if (c == 0) {
         return;
     }
-
-    parts->c = c;
 
     p = icalcomponent_get_first_property(c, ICAL_METHOD_PROPERTY);
     if (p != 0) {

--- a/src/libicalss/icaldirset.c
+++ b/src/libicalss/icaldirset.c
@@ -168,7 +168,9 @@ icalset *icaldirset_init(icalset *set, const char *dir, void *options_in)
     icaldirset_lock(dir);
 
     dset->dir = (char *)strdup(dir);
-    dset->options = *options;
+    if (options) {
+        dset->options = *options;
+    }
     dset->directory = icalpvl_newlist();
     dset->directory_iterator = 0;
     dset->gauge = 0;

--- a/src/test/builtin_timezones.c
+++ b/src/test/builtin_timezones.c
@@ -110,7 +110,7 @@ int main(void)
     printf("got %lu zones\n", (unsigned long)builtin_timezones->num_elements);
     if (builtin_timezones->num_elements == 0) {
         printf("YIKES. Try running from the build/bin directory\n");
-        return (1);
+        return 1;
     }
 
     for (zz = -1; zz < (int)builtin_timezones->num_elements; zz++) {

--- a/src/test/copycluster.c
+++ b/src/test/copycluster.c
@@ -38,7 +38,7 @@ static void sig_alrm(int i)
 
 /* This program copies a file that holds iCal components to an other file. */
 
-void usage(const char *arg0)
+static void usage(const char *arg0)
 {
     printf("usage: %s cluster-file1 cluster-file2\n", arg0);
 }

--- a/src/test/icalrecur_test.c
+++ b/src/test/icalrecur_test.c
@@ -14,8 +14,7 @@
 #include <config.h>
 #endif
 
-#include <libical/ical.h>
-#include <stdlib.h>
+#include "libical/ical.h"
 
 struct recur {
     int line_no;
@@ -25,7 +24,7 @@ struct recur {
     char instances[2000];
 };
 
-int check_and_copy_field(const char *line, const char *pref, char *field, size_t field_size)
+static int check_and_copy_field(const char *line, const char *pref, char *field, size_t field_size)
 {
     size_t l = strlen(pref);
     if (strncmp(line, pref, l) != 0) {
@@ -236,14 +235,14 @@ static int run_testcase(struct recur *r, bool verbose, bool forward, int proceed
                 icalrecur_iterator_set_range(ritr, start, dtstart);
             }
 
-            instances = skip_until(instances, start, forward ? 1 : -1);
+            instances = skip_until(instances, start, (int)forward ? 1 : -1);
         } else if (!forward) {
             while (!icaltime_is_null_time(icalrecur_iterator_next(ritr))) {
                 // skip to the end
             }
         }
 
-        struct icaltimetype (*iterator_proceed)(icalrecur_iterator *impl) = forward ? icalrecur_iterator_next : icalrecur_iterator_prev;
+        struct icaltimetype (*iterator_proceed)(icalrecur_iterator *impl) = (int)forward ? icalrecur_iterator_next : icalrecur_iterator_prev;
 
         const char *sep = "";
         for (struct icaltimetype next = iterator_proceed(ritr);
@@ -272,7 +271,7 @@ static int run_testcase(struct recur *r, bool verbose, bool forward, int proceed
             fprintf(stderr, "\n");
         }
 
-        const char *msg_prefix = forward ? "" : "PREV-";
+        const char *msg_prefix = (int)forward ? "" : "PREV-";
         fprintf(stderr, "Expected %sINSTANCES:%s\n", msg_prefix, (instances == NULL) ? "" : instances);
         fprintf(stderr, "Actual   %sINSTANCES:%s\n", msg_prefix, actual_instances);
         fprintf(stderr, "\n");
@@ -293,7 +292,7 @@ int main(int argc, const char *argv[])
 {
     /* Default to RFC 5545 tests */
     const char *file_name = "icalrecur_test.txt";
-    int verbose = 0;
+    bool verbose = false;
 
     /* Do not use getopt for command line parsing -- for portability on Windows */
     for (int i = 1; i < argc; ++i) {
@@ -303,19 +302,19 @@ int main(int argc, const char *argv[])
         }
 
         if (strncmp(argv[i], "-v", 2) == 0) { /* Verbose output to stdout */
-            verbose = 1;
+            verbose = true;
             continue;
         }
 
         fprintf(stderr, "usage: %s [-f <input file>]\n", argv[0]);
-        return (1);
+        return 1;
     }
 
     FILE *fp = fopen(file_name, "r");
 
     if (fp == NULL) {
         fprintf(stderr, "unable to open the input file '%s'\n", file_name);
-        return (1);
+        return 1;
     }
 
     if (verbose) {
@@ -379,10 +378,10 @@ int main(int argc, const char *argv[])
 
             nof_tests++;
 
-            if (run_testcase(&r, verbose, 1, -1, &has_skip)) {
+            if (run_testcase(&r, verbose, true, -1, &has_skip)) {
                 test_error = 1;
                 nof_errors++;
-            } else if (run_testcase(&r, verbose, 0, -1, 0)) {
+            } else if (run_testcase(&r, verbose, false, -1, 0)) {
                 test_error = 1;
                 nof_errors++;
             }
@@ -390,7 +389,7 @@ int main(int argc, const char *argv[])
             if ((test_error == 0) && *r.instances && !r.start_at[0] && !has_skip) {
                 int instance_count = get_instance_count(r.instances);
                 for (int instance_idx = 0; instance_idx < instance_count; instance_idx++) {
-                    if (run_testcase(&r, verbose, 1, instance_idx, 0)) {
+                    if (run_testcase(&r, verbose, true, instance_idx, 0)) {
                         test_error = 1;
                         nof_errors++;
                     }

--- a/src/test/icaltestparser.c
+++ b/src/test/icaltestparser.c
@@ -14,52 +14,11 @@
 
 #include "libical/ical.h"
 
-char str[] = "BEGIN:VCALENDAR\
-PRODID:\"-//RDU Software//NONSGML HandCal//EN\"\
-VERSION:2.0\
-BEGIN:VTIMEZONE\
-TZID:US-Eastern\
-BEGIN:STANDARD\
-DTSTART:19990404T020000\
-RDATE:19990u404xT020000\
-TZOFFSETFROM:-0500\
-TZOFFSETTO:-0400\
-END:STANDARD\
-BEGIN:DAYLIGHT\
-DTSTART:19990404T020000\
-RDATE:19990404T020000\
-TZOFFSETFROM:-0500\
-TZOFFSETTO:-0400\
-TZNAME:EDT\
-Dkjhgri:derhvnv;\
-BEGIN:dfkjh\
-END:dfdfkjh\
-END:DAYLIGHT\
-END:VTIMEZONE\
-BEGIN:VEVENT\
-GEO:Bongo\
-DTSTAMP:19980309T231000Z\
-UID:guid-1.host1.com\
-ORGANIZER;ROLE=CHAIR:MAILTO:mrbig@host.com\
-ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=GROUP\
- :MAILTO:employee-A@host.com\
-DESCRIPTION:Project XYZ Review Meeting\
-CATEGORIES:MEETING\
-CLASS:PUBLIC\
-CREATED:19980309T130000Z\
-SUMMARY:XYZ Project Review\
-DTSTART;TZID=US-Eastern:19980312T083000\
-DTEND;TZID=US-Eastern:19980312T093000\
-LOCATION:1CP Conference Room 4350\
-END:VEVENT\
-END:VCALENDAR\
-";
-
 extern int yydebug;
 
 /* Have the parser fetch data from stdin */
 
-char *read_stream(char *s, size_t size, void *d)
+static char *read_stream(char *s, size_t size, void *d)
 {
     char *c = fgets(s, (int)size, (FILE *)d);
 

--- a/src/test/icaltime_fuzz.c
+++ b/src/test/icaltime_fuzz.c
@@ -62,8 +62,7 @@ int main(void)
         v1,
     }; // dtend
 
-    i32 v4 = 40;                         // is_busy
-    (void)icaltime_span_new(v0, v3, v4); // $target
+    (void)icaltime_span_new(v0, v3, true); // $target
 
     icaltimezone_free(v1, 1);
     return 0;

--- a/src/test/libicalvcard/vcard_test.c
+++ b/src/test/libicalvcard/vcard_test.c
@@ -39,7 +39,7 @@
         }                                                                                        \
     }
 
-void strip_errors(vcardcomponent *comp)
+static void strip_errors(vcardcomponent *comp)
 {
     vcardproperty *prop, *next;
 

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -181,10 +181,14 @@ static void test_prop_x(void)
     vcardcomponent_free(card);
 }
 
+/* cppcheck-suppress constParameterCallback */
 static vcardvalue_kind my_xprop_value_kind_func(const char *name, void *data)
 {
-    (void)(data); // make CI happy, reporting unused parameter otherwise
+#if defined(NDEBUG)
+    _unused(data);
+#else
     assert(data == (void *)0x1234);
+#endif
     return !strcasecmp(name, "X-PROP-A") ? VCARD_TEXT_VALUE : VCARD_X_VALUE;
 }
 

--- a/src/test/process.c
+++ b/src/test/process.c
@@ -15,11 +15,6 @@
 
 #include <assert.h>
 
-void send_message(icalcomponent *reply, const char *this_user)
-{
-    printf("From: %s\n\n%s\n", this_user, icalcomponent_as_ical_string(reply));
-}
-
 int main(int argc, char *argv[])
 {
     icalcomponent *c, *next_c = NULL;

--- a/src/test/regression-classify.c
+++ b/src/test/regression-classify.c
@@ -9,13 +9,11 @@
 #include <config.h>
 #endif
 
-#include <assert.h>
-#include <stdio.h>  /* for printf */
-#include <string.h> /* For strerror */
-
-#include <libical/ical.h>
-#include <libicalss/icalss.h>
+#include "libical/ical.h"
+#include "libicalss/icalss.h"
 #include "regression.h"
+
+#include <assert.h>
 
 /* Gets a note about the purpose of the property*/
 static const char *get_note(icalcomponent *c)

--- a/src/test/regression-component.c
+++ b/src/test/regression-component.c
@@ -82,13 +82,13 @@ void create_new_component(void)
     icalcomponent *timezone;
     icalcomponent *tzc;
     icalcomponent *event;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(1023398689, 0, NULL);
+    struct icaltimetype atime = icaltime_from_timet_with_zone(1023398689, false, NULL);
     struct icaldatetimeperiodtype rtime;
     icalproperty *property;
     const char *calendar_as_string;
 
-    rtime.period.start = icaltime_from_timet_with_zone(1023398689, 0, NULL);
-    rtime.period.end = icaltime_from_timet_with_zone(1023409689, 0, NULL);
+    rtime.period.start = icaltime_from_timet_with_zone(1023398689, false, NULL);
+    rtime.period.end = icaltime_from_timet_with_zone(1023409689, false, NULL);
     rtime.period.end.hour++;
     rtime.period.duration = icaldurationtype_null_duration();
     rtime.time = icaltime_null_time();
@@ -211,11 +211,11 @@ void create_new_component(void)
 void create_new_component_with_va_args(void)
 {
     icalcomponent *calendar;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), false, NULL);
     struct icaldatetimeperiodtype rtime;
 
-    rtime.period.start = icaltime_from_timet_with_zone(time(0), 0, NULL);
-    rtime.period.end = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    rtime.period.start = icaltime_from_timet_with_zone(time(0), false, NULL);
+    rtime.period.end = icaltime_from_timet_with_zone(time(0), false, NULL);
     rtime.period.end.hour++;
     rtime.period.duration = icaldurationtype_null_duration();
     rtime.time = icaltime_null_time();
@@ -328,9 +328,9 @@ void test_icalcomponent_get_span(void)
     azone = icaltimezone_get_builtin_timezone("America/Los_Angeles");
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, 0, azone),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, false, azone),
                                    icalparameter_new_tzid("America/Los_Angeles"), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, 0, azone),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, false, azone),
                                  icalparameter_new_tzid("America/Los_Angeles"), (void *)0),
         (void *)0);
 
@@ -350,8 +350,8 @@ void test_icalcomponent_get_span(void)
      */
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, 0, NULL), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, 0, NULL), (void *)0),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, false, NULL), (void *)0),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, false, NULL), (void *)0),
         (void *)0);
 
     span = icalcomponent_get_span(c);
@@ -369,9 +369,9 @@ void test_icalcomponent_get_span(void)
     azone = icaltimezone_get_builtin_timezone("America/New_York");
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, 0, azone),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, false, azone),
                                    icalparameter_new_tzid("America/New_York"), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, 0, azone),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, false, azone),
                                  icalparameter_new_tzid("America/New_York"), (void *)0),
         (void *)0);
 
@@ -393,9 +393,9 @@ void test_icalcomponent_get_span(void)
     bzone = icaltimezone_get_builtin_timezone("America/Los_Angeles");
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, 0, azone),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, false, azone),
                                    icalparameter_new_tzid("America/New_York"), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, 0, bzone),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, false, bzone),
                                  icalparameter_new_tzid("America/Los_Angeles"), (void *)0),
         (void *)0);
 
@@ -418,7 +418,7 @@ void test_icalcomponent_get_span(void)
     dur.minutes = 30;
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, 0, azone),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1, false, azone),
                                    icalparameter_new_tzid("America/Los_Angeles"), (void *)0),
         icalproperty_new_duration(dur),
         (void *)0);
@@ -439,7 +439,7 @@ void test_icalcomponent_get_span(void)
      */
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, 0, NULL)),
+        icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, false, NULL)),
         (void *)0);
 
     span = icalcomponent_get_span(c);
@@ -455,8 +455,8 @@ void test_icalcomponent_get_span(void)
      */
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, 1, NULL)),
-        icalproperty_new_dtend(icaltime_from_timet_with_zone(tm1, 1, NULL)),
+        icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, true, NULL)),
+        icalproperty_new_dtend(icaltime_from_timet_with_zone(tm1, true, NULL)),
         (void *)0);
 
     span = icalcomponent_get_span(c);
@@ -471,8 +471,8 @@ void test_icalcomponent_get_span(void)
      *  We specify start and end date
      */
     c = icalcomponent_vanew(ICAL_VEVENT_COMPONENT,
-                            icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, 1, NULL)),
-                            icalproperty_new_dtend(icaltime_from_timet_with_zone(tm2, 1, NULL)),
+                            icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, true, NULL)),
+                            icalproperty_new_dtend(icaltime_from_timet_with_zone(tm2, true, NULL)),
                             (void *)0);
 
     span = icalcomponent_get_span(c);
@@ -487,7 +487,7 @@ void test_icalcomponent_get_span(void)
      *  We specify start date
      */
     c = icalcomponent_vanew(ICAL_VEVENT_COMPONENT,
-                            icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, 1, NULL)),
+                            icalproperty_new_dtstart(icaltime_from_timet_with_zone(tm1, true, NULL)),
                             (void *)0);
 
     span = icalcomponent_get_span(c);

--- a/src/test/regression-recur.c
+++ b/src/test/regression-recur.c
@@ -15,7 +15,7 @@
 #include "libicalss/icalss.h"
 
 #include <assert.h>
-#include <stdlib.h>
+#include <errno.h>
 
 #if defined(HAVE_SIGNAL) && defined(HAVE_ALARM)
 #if defined(__GNUC__) && !defined(__clang__)
@@ -53,7 +53,12 @@ static int get_expected_numevents(icalcomponent *c)
     }
 
     if (note != 0) {
-        num_events = atoi(note);
+        char *endptr;
+        errno = 0;
+        num_events = strtol(note, &endptr, 10);
+        if (note == endptr || errno != 0) {
+            num_events = -1;
+        }
     }
 
     return num_events;
@@ -112,8 +117,8 @@ void test_recur_file(void)
         char msg[128];
 
         struct icaltimetype start;
-        struct icaltimetype startmin = icaltime_from_timet_with_zone(1, 0, NULL);
-        struct icaltimetype endmax = icaltime_from_timet_with_zone(1748497476, 0, NULL);
+        struct icaltimetype startmin = icaltime_from_timet_with_zone(1, false, NULL);
+        struct icaltimetype endmax = icaltime_from_timet_with_zone(1748497476, false, NULL);
         const char *desc_str = "malformed component";
 
         desc = icalcomponent_get_first_property(itr, ICAL_DESCRIPTION_PROPERTY);

--- a/src/test/regression-storage.c
+++ b/src/test/regression-storage.c
@@ -42,17 +42,8 @@ struct calendar {
     char *title;
 };
 
-int vcalendar_init(struct calendar **cal, const char *vcalendar, const char *title);
-
 #if defined(HAVE_BDB)
 #include <db.h>
-
-/*
-int get_title(DB *dbp, const DBT *pkey, const DBT *pdata, DBT *skey);
-*/
-char *parse_vcalendar(const DBT *dbt);
-char *pack_calendar(struct calendar *cal, size_t size);
-struct calendar *unpack_calendar(const char *str, size_t size);
 #endif
 
 /*
@@ -98,7 +89,7 @@ UID:guid-1.host1.com\n\
 END:BOOGA\n\
 END:VCALENDAR";
 */
-char str2[] = "BEGIN:VCALENDAR\n\
+static char str2[] = "BEGIN:VCALENDAR\n\
 PRODID:\"-//RDU Software//NONSGML HandCal//EN\"\n\
 VERSION:2.0\n\
 BEGIN:VEVENT\n\
@@ -127,7 +118,7 @@ void test_fileset_extended(void)
     icalcomponent *c, *itr;
     icalsetiter iter;
 
-    start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    start = icaltime_from_timet_with_zone(time(0), false, NULL);
     end = start;
     end.hour++;
 
@@ -295,7 +286,7 @@ void test_bdbset(void)
 #pragma clang diagnostic push /* remove when/if we remove the proceeding return statement */
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
-    start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    start = icaltime_from_timet_with_zone(time(0), false, NULL);
     end = start;
     end.hour++;
 
@@ -434,180 +425,6 @@ void test_bdbset(void)
 
 #endif
 
-int vcalendar_init(struct calendar **rcal, const char *vcalendar, const char *title)
-{
-    size_t vcalendar_size, title_size, total_size;
-    struct calendar *cal;
-
-    if (vcalendar) {
-        vcalendar_size = strlen(vcalendar);
-    } else {
-        vcalendar = "";
-        vcalendar_size = strlen(vcalendar);
-    }
-
-    if (title) {
-        title_size = strlen(title);
-    } else {
-        title = "";
-        title_size = strlen(title);
-    }
-
-    total_size = sizeof(struct calendar) + vcalendar_size + title_size;
-
-    if ((cal = (struct calendar *)malloc(total_size)) == NULL) {
-        return 0;
-    }
-    memset(cal, 0, total_size);
-
-    /* offsets */
-    cal->total_size_offset = sizeof(int);
-    cal->vcalendar_size_offset = (sizeof(int) * 7);
-    cal->vcalendar_offset = cal->vcalendar_size_offset + sizeof(int);
-    cal->title_size_offset = cal->vcalendar_offset + vcalendar_size;
-    cal->title_offset = cal->title_size_offset + sizeof(int);
-
-    /* sizes */
-    cal->total_size = total_size;
-    cal->vcalendar_size = vcalendar_size;
-    cal->title_size = title_size;
-
-    if (*vcalendar) { /* we know that vcalendar is not NULL here */
-        cal->vcalendar = strdup(vcalendar);
-    }
-
-    if (*title) { /* we know that title is not NULL here */
-        cal->title = strdup(title);
-    }
-
-    *rcal = cal;
-
-    return 0;
-}
-
-/* get_title -- extracts a secondary key (the vcalendar)
- * from a primary key/data pair */
-
-/* just create a random title for now */
-#if defined(HAVE_BDB)
-/*
-int get_title(DB *dbp, const DBT *pkey, const DBT *pdata, DBT *skey)
-{
-    icalcomponent *cl;
-    static char title[255];
-
-    _unused(dbp);
-    _unused(pkey);
-
-    if (!skey) {
-        return -1;
-    }
-    memset(skey, 0, sizeof(DBT));
-
-    cl = icalparser_parse_string((char *)pdata->data);
-    snprintf(title, sizeof(title), "title_%s", icalcomponent_get_uid(cl));
-
-    skey->data = strdup(title);
-    skey->size = (u_int32_t)strlen(skey->data);
-    return 0;
-}
-*/
-char *pack_calendar(struct calendar *cal, size_t size)
-{
-    char *str;
-
-    if ((str = (char *)malloc(sizeof(char) * size)) == NULL) {
-        return 0;
-    }
-
-    /* ID */
-    memcpy(str, &cal->ID, sizeof(cal->ID));
-
-    /* total_size */
-    memcpy(str + cal->total_size_offset, &cal->total_size, sizeof(cal->total_size));
-
-    /* vcalendar_size */
-    memcpy(str + cal->vcalendar_size_offset, &cal->vcalendar_size, sizeof(cal->vcalendar_size));
-
-    /* vcalendar */
-    memcpy(str + cal->vcalendar_offset, cal->vcalendar, cal->vcalendar_size);
-
-    /* title_size */
-    memcpy(str + cal->title_size_offset, &cal->title_size, sizeof(cal->title_size));
-
-    /* title */
-    memcpy(str + cal->title_offset, cal->title, cal->title_size);
-
-    return str;
-}
-
-struct calendar *unpack_calendar(const char *str, size_t size)
-{
-    struct calendar *cal;
-
-    if ((cal = (struct calendar *)malloc(size)) == NULL) {
-        return 0;
-    }
-    memset(cal, 0, size);
-
-    /* offsets */
-    cal->total_size_offset = sizeof(int);
-    cal->vcalendar_size_offset = (sizeof(int) * 7);
-    cal->vcalendar_offset = cal->vcalendar_size_offset + sizeof(int);
-
-    /* ID */
-    memcpy(&cal->ID, str, sizeof(cal->ID));
-
-    /* total_size */
-    memcpy(&cal->total_size, str + cal->total_size_offset, sizeof(cal->total_size));
-
-    /* vcalendar_size */
-    memcpy(&cal->vcalendar_size, str + cal->vcalendar_size_offset, sizeof(cal->vcalendar_size));
-
-    if ((cal->vcalendar = (char *)malloc(sizeof(char) * cal->vcalendar_size)) == NULL) {
-        free(cal);
-        return 0;
-    }
-
-    /* vcalendar */
-    memcpy(cal->vcalendar, (char *)(str + cal->vcalendar_offset), cal->vcalendar_size);
-
-    cal->title_size_offset = cal->vcalendar_offset + cal->vcalendar_size;
-    cal->title_offset = cal->title_size_offset + sizeof(int);
-
-    /* title_size */
-    memcpy(&cal->title_size, str + cal->title_size_offset, sizeof(cal->title_size));
-
-    if ((cal->title = (char *)malloc(sizeof(char) * cal->title_size)) == NULL) {
-        free(cal->vcalendar);
-        free(cal);
-        return 0;
-    }
-
-    /* title */
-    memcpy(cal->title, (char *)(str + cal->title_offset), cal->title_size);
-
-    return cal;
-}
-
-char *parse_vcalendar(const DBT *dbt)
-{
-    char *str;
-    struct calendar *cal;
-
-    str = (char *)dbt->data;
-    cal = unpack_calendar(str, dbt->size);
-
-    if (cal) {
-        str = cal->vcalendar;
-        free(cal);
-        return str;
-    }
-    return NULL;
-}
-
-#endif
-
 void test_dirset_extended(void)
 {
     icalcomponent *c;
@@ -623,7 +440,7 @@ void test_dirset_extended(void)
     ok("Open dirset 'store'", (s != 0));
     assert(s != 0);
 
-    rtime.start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    rtime.start = icaltime_from_timet_with_zone(time(0), false, NULL);
 
     cluster = icalfileset_new(OUTPUT_FILE);
 

--- a/src/test/regression-utils.c
+++ b/src/test/regression-utils.c
@@ -80,17 +80,12 @@ static struct failed_tests {
     int test;
 } failed_tests[1024];
 
-void die_on_errors_set(int val)
-{
-    die_on_errors = val;
-}
-
-void _ok(const char *test_name, int success, const char *file, int linenum, const char *test)
+void _ok(const char *test_name, bool success, const char *file, int linenum, const char *test)
 {
     testnumber++;
 
     if (!QUIET || !success) {
-        printf("%sok %d - %s\n", (success) ? "" : "not ", testnumber, test_name);
+        printf("%sok %d - %s\n", (int)success ? "" : "not ", testnumber, test_name);
     }
 
     if (!success) {
@@ -102,6 +97,7 @@ void _ok(const char *test_name, int success, const char *file, int linenum, cons
         printf("#          at: %s:%-d\n", file, linenum);
     }
 
+    /* cppcheck-suppress knownConditionTrueFalse */
     if (die_on_errors == 1 && !success) {
         abort();
     }
@@ -137,11 +133,6 @@ void _int_is(const char *test_name, int i1, int i2, const char *file, int linenu
         printf("#      got: %d\n", i1);
         printf("# expected: %d\n", i2);
     }
-}
-
-void verbose(int newval)
-{
-    VERBOSE = newval;
 }
 
 void test_start(int numtests)

--- a/src/test/regression.c
+++ b/src/test/regression.c
@@ -10,6 +10,8 @@
 
 //Don't care about insecureAPI.strcpy issues in this test program
 //NOLINTBEGIN(clang-analyzer-security.insecureAPI.strcpy)
+//Don't care about random number generators here either
+//NOLINTBEGIN(misc-predictable-rand)
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -34,15 +36,6 @@
 #include <stdlib.h>
 
 #define TESTS_TZID_PREFIX "/softwarestudio.org/tests/"
-
-/* For GNU libc, strcmp appears to be a macro, so using strcmp in
- assert results in incomprehansible assertion messages. This
- eliminates the problem */
-
-int regrstrcmp(const char *a, const char *b)
-{
-    return strcmp(a, b);
-}
 
 /* This example creates and minipulates the ical object that appears
  * in rfc 2445, page 137 */
@@ -171,7 +164,7 @@ static char** get_required_attendees(icalcomponent* event)
     }
   */
 
-void test_values(void)
+static void test_values(void)
 {
     icalvalue *v;
     icalvalue *copy;
@@ -229,9 +222,9 @@ void test_values(void)
     icalvalue_free(v);
     icalvalue_free(copy);
 
-    v = icalvalue_new_datetime(icaltime_from_timet_with_zone(1023404802, 0, NULL));
+    v = icalvalue_new_datetime(icaltime_from_timet_with_zone(1023404802, false, NULL));
     str_is("icalvalue_new_datetime()", icalvalue_as_ical_string(v), "20020606T230642");
-    icalvalue_set_datetime(v, icaltime_from_timet_with_zone(1023404802 - 3600, 0, NULL));
+    icalvalue_set_datetime(v, icaltime_from_timet_with_zone(1023404802 - 3600, false, NULL));
     str_is("icalvalue_set_datetime()", icalvalue_as_ical_string(v), "20020606T220642");
 
     copy = icalvalue_clone(v);
@@ -302,7 +295,7 @@ void test_values(void)
     icalerror_set_error_state(ICAL_MALFORMEDDATA_ERROR, ICAL_ERROR_DEFAULT);
 }
 
-void test_properties(void)
+static void test_properties(void)
 {
     icalproperty *prop;
     icalparameter *param;
@@ -361,7 +354,7 @@ void test_properties(void)
     }
 }
 
-void test_utf8(void)
+static void test_utf8(void)
 {
     icalcomponent *comp;
     icalproperty *prop;
@@ -438,7 +431,7 @@ void test_utf8(void)
     icalcomponent_free(comp);
 }
 
-void test_icaltime_compare_utc_zone(void)
+static void test_icaltime_compare_utc_zone(void)
 {
     struct icaltimetype a;
     struct icaltimetype b;
@@ -455,25 +448,25 @@ void test_icaltime_compare_utc_zone(void)
     int_is("a < b", icaltime_compare(a, b), -1);
 }
 
-void test_icaltime_normalize(void)
+static void test_icaltime_normalize(void)
 {
     icalcomponent *comp = icalcomponent_new_vpatch();
     ok("icaltime_normalize new vpatch", (comp != 0));
     struct icaltimetype t = icalcomponent_get_dtstamp(comp);
     ok("icaltime_normalize dtstamp time is valid", icaltime_is_valid_time(t));
     if (VERBOSE) {
-        printf("Time: %d-%d-%d %d:%d:%d (is_valid: %d)\n", t.year, t.month, t.day, t.hour, t.minute, t.second, icaltime_is_valid_time(t));
+        printf("Time: %d-%d-%d %d:%d:%d (is_valid: %d)\n", t.year, t.month, t.day, t.hour, t.minute, t.second, (int)icaltime_is_valid_time(t));
     }
 
     struct icaltimetype norm = icaltime_normalize(t);
     ok("icaltime_normalize normalize normalized dtstamp time is valid", icaltime_is_valid_time(norm));
     if (VERBOSE) {
-        printf("Normalized Time: %d-%d-%d %d:%d:%d (is_valid: %d)\n", norm.year, norm.month, norm.day, norm.hour, norm.minute, norm.second, icaltime_is_valid_time(norm));
+        printf("Normalized Time: %d-%d-%d %d:%d:%d (is_valid: %d)\n", norm.year, norm.month, norm.day, norm.hour, norm.minute, norm.second, (int)icaltime_is_valid_time(norm));
     }
     icalcomponent_free(comp);
 }
 
-void test_parameters(void)
+static void test_parameters(void)
 {
     icalparameter *p;
     int i;
@@ -530,7 +523,7 @@ void test_parameters(void)
     }
 }
 
-const char *good_child =
+static const char *good_child =
     "BEGIN:VEVENT\r\n"
     "VERSION:2.0\r\n"
     "DESCRIPTION:This is an event\r\n"
@@ -539,7 +532,7 @@ const char *good_child =
     "X-LIC-ERROR;X-LIC-ERRORTYPE=COMPONENT-PARSE-ERROR:This is only a test\r\n"
     "END:VEVENT\r\n";
 
-const char *bad_child =
+static const char *bad_child =
     "BEGIN;\r\n"
     "TZNAME:\\r\n"
     "TZNAME:\\r\n"
@@ -549,11 +542,11 @@ const char *bad_child =
     "TZNAME:\\r\n"
     "TZNAME:\\r\n";
 
-void test_components(void)
+static void test_components(void)
 {
     icalcomponent *c;
     icalcomponent *child;
-    int estate;
+    bool estate;
 
     c = icalcomponent_vanew(
         ICAL_VCALENDAR_COMPONENT,
@@ -612,7 +605,7 @@ static void test_component_foreach_callback(icalcomponent *comp, const struct ic
     (*foundExpected)++;
 }
 
-int test_component_foreach_parameterized(int startOffsSec, int endOffsSec, int expectedFoundInstances)
+static int test_component_foreach_parameterized(int startOffsSec, int endOffsSec, int expectedFoundInstances)
 {
     const char *calStr =
         "BEGIN:VCALENDAR\n"
@@ -642,7 +635,7 @@ int test_component_foreach_parameterized(int startOffsSec, int endOffsSec, int e
     return 0;
 }
 
-void test_component_foreach_start_as_date_variant(const char *calStr, int expect_found)
+static void test_component_foreach_start_as_date_variant(const char *calStr, int expect_found)
 {
     icalcomponent *calendar = icalparser_parse_string(calStr);
     icalcomponent *event = icalcomponent_get_first_component(calendar, ICAL_VEVENT_COMPONENT);
@@ -659,7 +652,7 @@ void test_component_foreach_start_as_date_variant(const char *calStr, int expect
 }
 
 // reproduces #833
-void test_component_foreach_start_as_date(void)
+static void test_component_foreach_start_as_date(void)
 {
     test_component_foreach_start_as_date_variant(
         "BEGIN:VCALENDAR\n"
@@ -702,7 +695,7 @@ void test_component_foreach_start_as_date(void)
         1);
 }
 
-void test_component_foreach(void)
+static void test_component_foreach(void)
 {
     const char *calStr =
         "BEGIN:VCALENDAR\n"
@@ -891,7 +884,7 @@ static void test_component_foreach_dtend_callback(icalcomponent *comp, const str
     a->found++;
 }
 
-void test_component_foreach_dtend_daily(int count, const char *dtstart_str, const char *duration_str, const char **dtend_strs)
+static void test_component_foreach_dtend_daily(int count, const char *dtstart_str, const char *duration_str, const char **dtend_strs)
 {
     if (count <= 0) {
         return;
@@ -929,7 +922,7 @@ void test_component_foreach_dtend_daily(int count, const char *dtstart_str, cons
     icalrecurrencetype_unref(rrule);
 }
 
-void test_component_foreach_dtend_nominal(void)
+static void test_component_foreach_dtend_nominal(void)
 {
     const char *dtends[] = {
         "20251101T220000",
@@ -939,7 +932,7 @@ void test_component_foreach_dtend_nominal(void)
     test_component_foreach_dtend_daily(3, "20251031T220000", "P1D", dtends);
 }
 
-void test_component_foreach_dtend_exact(void)
+static void test_component_foreach_dtend_exact(void)
 {
     const char *dtends[] = {
         "20251101T220000",
@@ -949,7 +942,7 @@ void test_component_foreach_dtend_exact(void)
     test_component_foreach_dtend_daily(3, "20251031T220000", "PT24H", dtends);
 }
 
-void test_recur_iterator_set_start(void)
+static void test_recur_iterator_set_start(void)
 {
     icaltimetype start = icaltime_from_string("20150526");
     struct icalrecurrencetype *recurrence = icalrecurrencetype_new_from_string("FREQ=WEEKLY");
@@ -962,7 +955,7 @@ void test_recur_iterator_set_start(void)
     icalrecurrencetype_unref(recurrence);
 }
 
-void test_recur_iterator_on_jan_1(void)
+static void test_recur_iterator_on_jan_1(void)
 {
     icaltimetype start = icaltime_from_string("20190101");
     struct icalrecurrencetype *recurrence = icalrecurrencetype_new_from_string("FREQ=WEEKLY;WKST=SU;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR");
@@ -977,7 +970,7 @@ void test_recur_iterator_on_jan_1(void)
     icalrecurrencetype_unref(recurrence);
 }
 
-void test_memory(void)
+static void test_memory(void)
 {
     size_t bufsize = 256;
     int i;
@@ -1173,7 +1166,7 @@ void test_memory(void)
     }
 }
 
-void test_dirset(void)
+static void test_dirset(void)
 {
     icalcomponent *c;
     icalgauge *gauge;
@@ -1194,7 +1187,7 @@ void test_dirset(void)
     ok("opening 'store' dirset", s != NULL);
     ok("opening 'store-new' dirset", s2 != NULL);
 
-    rtime.start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    rtime.start = icaltime_from_timet_with_zone(time(0), false, NULL);
 
     cluster = icalfileset_new("clusterin.vcd");
 
@@ -1291,7 +1284,7 @@ void test_dirset(void)
     icalset_free(cluster);
 }
 
-void test_compare(void)
+static void test_compare(void)
 {
     icalvalue *v1, *v2;
 
@@ -1346,16 +1339,16 @@ void test_compare(void)
     icalvalue_free(v2);
 }
 
-void test_restriction(void)
+static void test_restriction(void)
 {
     icalcomponent *comp;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), 0, NULL);
-    int valid;
+    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), false, NULL);
+    bool valid;
 
     struct icaldatetimeperiodtype rtime;
 
-    rtime.period.start = icaltime_from_timet_with_zone(time(0), 0, NULL);
-    rtime.period.end = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    rtime.period.start = icaltime_from_timet_with_zone(time(0), false, NULL);
+    rtime.period.end = icaltime_from_timet_with_zone(time(0), false, NULL);
     rtime.period.end.hour++;
     rtime.period.duration = icaldurationtype_null_duration();
     rtime.time = icaltime_null_time();
@@ -1417,17 +1410,17 @@ void test_restriction(void)
     valid = icalrestriction_check(comp);
     (void)icalcomponent_as_ical_string(comp);
     icalcomponent_free(comp);
-    ok("icalrestriction_check() == 0", (valid == 0));
+    ok("icalrestriction_check() == false", !valid);
 }
 
-void test_calendar(void)
+static void test_calendar(void)
 {
     icalcomponent *comp;
     icalset *c;
     icalset *s;
     icalcalendar *calendar;
     icalerrorenum error;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), false, NULL);
 
     (void)mkdir("calendar", 0755);
     (void)mkdir("calendar/booked", 0755);
@@ -1473,9 +1466,7 @@ void test_calendar(void)
     ok("icalcalendar test", (1));
 }
 
-void test_increment(void);
-
-void print_occur(struct icalrecurrencetype *recur, struct icaltimetype start)
+static void print_occur(struct icalrecurrencetype *recur, struct icaltimetype start)
 {
     struct icaltimetype next;
     icalrecur_iterator *ritr;
@@ -1496,7 +1487,7 @@ void print_occur(struct icalrecurrencetype *recur, struct icaltimetype start)
     icalrecur_iterator_free(ritr);
 }
 
-void test_recur(void)
+static void test_recur(void)
 {
     struct icalrecurrencetype *rt;
     struct icaltimetype start;
@@ -1529,7 +1520,7 @@ void test_recur(void)
     /*    test_increment();*/
 }
 
-void test_recur_encode_by_day(void)
+static void test_recur_encode_by_day(void)
 {
     struct icalrecurrencetype *rt;
     int ii;
@@ -1576,7 +1567,7 @@ void test_recur_encode_by_day(void)
     }
 }
 
-void test_recur_encode_by_month(void)
+static void test_recur_encode_by_month(void)
 {
     struct icalrecurrencetype *rt;
     int ii, jj;
@@ -1607,7 +1598,7 @@ void test_recur_encode_by_month(void)
                 printf("  Trying month %d as %sleap\n", jj, ii ? "" : "not ");
             }
 
-            encoded = icalrecurrencetype_encode_month(jj, ii);
+            encoded = icalrecurrencetype_encode_month(jj, ii != 0);
 
             ok("Decoded month matches", (icalrecurrencetype_month_month(encoded) == jj));
             ok("Decoded is-leap matches", ((icalrecurrencetype_month_is_leap(encoded) ? 1 : 0) == ii));
@@ -1615,7 +1606,7 @@ void test_recur_encode_by_month(void)
     }
 }
 
-void test_expand_recurrence(void)
+static void test_expand_recurrence(void)
 {
     icaltime_t arr[10];
     icaltime_t now = 931057385;
@@ -1650,36 +1641,8 @@ enum byrule
     BY_SET_POS = 8,
 };
 
-void icalrecurrencetype_test(void)
-{
-    icalvalue *v =
-        icalvalue_new_from_string(
-            ICAL_RECUR_VALUE,
-            "FREQ=YEARLY;UNTIL=20060101T000000;INTERVAL=2;BYDAY=SU,WE;BYSECOND=15,30; BYMONTH=1,6,11");
-
-    struct icalrecurrencetype *r = icalvalue_get_recur(v);
-    struct icaltimetype t = icaltime_from_timet_with_zone(time(0), 0, NULL);
-    struct icaltimetype next;
-    icaltime_t tt;
-
-    struct icalrecur_iterator_impl *itr =
-        (struct icalrecur_iterator_impl *)icalrecur_iterator_new(r, t);
-
-    do {
-        next = icalrecur_iterator_next(itr);
-        tt = icaltime_as_timet(next);
-
-        printf("%s", icalctime(&tt));
-
-    } while (!icaltime_is_null_time(next));
-
-    icalvalue_free(v);
-
-    icalrecur_iterator_free(itr);
-}
-
 /* From Federico Mena Quintero <federico@ximian.com>    */
-void test_recur_parameter_bug(void)
+static void test_recur_parameter_bug(void)
 {
     static const char test_icalcomp_str[] =
         "BEGIN:VEVENT\r\n"
@@ -1727,7 +1690,7 @@ void test_recur_parameter_bug(void)
     icalcomponent_free(icalcomp);
 }
 
-void test_duration(void)
+static void test_duration(void)
 {
     struct icaldurationtype d;
 
@@ -1813,7 +1776,7 @@ void test_duration(void)
     str_is("PT4424400S", icaldurationtype_as_ical_string(d), "PT4424400S");
 }
 
-void test_period(void)
+static void test_period(void)
 {
     struct icalperiodtype p;
     icalvalue *v;
@@ -1835,7 +1798,7 @@ void test_period(void)
     icalvalue_free(v);
 }
 
-void test_strings(void)
+static void test_strings(void)
 {
     icalvalue *v;
 
@@ -1860,7 +1823,7 @@ void test_strings(void)
 }
 
 /* Check RFC6868 encoding of "unsafe" chars in parameter values, such as '\n' */
-void test_tzid_escape(void)
+static void test_tzid_escape(void)
 {
     icalparameter *tzid;
     icalproperty *prop;
@@ -1880,7 +1843,7 @@ void test_tzid_escape(void)
     icalproperty_free(prop);
 }
 
-void test_requeststat(void)
+static void test_requeststat(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -1990,7 +1953,7 @@ void test_requeststat(void)
     icalcomponent_free(c);
 }
 
-void test_dtstart(void)
+static void test_dtstart(void)
 {
     struct icaltimetype tt, tt2;
 
@@ -2038,7 +2001,7 @@ void test_dtstart(void)
     icalproperty_free(p);
 }
 
-void do_test_time(const char *zone)
+static void do_test_time(const char *zone)
 {
     struct icaltimetype ictt, icttutc, icttzone, icttdayl,
         icttla, icttny, icttphoenix, icttlocal, icttnorm;
@@ -2065,10 +2028,10 @@ void do_test_time(const char *zone)
         printf("Orig        : %s\n", ical_timet_string(tt));
     }
 
-    ictt = icaltime_from_timet_with_zone(tt, 0, NULL);
+    ictt = icaltime_from_timet_with_zone(tt, false, NULL);
     str_is("Floating time from icaltime_t", ictt_as_string(ictt), "2002-06-26 21:44:29 (floating)");
 
-    ictt = icaltime_from_timet_with_zone(tt, 0, utczone);
+    ictt = icaltime_from_timet_with_zone(tt, false, utczone);
     str_is("icaltime_from_timet_with_zone(tt,0,utc)", ictt_as_string(ictt),
            "2002-06-26 21:44:29 Z UTC");
 
@@ -2076,7 +2039,7 @@ void do_test_time(const char *zone)
         printf("\n---> Convert from floating \n");
     }
 
-    ictt = icaltime_from_timet_with_zone(tt, 0, NULL);
+    ictt = icaltime_from_timet_with_zone(tt, false, NULL);
     icttutc = icaltime_convert_to_zone(ictt, utczone);
 
     str_is("Convert from floating to UTC", ictt_as_string(icttutc), "2002-06-26 21:44:29 Z UTC");
@@ -2089,7 +2052,7 @@ void do_test_time(const char *zone)
         printf("\n---> Convert from UTC \n");
     }
 
-    ictt = icaltime_from_timet_with_zone(tt, 0, utczone);
+    ictt = icaltime_from_timet_with_zone(tt, false, utczone);
     icttutc = icaltime_convert_to_zone(ictt, utczone);
 
     str_is("Convert from UTC to UTC", ictt_as_string(icttutc), "2002-06-26 21:44:29 Z UTC");
@@ -2112,7 +2075,7 @@ void do_test_time(const char *zone)
     if (VERBOSE) {
         printf("\n---> Convert from zone \n");
     }
-    ictt = icaltime_from_timet_with_zone(tt, 0, azone);
+    ictt = icaltime_from_timet_with_zone(tt, false, azone);
     icttzone = icaltime_convert_to_zone(ictt, azone);
 
     if (VERBOSE) {
@@ -2311,7 +2274,7 @@ void do_test_time(const char *zone)
 #endif
     tt_p200 = tt + 200 * 24 * 60 * 60; /* Add 200 days */
 
-    icttdayl = icaltime_from_timet_with_zone(tt_p200, 0, icaltimezone_get_utc_timezone());
+    icttdayl = icaltime_from_timet_with_zone(tt_p200, false, icaltimezone_get_utc_timezone());
     icttny = icaltime_convert_to_zone(icttdayl,
                                       icaltimezone_get_builtin_timezone("America/New_York"));
 
@@ -2400,7 +2363,7 @@ void do_test_time(const char *zone)
     int_is("convert to time_t EPOCH+2", (int)tt, 2);
 }
 
-void test_iterators(void)
+static void test_iterators(void)
 {
     icalcomponent *c, *inner, *next;
     icalcompiter i;
@@ -2518,7 +2481,7 @@ void test_iterators(void)
     icalcomponent_free(c);
 }
 
-void test_time(void)
+static void test_time(void)
 {
     const char *zones[6] =
         {
@@ -2537,12 +2500,12 @@ void test_time(void)
     }
 }
 
-void test_icalset(void)
+static void test_icalset(void)
 {
     icalcomponent *c;
 
-    icalset *f = icalset_new_file("2446.ics");
-    icalset *d = icalset_new_dir("outdir");
+    icalset *f = icalset_new_file(TEST_DATADIR "/2446.ics");
+    icalset *d = icalset_new_dir(TEST_DATADIR "/outdir");
 
     assert(f != 0);
     assert(d != 0);
@@ -2561,7 +2524,7 @@ void test_icalset(void)
     icalset_free(d);
 }
 
-void test_overlaps(void)
+static void test_overlaps(void)
 {
     icalcomponent *cset, *c;
     icalset *set;
@@ -2576,8 +2539,8 @@ void test_overlaps(void)
     set = icalset_new(ICAL_FILE_SET, TEST_DATADIR "/overlaps.ics", &options);
 
     c = icalcomponent_vanew(ICAL_VEVENT_COMPONENT,
-                            icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 - hh, 0, NULL), (void *)0),
-                            icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2 - hh, 0, NULL), (void *)0),
+                            icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 - hh, false, NULL), (void *)0),
+                            icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2 - hh, false, NULL), (void *)0),
                             (void *)0);
 
     cset = icalclassify_find_overlaps(set, c);
@@ -2597,8 +2560,8 @@ void test_overlaps(void)
 
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 - hh, 0, NULL), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, 0, NULL), (void *)0),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 - hh, false, NULL), (void *)0),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2, false, NULL), (void *)0),
         (void *)0);
 
     cset = icalclassify_find_overlaps(set, c);
@@ -2618,8 +2581,8 @@ void test_overlaps(void)
 
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 + 3 * hh, 0, NULL), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2 + 3 * hh, 0, NULL), (void *)0),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 + 3 * hh, false, NULL), (void *)0),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2 + 3 * hh, false, NULL), (void *)0),
         (void *)0);
 
     cset = icalclassify_find_overlaps(set, c);
@@ -2638,8 +2601,8 @@ void test_overlaps(void)
 
     c = icalcomponent_vanew(
         ICAL_VEVENT_COMPONENT,
-        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 + 5 * hh, 0, NULL), (void *)0),
-        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2 + 5 * hh, 0, NULL), (void *)0),
+        icalproperty_vanew_dtstart(icaltime_from_timet_with_zone(tm1 + 5 * hh, false, NULL), (void *)0),
+        icalproperty_vanew_dtend(icaltime_from_timet_with_zone(tm2 + 5 * hh, false, NULL), (void *)0),
         (void *)0);
 
     cset = icalclassify_find_overlaps(set, c);
@@ -2661,7 +2624,7 @@ void test_overlaps(void)
     }
 }
 
-void test_fblist(void)
+static void test_fblist(void)
 {
     icalspanlist *sl, *new_sl;
     icalfileset_options options = {O_RDONLY, 0644, 0, NULL};
@@ -2801,7 +2764,7 @@ void test_fblist(void)
     icalset_free(set);
 }
 
-void test_convenience(void)
+static void test_convenience(void)
 {
     icalcomponent *c;
     int duration;
@@ -3019,7 +2982,7 @@ void test_convenience(void)
     icalcomponent_free(c);
 }
 
-void test_time_parser(void)
+static void test_time_parser(void)
 {
     struct icaltimetype tt;
 
@@ -3055,7 +3018,7 @@ void test_time_parser(void)
     icalerror_set_errors_are_fatal(true);
 }
 
-void test_recur_parser(void)
+static void test_recur_parser(void)
 {
     struct icalrecurrencetype *rt;
     icalvalue *v = NULL;
@@ -3139,7 +3102,7 @@ static int test_juldat_caldat_instance(long year, int month, int day)
  * output of the icaltime_day_of_week and icaltime_start_doy_week functions
  * which are based on the functions to be tested.
  */
-void test_juldat_caldat(void)
+static void test_juldat_caldat(void)
 {
     int i;
     int failed = 0;
@@ -3183,12 +3146,7 @@ void test_juldat_caldat(void)
     ok("ical_juldat and ical_caldat return the expected values for random input values", failed == 0);
 }
 
-char *ical_strstr(const char *haystack, const char *needle)
-{
-    return (char *)strstr(haystack, needle);
-}
-
-void test_start_of_week(void)
+static void test_start_of_week(void)
 {
     struct icaltimetype tt1 = icaltime_from_string("19900110");
 
@@ -3220,7 +3178,7 @@ void test_start_of_week(void)
     } while (tt1.year < 2010);
 }
 
-void test_doy(void)
+static void test_doy(void)
 {
     struct icaltimetype tt1, tt2;
     short doy, doy2;
@@ -3319,7 +3277,7 @@ void test_doy(void)
     ok("day of year == 60", (doy == 60));
 }
 
-void test_x(void)
+static void test_x(void)
 {
     static const char test_icalcomp_str[] =
         "BEGIN:VEVENT\r\n"
@@ -3370,7 +3328,7 @@ void test_x(void)
     icalcomponent_free(icalcomp);
 }
 
-void test_gauge_sql(void)
+static void test_gauge_sql(void)
 {
     icalgauge *g;
     const char *str;
@@ -3428,7 +3386,7 @@ void test_gauge_sql(void)
     icalgauge_free(g);
 }
 
-void test_gauge_compare(void)
+static void test_gauge_compare(void)
 {
     icalgauge *g;
     icalcomponent *c;
@@ -3708,7 +3666,7 @@ void test_gauge_compare(void)
     icalcomponent_free(c);
 }
 
-icalcomponent *make_component(int i)
+static icalcomponent *make_component(int i)
 {
     icalcomponent *c;
 
@@ -3727,7 +3685,7 @@ icalcomponent *make_component(int i)
     return c;
 }
 
-void test_fileset(void)
+static void test_fileset(void)
 {
 #if defined(HAVE_UNLINK)
     icalset *fs;
@@ -3799,8 +3757,8 @@ void test_fileset(void)
     /*icalgauge_free(g); */
 #endif
 }
-
-void microsleep(int us)
+#if defined(LIBICAL_BUILD_TESTING_LONGRUNNING)
+static void microsleep(int us)
 { /*us is in microseconds */
 #if defined(HAVE_NANOSLEEP)
     struct timespec ts;
@@ -3813,8 +3771,10 @@ void microsleep(int us)
     usleep(us);
 #endif /*Windows Sleep is useless for microsleeping */
 }
+#endif
 
-void test_file_locks(void)
+#if defined(LIBICAL_BUILD_TESTING_LONGRUNNING)
+static void test_file_locks(void)
 {
 #if defined(HAVE_WAITPID) && defined(HAVE_FORK) && defined(HAVE_UNLINK)
     pid_t pid;
@@ -3942,8 +3902,9 @@ void test_file_locks(void)
     _unused(sec);
 #endif
 }
+#endif
 
-void test_action(void)
+static void test_action(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -3986,7 +3947,7 @@ void test_action(void)
     icalcomponent_free(c);
 }
 
-void test_trigger(void)
+static void test_trigger(void)
 {
     struct icaltriggertype tr;
     icalcomponent *c;
@@ -4105,7 +4066,7 @@ void test_trigger(void)
     icalproperty_free(p);
 }
 
-void test_rdate(void)
+static void test_rdate(void)
 {
     struct icaldatetimeperiodtype dtp;
     icalproperty *p;
@@ -4194,7 +4155,7 @@ void test_rdate(void)
     icalproperty_free(p);
 }
 
-void test_langbind(void)
+static void test_langbind(void)
 {
     icalcomponent *c, *inner;
     icalproperty *p;
@@ -4271,7 +4232,7 @@ void test_langbind(void)
     icalcomponent_free(c);
 }
 
-void test_property_parse(void)
+static void test_property_parse(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4313,7 +4274,7 @@ void test_property_parse(void)
     icalcomponent_free(c);
 }
 
-void test_value_from_string(void)
+static void test_value_from_string(void)
 {
     icalproperty *p = icalproperty_new_from_string("SUMMARY:foo");
     ok("value_from_string(), SUMMARY FOO", (p != 0));
@@ -4326,7 +4287,7 @@ void test_value_from_string(void)
     icalproperty_free(p);
 }
 
-void test_value_parameter(void)
+static void test_value_parameter(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4361,7 +4322,7 @@ void test_value_parameter(void)
     icalcomponent_free(c);
 }
 
-void test_empty_parameter(void)
+static void test_empty_parameter(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4390,7 +4351,7 @@ void test_empty_parameter(void)
     icalcomponent_free(c);
 }
 
-void test_x_parameter(void)
+static void test_x_parameter(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4430,7 +4391,7 @@ void test_x_parameter(void)
     icalcomponent_free(c);
 }
 
-void test_empty_property(void)
+static void test_empty_property(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4443,10 +4404,10 @@ void test_empty_property(void)
         "GEO:\n" //structured
         "END:VEVENT\n";
 
-    int estate = icalerror_get_errors_are_fatal();
+    bool estate = icalerror_get_errors_are_fatal();
     icalerror_set_errors_are_fatal(false);
 
-    int pstate = icalproperty_get_allow_empty_properties();
+    bool pstate = icalproperty_get_allow_empty_properties();
 
     /* First test: do not allow empty properties */
     icalproperty_set_allow_empty_properties(false);
@@ -4515,7 +4476,7 @@ void test_empty_property(void)
     icalerror_set_errors_are_fatal(estate);
 }
 
-void test_x_property(void)
+static void test_x_property(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4543,7 +4504,7 @@ void test_x_property(void)
     icalcomponent_free(c);
 }
 
-void test_utcoffset(void)
+static void test_utcoffset(void)
 {
     icalcomponent *c;
 
@@ -4564,7 +4525,7 @@ void test_utcoffset(void)
     }
 }
 
-void test_attach(void)
+static void test_attach(void)
 {
     icalcomponent *c;
 
@@ -4586,7 +4547,7 @@ void test_attach(void)
     }
 }
 
-void test_attach_caldav(void)
+static void test_attach_caldav(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4646,7 +4607,7 @@ void test_attach_caldav(void)
     }
 }
 
-void test_attach_url(void)
+static void test_attach_url(void)
 {
     static const char test_icalcomp_str_attachwithurl[] =
         "BEGIN:VALARM\r\n"
@@ -4681,7 +4642,7 @@ static void test_free_attach_data(char *data, void *user_data)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
 #endif
-void test_attach_data(void)
+static void test_attach_data(void)
 {
     static const char test_icalcomp_str_attachwithdata[] =
         "BEGIN:VALARM\r\n"
@@ -4750,7 +4711,7 @@ void test_attach_data(void)
 #pragma GCC diagnostic pop
 #endif
 
-void test_vcal(void)
+static void test_vcal(void)
 {
     VObject *vcal;
     const char *file = TEST_DATADIR "/user-cal.vcf";
@@ -4780,7 +4741,7 @@ void test_vcal(void)
  * Test to see if recurrences are excluded in certain situations
  * See r961 for more information
  */
-void test_recurrenceexcluded(void)
+static void test_recurrenceexcluded(void)
 {
     char funTime[2048] = {0};
     icalcomponent *calendar = NULL;
@@ -4834,7 +4795,7 @@ void test_recurrenceexcluded(void)
 
 #if defined(USE_BUILTIN_TZDATA)
 // this test is setup for testing against our builtin tzdata
-void test_bad_dtstart_in_timezone(void)
+static void test_bad_dtstart_in_timezone(void)
 {
     icaltimezone *myTZ = NULL;
     icalcomponent *vtimezone = NULL;
@@ -4851,7 +4812,7 @@ void test_bad_dtstart_in_timezone(void)
 }
 #endif
 
-void test_icalcomponent_new_from_string(void)
+static void test_icalcomponent_new_from_string(void)
 {
     const char *item =
         "BEGIN:VCALENDAR\n"
@@ -4879,7 +4840,7 @@ void test_icalcomponent_new_from_string(void)
     icalcomponent_free(comp);
 }
 
-void test_comma_in_quoted_value(void)
+static void test_comma_in_quoted_value(void)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -4908,9 +4869,9 @@ void test_comma_in_quoted_value(void)
     icalcomponent_free(c);
 }
 
-void test_geo_props(void)
+static void test_geo_props(void)
 {
-    int estate;
+    bool estate;
     icalcomponent *c;
     icalproperty *p;
 
@@ -4979,7 +4940,7 @@ void test_geo_props(void)
     icalerror_set_errors_are_fatal(estate);
 }
 
-void test_zoneinfo_stuff(void)
+static void test_zoneinfo_stuff(void)
 {
 #if defined(HAVE_SETENV)
     setenv("TZDIR", TEST_DATADIR, 1);
@@ -5003,7 +4964,7 @@ void test_zoneinfo_stuff(void)
     icaltimezone_set_system_zone_directory(NULL);
 }
 
-void test_tzid_with_utc_time(void)
+static void test_tzid_with_utc_time(void)
 {
     const char *strcomp =
         "BEGIN:VCALENDAR\r\n"
@@ -5076,7 +5037,7 @@ void test_tzid_with_utc_time(void)
     icalcomponent_free(comp);
 }
 
-void test_recur_tzid(void)
+static void test_recur_tzid(void)
 {
     const char *calstr =
         "BEGIN:VCALENDAR\r\n"
@@ -5121,7 +5082,7 @@ void test_recur_tzid(void)
     icalcomponent_free(comp);
 }
 
-void test_kind_to_string(void)
+static void test_kind_to_string(void)
 {
     // value testing
     ok("VALUE_KIND ICAL_ANY_VALUE is NULL",
@@ -5169,7 +5130,7 @@ void test_kind_to_string(void)
        icalproperty_kind_is_valid(ICAL_NO_PROPERTY));
 }
 
-void test_string_to_kind(void)
+static void test_string_to_kind(void)
 {
     ok("VALUE NULL is ICAL_NO_VALUE",
        (icalvalue_string_to_kind(NULL) == ICAL_NO_VALUE));
@@ -5193,7 +5154,7 @@ void test_string_to_kind(void)
            (int)icalproperty_string_to_kind(""), ICAL_NO_PROPERTY);
 }
 
-void test_set_date_datetime_value(void)
+static void test_set_date_datetime_value(void)
 {
     icalproperty *prop;
     icalparameter *param;
@@ -5241,7 +5202,7 @@ void test_set_date_datetime_value(void)
     icalproperty_free(prop);
 }
 
-void test_timezone_from_builtin(void)
+static void test_timezone_from_builtin(void)
 {
     const char *strcomp_fmt =
         "BEGIN:VCALENDAR\r\n"
@@ -5328,7 +5289,7 @@ void test_timezone_from_builtin(void)
     icaltimezone_set_tzid_prefix(TESTS_TZID_PREFIX);
 }
 
-void test_icalvalue_decode_ical_string(void)
+static void test_icalvalue_decode_ical_string(void)
 {
     char buff[12];
     const char *defvalue, *value;
@@ -5378,7 +5339,7 @@ static int test_icalarray_sort_compare_char(const void *p1, const void *p2)
     return (c1 < c2) ? -1 : ((c1 > c2) ? 1 : 0);
 }
 
-void test_icalarray_sort(void)
+static void test_icalarray_sort(void)
 {
     /* this test is based on the work from the PDCLib project */
 
@@ -5403,7 +5364,7 @@ void test_icalarray_sort(void)
     icalarray_free(array);
 }
 
-void test_icalcomponent_normalize(void)
+static void test_icalcomponent_normalize(void)
 {
     const char *calStr1 =
         "BEGIN:VCALENDAR\n"
@@ -5480,7 +5441,7 @@ void test_icalcomponent_normalize(void)
     str_is("Normalized components match", calStr1, calStr2);
 }
 
-void test_icalcomponent_normalize_missing_mandatory_props(void)
+static void test_icalcomponent_normalize_missing_mandatory_props(void)
 {
     // This test asserts that normalize does not crash when comparing
     // components which do not have mandatory properties set. If one
@@ -5848,7 +5809,7 @@ static void test_implicit_dtend_duration(void)
     str_is("P1D", "P1D", icaldurationtype_as_ical_string(d));
 
     if (VERBOSE) {
-        printf("%i\n", icaltime_is_null_time(end));
+        printf("%i\n", (int)icaltime_is_null_time(end));
     }
     int_is("icaltime_is_null_time(end)", 1, icaltime_is_null_time(end));
     icalcomponent_free(c);
@@ -5920,9 +5881,8 @@ test_icalvalue_resets_timezone_on_set(void)
     icaltimetype comp_dtstart, comp_dtend, comp_due;
     icaltimetype clone_dtstart, clone_dtend, clone_due;
     const char *orig_str, *clone_str;
-    int estate;
 
-    estate = icalerror_get_errors_are_fatal();
+    bool estate = icalerror_get_errors_are_fatal();
     icalerror_set_errors_are_fatal(false);
 
     /* First try without calling 'set' */
@@ -6041,7 +6001,7 @@ static void test_remove_tzid_from_due(void)
     icalcomponent_free(c);
 }
 
-void test_icaltime_as_timet(void)
+static void test_icaltime_as_timet(void)
 {
     icaltimetype tt;
     time_t expectedTimeT;
@@ -6097,12 +6057,12 @@ void test_icaltime_as_timet(void)
     ok("icaltime_as_timet translates out of bounds correctly", icaltime_as_timet(tt) == -1);
 }
 
-void test_icalcomponent_with_lastmodified(void)
+static void test_icalcomponent_with_lastmodified(void)
 {
     /* for https://github.com/libical/libical/issues/585 */
 
     icalcomponent *comp;
-    struct icaltimetype lm = icaltime_from_timet_with_zone(1661280150, 0, NULL);
+    struct icaltimetype lm = icaltime_from_timet_with_zone(1661280150, false, NULL);
     comp = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT,
                                icalproperty_new_version("2.0"),
                                icalproperty_new_prodid("PROD-ABC"),
@@ -6113,7 +6073,7 @@ void test_icalcomponent_with_lastmodified(void)
     icalcomponent_free(comp);
 }
 
-void test_tzid_setter(void)
+static void test_tzid_setter(void)
 {
     char *saveTzid, *builtinTzid;
 
@@ -6164,7 +6124,7 @@ static void verify_comp_attendee(icalcomponent *comp)
 #undef get_param
 }
 
-void test_attendees(void)
+static void test_attendees(void)
 {
     icalcomponent *comp, *clone;
     icalproperty *prop;
@@ -6255,7 +6215,7 @@ static void verify_comp_relations(icalcomponent *comp)
 #undef get_param
 }
 
-void test_ical_relationships(void)
+static void test_ical_relationships(void)
 {
     icalcomponent *comp, *clone;
     const char *str;
@@ -6911,7 +6871,7 @@ static void test_internal_limits(void)
     ok("value chars is size_max", icallimit_get(ICAL_LIMIT_VALUE_CHARS) == SIZE_MAX);
 }
 
-void test_icaldurationtype_normalize(void)
+static void test_icaldurationtype_normalize(void)
 {
 #define assert_normalized_duration(input, want) \
     str_is("normalize(" input ")=" want, want,  \
@@ -7530,7 +7490,7 @@ static void test_create_iana_parameter_value(void)
 static void assert_folded_line(const char *line)
 {
     size_t len = strlen(line);
-    bool ends_with_crlf = len >= 2 && line[len - 2] == '\r' && line[len - 1] == '\n';
+    bool ends_with_crlf = (len >= 2 && line[len - 2] == '\r' && line[len - 1] == '\n') != 0;
     ok("line ends with CRLF", ends_with_crlf);
     if (!ends_with_crlf) {
         return;
@@ -7548,8 +7508,8 @@ static void assert_folded_line(const char *line)
         ok("no stray LF character", p[0] != '\n');
         // verify folds
         if (p[0] == '\r') {
-            bool is_valid_fold = eol - p > 3 &&
-                                 p[1] == '\n' && (p[2] == ' ' || p[2] == '\t') && p[3] != '\r';
+            bool is_valid_fold = (eol - p > 3 &&
+                                  p[1] == '\n' && (p[2] == ' ' || p[2] == '\t') && p[3] != '\r') != 0;
             ok("a fold must be followed by a content character", is_valid_fold);
             if (!is_valid_fold) {
                 return;
@@ -7618,7 +7578,7 @@ static void test_geo_zoneinfo_coordinates(void)
 static void test_dtend_duration_due_validation(void)
 {
     icalcomponent *ical;
-    int valid;
+    bool valid;
 
     /* In a VTODO, DUE MUST have the same value type as DTSTART */
     const char *task1 =
@@ -7636,7 +7596,7 @@ static void test_dtend_duration_due_validation(void)
 
     ical = icalcomponent_new_from_string(task1);
     valid = icalrestriction_check(ical);
-    ok("DUE value type != DTSTART value type", (valid == 0));
+    ok("DUE value type != DTSTART value type", !valid);
     icalcomponent_free(ical);
 
     /* In a VTODO, if DTSTART is local time then DUE must also be */
@@ -7655,7 +7615,7 @@ static void test_dtend_duration_due_validation(void)
 
     ical = icalcomponent_new_from_string(task2);
     valid = icalrestriction_check(ical);
-    ok("DUE & DTSTART not both local time", (valid == 0));
+    ok("DUE & DTSTART not both local time", !valid);
     icalcomponent_free(ical);
 
     /* A VTODO must have only one of DUE and DURATION */
@@ -7675,7 +7635,7 @@ static void test_dtend_duration_due_validation(void)
 
     ical = icalcomponent_new_from_string(task3);
     valid = icalrestriction_check(ical);
-    ok("DUE + DURATION", (valid == 0));
+    ok("DUE + DURATION", !valid);
     icalcomponent_free(ical);
 
     /* DUE must be later than DTSTART */
@@ -7694,7 +7654,7 @@ static void test_dtend_duration_due_validation(void)
 
     ical = icalcomponent_new_from_string(task4);
     valid = icalrestriction_check(ical);
-    ok("DUE < DTSTART", (valid == 0));
+    ok("DUE < DTSTART", !valid);
     icalcomponent_free(ical);
 
     /* DURATION must be greater than zero */
@@ -7713,7 +7673,7 @@ static void test_dtend_duration_due_validation(void)
 
     ical = icalcomponent_new_from_string(task5);
     valid = icalrestriction_check(ical);
-    ok("Negative DURATION", (valid == 0));
+    ok("Negative DURATION", !valid);
     icalcomponent_free(ical);
 
     /* A VTODO with DUE but no DTSTART is valid */
@@ -7731,7 +7691,7 @@ static void test_dtend_duration_due_validation(void)
 
     ical = icalcomponent_new_from_string(task6);
     valid = icalrestriction_check(ical);
-    ok("DUE without DTSTART", (valid == 1));
+    ok("DUE without DTSTART", valid);
     icalcomponent_free(ical);
 
     /* A VEVENT with DTEND but no DTSTART is invalid */
@@ -7882,11 +7842,11 @@ int main(int argc, const char *argv[])
     }
 
     if (optind < argc) {
-        do_test = atoi(argv[argc - 1]);
+        do_test = atoi(argv[argc - 1]); //NOLINT(bugprone-unchecked-string-to-number-conversion)
     }
 #else
     if (argc > 1) {
-        do_test = atoi(argv[1]);
+        do_test = atoi(argv[1]); //NOLINT(bugprone-unchecked-string-to-number-conversion)
     }
 
 #endif
@@ -7914,13 +7874,16 @@ int main(int argc, const char *argv[])
     test_run("Test Span", test_icalcomponent_get_span, do_test, do_header);
     test_run("Test Gauge SQL", test_gauge_sql, do_test, do_header);
     test_run("Test Gauge Compare", test_gauge_compare, do_test, do_header);
+    test_run("Test ICal Set", test_icalset, do_test, do_header);
     test_run("Test File Set", test_fileset, do_test, do_header);
     test_run("Test File Set (Extended)", test_fileset_extended, do_test, do_header);
     test_run("Test Dir Set", test_dirset, do_test, do_header);
     test_run("Test Dir Set (Extended)", test_dirset_extended, do_test, do_header);
 
-    /* test_file_locks is slow but should work ok -- uncomment to test it */
+#if defined(LIBICAL_BUILD_TESTING_LONGRUNNING)
+    /* test_file_locks is slow but should work ok */
     /*    test_run("Test File Locks", test_file_locks, do_test, do_header);*/
+#endif
     test_run("Test X Props and Params", test_x, do_test, do_header);
     test_run("Test Trigger", test_trigger, do_test, do_header);
     test_run("Test Restriction", test_restriction, do_test, do_header);
@@ -8032,7 +7995,6 @@ int main(int argc, const char *argv[])
     test_run("Test compare date only", test_icaltime_compare_date_only, do_test, do_header);
     test_run("Test folding", test_line_folding, do_test, do_header);
     test_run("Test zoneinfo geo coordinates", test_geo_zoneinfo_coordinates, do_test, do_header);
-    /** OPTIONAL TESTS go here... **/
 
 #if defined(LIBICAL_CXX_BINDINGS)
     test_run("Test C++ API", test_cxx, do_test, do_header);
@@ -8052,6 +8014,7 @@ int main(int argc, const char *argv[])
     return failed_count > 0;
 }
 
+//NOLINTEND(misc-predictable-rand)
 //NOLINTEND(clang-analyzer-security.insecureAPI.strcpy)
 
 /* make sure to keep tabs in our test strings */

--- a/src/test/regression.h
+++ b/src/test/regression.h
@@ -42,7 +42,7 @@ const char *ical_timet_string(const icaltime_t t);
 const char *ictt_as_string(struct icaltimetype t);
 char *icaltime_as_ctime(struct icaltimetype t);
 
-void _ok(const char *test_name, int success, const char *file, int linenum, const char *test);
+void _ok(const char *test_name, bool success, const char *file, int linenum, const char *test);
 void _is(const char *test_name, const char *str1, const char *str2, const char *file,
          int linenum);
 void _int_is(const char *test_name, int i1, int i2, const char *file, int linenum);

--- a/src/test/test-malloc.c
+++ b/src/test/test-malloc.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct testmalloc_statistics global_testmalloc_statistics;
+static struct testmalloc_statistics global_testmalloc_statistics;
 static int global_testmalloc_remaining_attempts = -1;
 
 #define TESTMALLOC_MAGIC_NO 0x1234abcd


### PR DESCRIPTION
- fix clang-tidy misc-internal-linkage issues
- fix clang-tidy readability-implicit-bool-conversion issues
- restore a few tests that were commented (and fix them)
- clean includes
- remove old, no longer needed comments
