### PR TITLE
src/java/CMakeLists.txt - fix DESTINATION path for libical.jar

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -133,4 +133,4 @@ install(TARGETS ical_jni EXPORT icalTargets DESTINATION ${INSTALL_TARGETS_DEFAUL
 
 ########### install files ###############
 
-install(FILES ${PROJECT_BINARY_DIR}/src/java/libical.jar DESTINATION ${CMAKE_INSTALL_PREFIX}/share)
+install(FILES ${PROJECT_BINARY_DIR}/src/java/libical.jar DESTINATION ${SHARE_INSTALL_DIR})


### PR DESCRIPTION
cmake version 4.4 reported:
CMake Error (install-absolute-destination) src/java/CMakeLists.txt:136
  INSTALL command given absolute DESTINATION path:  /usr/local/share

Fixed by using the project's SHARE_INSTALL_DIR variable.
