### PR TITLE
Fix use as CMake subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -994,7 +994,7 @@ libical_option(LIBICAL_BUILD_EXAMPLES "Build examples." True)
 
 ########### Configure pkg-config variables #########
 
-set(VERSION "${CMAKE_PROJECT_VERSION}")
+set(VERSION "${libical_VERSION}")
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\${prefix}")
 if(IS_ABSOLUTE ${LIB_INSTALL_DIR})
@@ -1098,7 +1098,7 @@ configure_package_config_file(
 # Create a version file
 write_basic_package_version_file(
   ${libical_BINARY_DIR}/LibIcalConfigVersion.cmake
-  VERSION ${CMAKE_PROJECT_VERSION}
+  VERSION ${libical_VERSION}
   COMPATIBILITY SameMajorVersion
 )
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -174,16 +174,16 @@ SPDX-License-Identifier: LGPL-2.1-only OR MPL-2.0
 #cmakedefine HAVE_WCTYPE_H 1
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "${CMAKE_PROJECT_HOMEPAGE_URL}"
+#define PACKAGE_BUGREPORT "${libical_HOMEPAGE_URL}"
 
 /* Define to the full name of this package. */
-#define PACKAGE_NAME "${CMAKE_PROJECT_NAME}"
+#define PACKAGE_NAME "${PROJECT_NAME}"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "${CMAKE_PROJECT_NAME} ${PROJECT_VERSION}"
+#define PACKAGE_STRING "${PROJECT_NAME} ${PROJECT_VERSION}"
 
 /* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "${CMAKE_PROJECT_NAME}"
+#define PACKAGE_TARNAME "${PROJECT_NAME}"
 
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "${PROJECT_VERSION}"

--- a/docs/reference/libical-glib/libical-glib.toml.in
+++ b/docs/reference/libical-glib/libical-glib.toml.in
@@ -1,5 +1,5 @@
 [library]
-version = "@CMAKE_PROJECT_VERSION_MAJOR@"
+version = "@libical_VERSION_MAJOR@"
 browse_url = "https://github.com/libical/libical"
 repository_url = "https://github.com/libical/libical.git"
 website_url = "https://libical.github.io/libical/"

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -51,7 +51,7 @@ if(NOT ANDROID)
     ical_jni
     PROPERTIES
       VERSION
-        ${CMAKE_PROJECT_VERSION}
+        ${libical_VERSION}
       SOVERSION
         ${LIBICAL_LIB_SOVERSION_STRING}
   )

--- a/src/libical-glib/CMakeLists.txt
+++ b/src/libical-glib/CMakeLists.txt
@@ -398,7 +398,7 @@ if(NOT ANDROID)
     ical-glib
     PROPERTIES
       VERSION
-        ${CMAKE_PROJECT_VERSION}
+        ${libical_VERSION}
       SOVERSION
         ${LIBICAL_LIB_SOVERSION_STRING}
   )

--- a/src/libical-glib/libical-glib.pc.in
+++ b/src/libical-glib/libical-glib.pc.in
@@ -8,7 +8,7 @@ includedir=@includedir@
 
 Name: libical-glib
 Description: A GObject interface of the libical library
-Version: @CMAKE_PROJECT_VERSION@
+Version: @libical_VERSION@
 Requires: glib-2.0, gobject-2.0, libical
 Cflags: -I${includedir}
 Libs: -L${libdir} -lical-glib

--- a/src/libical/CMakeLists.txt
+++ b/src/libical/CMakeLists.txt
@@ -319,7 +319,7 @@ if(NOT ANDROID)
     ical
     PROPERTIES
       VERSION
-        ${CMAKE_PROJECT_VERSION}
+        ${libical_VERSION}
       SOVERSION
         ${LIBICAL_LIB_SOVERSION_STRING}
   )
@@ -380,7 +380,7 @@ if(LIBICAL_CXX_BINDINGS)
       ical_cxx
       PROPERTIES
         VERSION
-          ${CMAKE_PROJECT_VERSION}
+          ${libical_VERSION}
         SOVERSION
           ${LIBICAL_LIB_SOVERSION_STRING}
     )

--- a/src/libical/icalversion.h.cmake
+++ b/src/libical/icalversion.h.cmake
@@ -17,7 +17,7 @@
 /**
  * The library project name as a string.
  */
-#define ICAL_PACKAGE "@CMAKE_PROJECT_NAME@"
+#define ICAL_PACKAGE "@PROJECT_NAME@"
 /**
  * The full library version as a string.
  */
@@ -26,15 +26,15 @@
 /**
  * Return the library major version number.
  */
-#define ICAL_MAJOR_VERSION (@CMAKE_PROJECT_VERSION_MAJOR@)
+#define ICAL_MAJOR_VERSION (@libical_VERSION_MAJOR@)
 /**
  * Return the library minor version number.
  */
-#define ICAL_MINOR_VERSION (@CMAKE_PROJECT_VERSION_MINOR@)
+#define ICAL_MINOR_VERSION (@libical_VERSION_MINOR@)
 /**
  * Return the library patch version number.
  */
-#define ICAL_PATCH_VERSION (@CMAKE_PROJECT_VERSION_PATCH@)
+#define ICAL_PATCH_VERSION (@libical_VERSION_PATCH@)
 /**
  * Return the library micro version number.
  */

--- a/src/libical/libical.pc.in
+++ b/src/libical/libical.pc.in
@@ -6,8 +6,8 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libical
-Description: @CMAKE_PROJECT_DESCRIPTION@
-URL: @CMAKE_PROJECT_HOMEPAGE_URL@
-Version: @CMAKE_PROJECT_VERSION@
+Description: @libical_DESCRIPTION@
+URL: @libical_HOMEPAGE_URL@
+Version: @libical_VERSION@
 Libs: -L${libdir} -lical@PTHREAD_LIBS_PRIVATE@@REQUIRES_PRIVATE_ICU@
 Cflags: -I${includedir}

--- a/src/libicalss/CMakeLists.txt
+++ b/src/libicalss/CMakeLists.txt
@@ -117,7 +117,7 @@ if(NOT ANDROID)
     icalss
     PROPERTIES
       VERSION
-        ${CMAKE_PROJECT_VERSION}
+        ${libical_VERSION}
       SOVERSION
         ${LIBICAL_LIB_SOVERSION_STRING}
   )
@@ -176,7 +176,7 @@ if(LIBICAL_CXX_BINDINGS)
       icalss_cxx
       PROPERTIES
         VERSION
-          ${CMAKE_PROJECT_VERSION}
+          ${libical_VERSION}
         SOVERSION
           ${LIBICAL_LIB_SOVERSION_STRING}
     )

--- a/src/libicalss/libicalss.pc.in
+++ b/src/libicalss/libicalss.pc.in
@@ -6,9 +6,9 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libicalss
-Description: @CMAKE_PROJECT_DESCRIPTION@ (Storage Support)
-URL: @CMAKE_PROJECT_HOMEPAGE_URL@
-Version: @CMAKE_PROJECT_VERSION@
+Description: @libical_DESCRIPTION@ (Storage Support)
+URL: @libical_HOMEPAGE_URL@
+Version: @libical_VERSION@
 Libs: -L${libdir} -licalss@PTHREAD_LIBS_PRIVATE@
 Requires: libical
 Cflags: -I${includedir}

--- a/src/libicalvcal/CMakeLists.txt
+++ b/src/libicalvcal/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT ANDROID)
     icalvcal
     PROPERTIES
       VERSION
-        ${CMAKE_PROJECT_VERSION}
+        ${libical_VERSION}
       SOVERSION
         ${LIBICAL_LIB_SOVERSION_STRING}
   )

--- a/src/libicalvcal/libicalvcal.pc.in
+++ b/src/libicalvcal/libicalvcal.pc.in
@@ -6,9 +6,9 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libicalvcal
-Description: @CMAKE_PROJECT_DESCRIPTION@ (VCal)
-URL: @CMAKE_PROJECT_HOMEPAGE_URL@
-Version: @CMAKE_PROJECT_VERSION@
+Description: @libical_DESCRIPTION@ (VCal)
+URL: @libical_HOMEPAGE_URL@
+Version: @libical_VERSION@
 Libs: -L${libdir} -licalvcal
 Requires: libical
 Cflags: -I${includedir}

--- a/src/libicalvcard/CMakeLists.txt
+++ b/src/libicalvcard/CMakeLists.txt
@@ -231,7 +231,7 @@ if(NOT ANDROID)
     icalvcard
     PROPERTIES
       VERSION
-        ${CMAKE_PROJECT_VERSION}
+        ${libical_VERSION}
       SOVERSION
         ${LIBICAL_LIB_SOVERSION_STRING}
   )

--- a/src/libicalvcard/libicalvcard.pc.in
+++ b/src/libicalvcard/libicalvcard.pc.in
@@ -6,9 +6,9 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libicalvcard
-Description: @CMAKE_PROJECT_DESCRIPTION@ (VCard)
-URL: @CMAKE_PROJECT_HOMEPAGE_URL@
-Version: @CMAKE_PROJECT_VERSION@
+Description: @libical_DESCRIPTION@ (VCard)
+URL: @libical_HOMEPAGE_URL@
+Version: @libical_VERSION@
 Libs: -L${libdir} -licalvcard
 Requires: libical
 Cflags: -I${includedir}


### PR DESCRIPTION
Create the following CMakeLists.txt in the directory above where your libical exists:

    cmake_minimum_required(VERSION 3.25)
    project(exampleProj)
    add_subdirectory(libical)

Trying to configure this CMake project results in CMake errors:

    CMake Error at libical/src/libical/CMakeLists.txt:318 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

    CMake Error at libical/src/libical/CMakeLists.txt:379 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

    CMake Error at libical/src/libicalss/CMakeLists.txt:116 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

    CMake Error at libical/src/libicalss/CMakeLists.txt:175 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

    CMake Error at libical/src/libicalvcal/CMakeLists.txt:53 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

    CMake Error at libical/src/libical-glib/CMakeLists.txt:397 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

    CMake Error at libical/src/libicalvcard/CMakeLists.txt:230 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

The reason for this error can be found in the docs for CMake's project() command:

    Sets the name of the project, and stores it in the variable
    ``PROJECT_NAME``. When called from the top-level
    ``CMakeLists.txt`` also stores the project name in the
    variable ``CMAKE_PROJECT_NAME``.

Similar wording is also present for other variables, for example CMAKE_PROJECT_VERSION.

In this commit, I replace all uses of CMAKE_PROJECT_XXX that I could find with libical_XXX, which also works when libical is not the top-level project.

The variables that I found are:

- CMAKE_PROJECT_DESCRIPTION
- CMAKE_PROJECT_HOMEPAGE_URL
- CMAKE_PROJECT_VERSION
- CMAKE_PROJECT_VERSION_MAJOR
- CMAKE_PROJECT_VERSION_MINOR
- CMAKE_PROJECT_VERSION_PATCH
- CMAKE_PROJECT_NAME (which is replaced with PROJECT_NAME and not libical_NAME since the later does not exist)

I did not touch scripts/cmp-abi-data-libical.sh since that seems to be for internal use.

The result of this commit was tested by looking at some of the generated files in the CMake build dir. I did _not_ look at every single place individually since that would require installing all necessary build dependencies.