### PR TITLE
clang-tidy readability-implicit-bool-conversion fixes

### DIFF
--- a/src/libical/icalcomponent.c
+++ b/src/libical/icalcomponent.c
@@ -70,12 +70,12 @@ void icalcomponent_add_children(icalcomponent *impl, va_list args)
     void *vp;
 
     while ((vp = va_arg(args, void *)) != 0) {
-        icalassert(icalcomponent_isa_component(vp) != 0 || icalproperty_isa_property(vp) != 0);
+        icalassert(icalcomponent_isa_component(vp) || icalproperty_isa_property(vp));
 
         if (icalcomponent_isa_component(vp)) {
             icalcomponent_add_component(impl, (icalcomponent *)vp);
 
-        } else if (icalproperty_isa_property(vp) != 0) {
+        } else if (icalproperty_isa_property(vp)) {
             icalcomponent_add_property(impl, (icalproperty *)vp);
         }
     }
@@ -1007,9 +1007,9 @@ void icalcomponent_foreach_recurrence(icalcomponent *comp,
 
     /* Now set up the base span for this item, corresponding to the
        base DTSTART and DTEND */
-    basespan = icaltime_span_new(dtstart, dtend, 1);
+    basespan = icaltime_span_new(dtstart, dtend, true);
 
-    basespan.is_busy = icalcomponent_is_busy(comp);
+    basespan.is_busy = (int)icalcomponent_is_busy(comp);
 
     if (start.is_date) {
         /* We always treat start as date-time, because we do arithmetic calculations later
@@ -1391,7 +1391,10 @@ bool icalcompiter_is_valid(const icalcompiter *i)
         return false;
     }
     /* compare to icalcompiter_null */
-    return !((i->kind == ICAL_NO_COMPONENT) && (i->iter == 0));
+    if (i->kind == ICAL_NO_COMPONENT && i->iter == 0) {
+        return false;
+    }
+    return true;
 }
 
 icalcompiter icalcomponent_begin_component(icalcomponent *component, icalcomponent_kind kind)
@@ -1512,7 +1515,10 @@ bool icalpropiter_is_valid(const icalpropiter *i)
         return false;
     }
     /* compare to icalpropiter_null */
-    return !((i->kind == ICAL_NO_PROPERTY) && (i->iter == 0));
+    if ((i->kind == ICAL_NO_PROPERTY) && (i->iter == 0)) {
+        return false;
+    }
+    return true;
 }
 
 icalproperty *icalpropiter_next(icalpropiter *i)
@@ -2528,14 +2534,24 @@ icaltimezone *icalcomponent_get_timezone(icalcomponent *comp, const char *tzid)
  */
 static int icalcomponent_compare_timezone_fn(const void *elem1, const void *elem2)
 {
-    icaltimezone *zone1, *zone2;
+    bool zone1_is_valid = false, zone2_is_valid = false;
     const char *zone1_tzid = 0, *zone2_tzid = 0;
 
-    zone1 = (icaltimezone *)elem1;
-    zone2 = (icaltimezone *)elem2;
+    icaltimezone *zone1 = (icaltimezone *)elem1;
+    icaltimezone *zone2 = (icaltimezone *)elem2;
 
-    const bool zone1_is_valid = (zone1 && (zone1_tzid = icaltimezone_get_tzid(zone1)));
-    const bool zone2_is_valid = (zone2 && (zone2_tzid = icaltimezone_get_tzid(zone2)));
+    if (zone1) {
+        zone1_tzid = icaltimezone_get_tzid(zone1);
+        if (zone1_tzid) {
+            zone1_is_valid = true;
+        }
+    }
+    if (zone2) {
+        zone2_tzid = icaltimezone_get_tzid(zone2);
+        if (zone2_tzid) {
+            zone2_is_valid = true;
+        }
+    }
 
     if (zone1_is_valid && !zone2_is_valid) {
         return 1;

--- a/src/libical/icalduration.c
+++ b/src/libical/icalduration.c
@@ -270,7 +270,7 @@ struct icaldurationtype icaldurationtype_null_duration(void)
 bool icaldurationtype_is_null_duration(struct icaldurationtype d)
 {
     struct icaldurationtype n = icaldurationtype_null_duration();
-    return memcmp(&d, &n, sizeof(struct icaldurationtype)) ? false : true;
+    return memcmp(&d, &n, sizeof(struct icaldurationtype)) == 0;
 }
 
 /* In icalvalue_new_from_string_with_error, we should not call

--- a/src/libical/icalerror.c
+++ b/src/libical/icalerror.c
@@ -91,7 +91,7 @@ void icalerror_set_errno(icalerrorenum x)
 {
     icalerrno = x;
     if (icalerror_get_error_state(x) == ICAL_ERROR_FATAL ||
-        (icalerror_get_error_state(x) == ICAL_ERROR_DEFAULT && icalerror_errors_are_fatal == 1)) {
+        (icalerror_get_error_state(x) == ICAL_ERROR_DEFAULT && icalerror_errors_are_fatal)) {
         icalerror_warn(icalerror_strerror(x));
         icalerror_backtrace();
         icalassert(0);

--- a/src/libical/icalmemory.c
+++ b/src/libical/icalmemory.c
@@ -513,7 +513,7 @@ void icalmemory_append_encoded_string(char **buf, char **pos,
         }
     }
 
-    if (quoted == true) {
+    if (quoted) {
         icalmemory_append_char(buf, pos, buf_size, '"');
     }
 }

--- a/src/libical/icalparameter.c
+++ b/src/libical/icalparameter.c
@@ -407,7 +407,7 @@ bool icalparameter_is_multivalued(const icalparameter *param)
 {
     icalerror_check_arg_rz((param != 0), "param");
 
-    return param->is_multivalued;
+    return param->is_multivalued != 0;
 }
 
 void icalparameter_decode_value(char *value)

--- a/src/libical/icalparser.c
+++ b/src/libical/icalparser.c
@@ -665,7 +665,7 @@ icalcomponent *icalparser_add_line(icalparser *parser, char *line)
         return 0;
     }
 
-    if (line_is_blank(line) == 1) {
+    if (line_is_blank(line)) {
         return 0;
     }
 

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -1828,7 +1828,7 @@ static bool initialize_rscale(icalrecur_iterator *impl)
         en = ucal_getKeywordValuesForLocale("calendar", "", false, &status);
         while ((cal = uenum_next(en, NULL, &status))) {
             if (!strcmp(cal, rule->rscale)) {
-                is_hebrew = !strcmp(rule->rscale, "hebrew");
+                is_hebrew = (strcmp(rule->rscale, "hebrew") == 0);
                 break;
             }
         }
@@ -1858,11 +1858,11 @@ static bool initialize_rscale(icalrecur_iterator *impl)
     /* Validate BY_* array values whose legal maximums differ based on RSCALE */
     if (!validate_byrule(impl, ICAL_BY_MONTH, UCAL_MONTH,
                          &decode_month, is_hebrew) ||
-        !validate_byrule(impl, ICAL_BY_DAY, UCAL_WEEK_OF_YEAR, &decode_day, 0) ||
-        !validate_byrule(impl, ICAL_BY_MONTH_DAY, UCAL_DAY_OF_MONTH, NULL, 0) ||
-        !validate_byrule(impl, ICAL_BY_YEAR_DAY, UCAL_DAY_OF_YEAR, NULL, 0) ||
-        !validate_byrule(impl, ICAL_BY_WEEK_NO, UCAL_WEEK_OF_YEAR, NULL, 0) ||
-        !validate_byrule(impl, ICAL_BY_SET_POS, UCAL_DAY_OF_YEAR, NULL, 0)) {
+        !validate_byrule(impl, ICAL_BY_DAY, UCAL_WEEK_OF_YEAR, &decode_day, false) ||
+        !validate_byrule(impl, ICAL_BY_MONTH_DAY, UCAL_DAY_OF_MONTH, NULL, false) ||
+        !validate_byrule(impl, ICAL_BY_YEAR_DAY, UCAL_DAY_OF_YEAR, NULL, false) ||
+        !validate_byrule(impl, ICAL_BY_WEEK_NO, UCAL_WEEK_OF_YEAR, NULL, false) ||
+        !validate_byrule(impl, ICAL_BY_SET_POS, UCAL_DAY_OF_YEAR, NULL, false)) {
         icalerror_set_errno(ICAL_MALFORMEDDATA_ERROR);
         return false;
     }
@@ -2416,7 +2416,7 @@ icalrecur_iterator *icalrecur_iterator_new(struct icalrecurrencetype *rule,
         }
     }
 
-    if (initialize_rscale(impl) == 0) {
+    if (!initialize_rscale(impl)) {
         icalrecur_iterator_free(impl);
         return 0;
     }
@@ -2781,7 +2781,7 @@ static void expand_bymonth_days(icalrecur_iterator *impl, int year, int month)
 static void expand_by_day(icalrecur_iterator *impl, int year,
                           int doy_offset, int last_day,
                           int first_dow, int last_dow,
-                          int is_limiting)
+                          bool is_limiting)
 {
     /* Try to calculate each of the occurrences. */
     unsigned long bydays[LONGS_PER_BITS(ICAL_YEARDAYS_MASK_SIZE)];
@@ -2858,9 +2858,10 @@ static void expand_by_day(icalrecur_iterator *impl, int year,
             }
 
             if (valid) {
+                const unsigned long daysmask = daysmask_getbit(bydays, day + doy_offset);
                 int new_val = is_limiting
                                   /* "Filter" the year days bitmask with the bydays bitmask */
-                                  ? (int)daysmask_getbit(bydays, day + doy_offset)
+                                  ? (int)daysmask
                                   /* Add each BYDAY to the year days bitmask */
                                   : 1;
 
@@ -2984,7 +2985,7 @@ static bool next_week(icalrecur_iterator *impl)
     /* Increment to the next week day,
        if there is data at a level less than a week */
     if (next_weekday_by_week(impl) == 0) {
-        return 0; /* Have not reached end of week yet */
+        return false; /* Have not reached end of week yet */
     }
 
     /* If we get here, we have incremented through the entire week, and
@@ -2993,7 +2994,7 @@ static bool next_week(icalrecur_iterator *impl)
     /* Jump to the next week */
     increment_monthday(impl, 7 * impl->rule->interval);
 
-    return 1;
+    return true;
 }
 
 static int prev_weekday_by_week(icalrecur_iterator *impl)
@@ -3183,7 +3184,7 @@ static void expand_year_days(icalrecur_iterator *impl, int year)
 
     if (has_by_data(impl, ICAL_BY_DAY)) {
         /* Apply each BYDAY to the year days bitmask */
-        int limiting =
+        bool limiting =
             has_by_data(impl, ICAL_BY_YEAR_DAY) || has_by_data(impl, ICAL_BY_MONTH_DAY);
         int first_dow, last_dow;
 
@@ -3746,7 +3747,7 @@ struct icaltimetype icalrecur_iterator_next(icalrecur_iterator *impl)
             break;
 
         case ICAL_WEEKLY_RECURRENCE:
-            period_change = next_week(impl);
+            period_change = (int)next_week(impl);
             break;
 
         case ICAL_MONTHLY_RECURRENCE:
@@ -4246,7 +4247,7 @@ short icalrecurrencetype_encode_day(enum icalrecurrencetype_weekday weekday, int
 
 bool icalrecurrencetype_month_is_leap(short month)
 {
-    return (month & LEAP_MONTH);
+    return (month & LEAP_MONTH) != 0;
 }
 
 int icalrecurrencetype_month_month(short month)
@@ -4268,7 +4269,7 @@ bool icalrecur_expand_recurrence(const char *rule,
 
     memset(array, 0, (size_t)count * sizeof(icaltime_t));
 
-    icstart = icaltime_from_timet_with_zone(start, 0, 0);
+    icstart = icaltime_from_timet_with_zone(start, false, 0);
 
     recur = icalrecurrencetype_new_from_string(rule);
     if (!recur) {

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -239,7 +239,7 @@ struct icaltimetype icaltime_from_timet_with_zone(const icaltime_t tm, const boo
     /* Use our timezone functions to convert to the required timezone. */
     icaltimezone_convert_time(&tt, utc_zone, (icaltimezone *)zone);
 
-    tt.is_date = is_date;
+    tt.is_date = (int)is_date;
 
     /* If it is a DATE value, make sure hour, minute & second are 0. */
     if (is_date) {
@@ -253,12 +253,12 @@ struct icaltimetype icaltime_from_timet_with_zone(const icaltime_t tm, const boo
 
 struct icaltimetype icaltime_current_time_with_zone(const icaltimezone *zone)
 {
-    return icaltime_from_timet_with_zone(icaltime(NULL), 0, zone);
+    return icaltime_from_timet_with_zone(icaltime(NULL), false, zone);
 }
 
 struct icaltimetype icaltime_today(void)
 {
-    return icaltime_from_timet_with_zone(icaltime(NULL), 1, NULL);
+    return icaltime_from_timet_with_zone(icaltime(NULL), true, NULL);
 }
 
 icaltime_t icaltime_as_timet(const struct icaltimetype tt)
@@ -492,7 +492,7 @@ int icaltime_days_in_month(const int month, const int year)
     days = _days_in_month[month];
 
     if (month == 2) {
-        days += (icaltime_is_leap_year(year) ? 1 : 0);
+        days += (int)icaltime_is_leap_year(year);
     }
 
     return days;
@@ -537,33 +537,31 @@ int icaltime_start_doy_week(const struct icaltimetype t, int fdow)
 
 int icaltime_day_of_year(const struct icaltimetype t)
 {
-    unsigned int is_leap = (icaltime_is_leap_year(t.year) ? 1 : 0);
-
     if (t.month < 1 || t.month > 12) {
         return 0;
     }
 
-    return days_in_year_passed_month[is_leap][t.month - 1] + t.day;
+    return days_in_year_passed_month[icaltime_is_leap_year(t.year)][t.month - 1] + t.day;
 }
 
 struct icaltimetype icaltime_from_day_of_year(const int _doy, const int _year)
 {
     struct icaltimetype tt = icaltime_null_date();
-    unsigned int is_leap;
+    bool is_leap;
     int month;
     int doy = _doy;
     int year = _year;
 
-    is_leap = (icaltime_is_leap_year(year) ? 1 : 0);
+    is_leap = icaltime_is_leap_year(year);
 
     /* Zero and neg numbers represent days  of the previous year */
     if (doy < 1) {
         year--;
-        is_leap = (icaltime_is_leap_year(year) ? 1 : 0);
+        is_leap = icaltime_is_leap_year(year);
         doy += days_in_year_passed_month[is_leap][12];
     } else if (doy > days_in_year_passed_month[is_leap][12]) {
         /* Move on to the next year */
-        is_leap = (icaltime_is_leap_year(year) ? 1 : 0);
+        is_leap = icaltime_is_leap_year(year);
         doy -= days_in_year_passed_month[is_leap][12];
         year++;
     }

--- a/src/libical/icaltime_p.c
+++ b/src/libical/icaltime_p.c
@@ -20,7 +20,7 @@ icaltime_span icaltime_span_new(struct icaltimetype dtstart, struct icaltimetype
 {
     icaltime_span span;
 
-    span.is_busy = is_busy;
+    span.is_busy = (int)is_busy;
 
     span.start = icaltime_as_timet_with_zone(dtstart,
                                              dtstart.zone ? dtstart.zone : icaltimezone_get_utc_timezone());

--- a/src/libical/icaltimezone.c
+++ b/src/libical/icaltimezone.c
@@ -147,9 +147,9 @@ static ICAL_GLOBAL_VAR icaltimezone utc_timezone = {0, 0, 0, 0, 0, 0, 0, 0, 0};
 static ICAL_GLOBAL_VAR char *zone_files_directory = NULL;
 
 #if defined(USE_BUILTIN_TZDATA)
-static ICAL_GLOBAL_VAR int use_builtin_tzdata = true;
+static ICAL_GLOBAL_VAR bool use_builtin_tzdata = true;
 #else
-static ICAL_GLOBAL_VAR int use_builtin_tzdata = false;
+static ICAL_GLOBAL_VAR bool use_builtin_tzdata = false;
 #endif
 
 static void icaltimezone_reset(icaltimezone *zone);
@@ -1769,9 +1769,9 @@ static bool fetch_lat_long_from_string(const char *str,
     if (parse_coord(lat, (int)(lon - lat),
                     latitude_degrees,
                     latitude_minutes,
-                    latitude_seconds) == 1 ||
+                    latitude_seconds) ||
         parse_coord(lon, (int)strlen(lon),
-                    longitude_degrees, longitude_minutes, longitude_seconds) == 1) {
+                    longitude_degrees, longitude_minutes, longitude_seconds)) {
         icalmemory_free_buffer(lat);
         return true;
     }

--- a/src/libical/icaltimezone_p.c
+++ b/src/libical/icaltimezone_p.c
@@ -631,7 +631,7 @@ icalcomponent *icaltimezone_fetch_timezone(const char *location)
                 } else {
                     struct icaltimetype last_trans =
                         icaltime_from_timet_with_zone(transitions[num_trans - 1],
-                                                      0, NULL);
+                                                      false, NULL);
                     icalrecur_iterator *iter;
 
                     if (types[trans_idx[num_trans - 1]].isdst) {
@@ -697,7 +697,7 @@ icalcomponent *icaltimezone_fetch_timezone(const char *location)
             goto error;
         }
         start = transitions[i] + types[prev_idx].gmtoff;
-        icaltime = icaltime_from_timet_with_zone(start, 0, NULL);
+        icaltime = icaltime_from_timet_with_zone(start, false, NULL);
 
         if (types[idx].isdst) {
             zone = &daylight;

--- a/src/libicalss/icalbdbset.c
+++ b/src/libicalss/icalbdbset.c
@@ -1225,7 +1225,7 @@ icalcomponent *icalbdbset_get_first_component(icalset *set)
             c = icalcomponent_get_next_component(bset->cluster, ICAL_ANY_COMPONENT);
         }
 
-        if (c != 0 && (bset->gauge == 0 || icalgauge_compare(bset->gauge, c) == 1)) {
+        if (c != 0 && (bset->gauge == 0 || icalgauge_compare(bset->gauge, c))) {
             return c;
         }
 
@@ -1280,7 +1280,7 @@ icalsetiter icalbdbset_begin_component(icalset *set, icalcomponent_kind kind,
                 u_zone = icaltimezone_get_utc_timezone();
             }
 
-            start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+            start = icaltime_from_timet_with_zone(time(0), false, NULL);
 
             if (icalcomponent_isa(comp) == ICAL_VEVENT_COMPONENT) {
                 dtstart = icalcomponent_get_first_property(comp, ICAL_DTSTART_PROPERTY);
@@ -1339,7 +1339,7 @@ icalsetiter icalbdbset_begin_component(icalset *set, icalcomponent_kind kind,
             }
         }
         /* end of a recurring event */
-        if (gauge == 0 || icalgauge_compare(itr.gauge, comp) == 1) {
+        if (gauge == 0 || icalgauge_compare(itr.gauge, comp)) {
             /* find a matched and return it */
             itr.iter = citr;
             return itr;
@@ -1388,7 +1388,7 @@ icalcomponent *icalbdbset_form_a_matched_recurrence_component(icalsetiter *itr)
         u_zone = icaltimezone_get_utc_timezone();
     }
 
-    start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    start = icaltime_from_timet_with_zone(time(0), false, NULL);
 
     if (icalcomponent_isa(comp) == ICAL_VEVENT_COMPONENT) {
         icalproperty *dtstart = icalcomponent_get_first_property(comp, ICAL_DTSTART_PROPERTY);
@@ -1447,7 +1447,7 @@ icalcomponent *icalbdbset_form_a_matched_recurrence_component(icalsetiter *itr)
         next = icaltime_convert_to_zone(next, icaltimezone_get_utc_timezone());
     }
 
-    if (itr->gauge == 0 || icalgauge_compare(itr->gauge, comp) == 1) {
+    if (itr->gauge == 0 || icalgauge_compare(itr->gauge, comp)) {
         /* find a matched and return it */
         return comp;
     }
@@ -1497,7 +1497,7 @@ icalcomponent *icalbdbsetiter_to_next(icalset *set, icalsetiter *i)
                 u_zone = icaltimezone_get_utc_timezone();
             }
 
-            start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+            start = icaltime_from_timet_with_zone(time(0), false, NULL);
 
             if (icalcomponent_isa(comp) == ICAL_VEVENT_COMPONENT) {
                 icalproperty *dtstart = icalcomponent_get_first_property(comp, ICAL_DTSTART_PROPERTY);
@@ -1555,7 +1555,7 @@ icalcomponent *icalbdbsetiter_to_next(icalset *set, icalsetiter *i)
             }
         }
         /* end of recurring event with expand query */
-        if ((i->gauge == 0 || icalgauge_compare(i->gauge, comp) == 1)) {
+        if ((i->gauge == 0 || icalgauge_compare(i->gauge, comp))) {
             /* found a matched, return it */
             return comp;
         }
@@ -1574,7 +1574,7 @@ icalcomponent *icalbdbset_get_next_component(icalset *set)
 
     do {
         c = icalcomponent_get_next_component(bset->cluster, ICAL_ANY_COMPONENT);
-        if (c != 0 && (bset->gauge == 0 || icalgauge_compare(bset->gauge, c) == 1)) {
+        if (c != 0 && (bset->gauge == 0 || icalgauge_compare(bset->gauge, c))) {
             return c;
         }
 

--- a/src/libicalss/icaldirset.c
+++ b/src/libicalss/icaldirset.c
@@ -613,7 +613,7 @@ icalcomponent *icaldirset_get_next_component(icalset *set)
             /* If there is a gauge defined and the component does not
                pass the gauge, skip the rest of the loop */
 
-            if (dset->gauge != 0 && icalgauge_compare(dset->gauge, c) == 0) {
+            if (dset->gauge != 0 && !icalgauge_compare(dset->gauge, c)) {
                 continue;
             }
 

--- a/src/libicalss/icalfileset.c
+++ b/src/libicalss/icalfileset.c
@@ -680,7 +680,7 @@ icalcomponent *icalfileset_get_first_component(icalset *set)
             c = icalcomponent_get_next_component(fset->cluster, ICAL_ANY_COMPONENT);
         }
 
-        if (c != 0 && (fset->gauge == 0 || icalgauge_compare(fset->gauge, c) == 1)) {
+        if (c != 0 && (fset->gauge == 0 || icalgauge_compare(fset->gauge, c))) {
             return c;
         }
 
@@ -700,7 +700,7 @@ icalcomponent *icalfileset_get_next_component(icalset *set)
     do {
         c = icalcomponent_get_next_component(fset->cluster, ICAL_ANY_COMPONENT);
 
-        if (c != 0 && (fset->gauge == 0 || icalgauge_compare(fset->gauge, c) == 1)) {
+        if (c != 0 && (fset->gauge == 0 || icalgauge_compare(fset->gauge, c))) {
             return c;
         }
 
@@ -752,7 +752,7 @@ icalsetiter icalfileset_begin_component(icalset *set, icalcomponent_kind kind, i
 
     icalerror_check_arg_re((set != 0), "set", icalsetiter_null);
 
-    start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    start = icaltime_from_timet_with_zone(time(0), false, NULL);
     itr.gauge = gauge;
 
     fset = (icalfileset *)set;
@@ -808,7 +808,7 @@ icalsetiter icalfileset_begin_component(icalset *set, icalcomponent_kind kind, i
             icalcomponent_add_property(comp, icalproperty_new_recurrenceid(next));
         }
 
-        if (icalgauge_compare(itr.gauge, comp) == 1) {
+        if (icalgauge_compare(itr.gauge, comp)) {
             /* matches and returns */
             itr.iter = citr;
             return itr;
@@ -830,7 +830,7 @@ icalcomponent *icalfileset_form_a_matched_recurrence_component(icalsetiter *itr)
     icalproperty *rrule, *prop;
     struct icalrecurrencetype *recur;
 
-    start = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    start = icaltime_from_timet_with_zone(time(0), false, NULL);
     comp = itr->last_component;
 
     if (comp == NULL || itr->gauge == NULL) {
@@ -881,7 +881,7 @@ icalcomponent *icalfileset_form_a_matched_recurrence_component(icalsetiter *itr)
     }
     icalcomponent_add_property(comp, icalproperty_new_recurrenceid(next));
 
-    if (itr->gauge == 0 || icalgauge_compare(itr->gauge, comp) == 1) {
+    if (itr->gauge == 0 || icalgauge_compare(itr->gauge, comp)) {
         /* matches and returns */
         return comp;
     }
@@ -899,8 +899,8 @@ icalcomponent *icalfilesetiter_to_next(icalset *set, icalsetiter *i)
 
     _unused(set);
 
-    start = icaltime_from_timet_with_zone(time(0), 0, NULL);
-    next = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    start = icaltime_from_timet_with_zone(time(0), false, NULL);
+    next = icaltime_from_timet_with_zone(time(0), false, NULL);
 
     do {
         c = icalcompiter_next(&(i->iter));
@@ -956,7 +956,7 @@ icalcomponent *icalfilesetiter_to_next(icalset *set, icalsetiter *i)
         }
         icalcomponent_add_property(c, icalproperty_new_recurrenceid(next));
 
-        if ((i->gauge == 0 || icalgauge_compare(i->gauge, c) == 1)) {
+        if ((i->gauge == 0 || icalgauge_compare(i->gauge, c))) {
             return c;
         }
     } while (true);

--- a/src/libicalss/icalmessage.c
+++ b/src/libicalss/icalmessage.c
@@ -109,7 +109,7 @@ static icalcomponent *icalmessage_new_reply_base(const icalcomponent *c,
             ICAL_VCALENDAR_COMPONENT, icalproperty_new_method(ICAL_METHOD_REPLY),
             icalcomponent_vanew(
                 ICAL_VEVENT_COMPONENT,
-                icalproperty_new_dtstamp(icaltime_from_timet_with_zone(time(0), 0, NULL)),
+                icalproperty_new_dtstamp(icaltime_from_timet_with_zone(time(0), false, NULL)),
                 (void *)0),
             (void *)0);
 
@@ -123,7 +123,7 @@ static icalcomponent *icalmessage_new_reply_base(const icalcomponent *c,
     icalmessage_copy_properties(reply, c, ICAL_SUMMARY_PROPERTY);
     icalmessage_copy_properties(reply, c, ICAL_SEQUENCE_PROPERTY);
 
-    icalcomponent_set_dtstamp(reply, icaltime_from_timet_with_zone(time(0), 0, NULL));
+    icalcomponent_set_dtstamp(reply, icaltime_from_timet_with_zone(time(0), false, NULL));
 
     if (msg != 0) {
         icalcomponent_add_property(inner, icalproperty_new_comment(msg));

--- a/src/libicalss/icalset.c
+++ b/src/libicalss/icalset.c
@@ -426,7 +426,7 @@ icalcomponent *icalsetiter_next(icalsetiter *itr)
 
     do {
         c = icalcompiter_next(&(itr->iter));
-        if (c != 0 && (itr->gauge == 0 || icalgauge_compare(itr->gauge, c) == 1)) {
+        if (c != 0 && (itr->gauge == 0 || icalgauge_compare(itr->gauge, c))) {
             return c;
         }
     } while (c != 0);
@@ -442,7 +442,7 @@ icalcomponent *icalsetiter_prior(icalsetiter *i)
 
     do {
         c = icalcompiter_prior(&(i->iter));
-        if (c != 0 && (i->gauge == 0 || icalgauge_compare(i->gauge, c) == 1)) {
+        if (c != 0 && (i->gauge == 0 || icalgauge_compare(i->gauge, c))) {
             return c;
         }
     } while (c != 0);

--- a/src/libicalss/icalspanlist.c
+++ b/src/libicalss/icalspanlist.c
@@ -241,9 +241,9 @@ struct icalperiodtype icalspanlist_next_free_time(icalspanlist *sl, struct icalt
         period.start = t;
 
         if (s->is_busy == 1) {
-            period.end = icaltime_from_timet_with_zone(s->start, 0, NULL);
+            period.end = icaltime_from_timet_with_zone(s->start, false, NULL);
         } else {
-            period.end = icaltime_from_timet_with_zone(s->end, 0, NULL);
+            period.end = icaltime_from_timet_with_zone(s->end, false, NULL);
         }
 
         return period;
@@ -260,12 +260,12 @@ struct icalperiodtype icalspanlist_next_free_time(icalspanlist *sl, struct icalt
 
         if (s->is_busy == 0 && s->start >= rangett && (rangett < s->end || s->end == s->start)) {
             if (rangett < s->start) {
-                period.start = icaltime_from_timet_with_zone(s->start, 0, NULL);
+                period.start = icaltime_from_timet_with_zone(s->start, false, NULL);
             } else {
-                period.start = icaltime_from_timet_with_zone(rangett, 0, NULL);
+                period.start = icaltime_from_timet_with_zone(rangett, false, NULL);
             }
 
-            period.end = icaltime_from_timet_with_zone(s->end, 0, NULL);
+            period.end = icaltime_from_timet_with_zone(s->end, false, NULL);
 
             return period;
         }
@@ -344,7 +344,7 @@ icalcomponent *icalspanlist_as_vfreebusy(icalspanlist *sl,
                                          const char *organizer, const char *attendee)
 {
     icalcomponent *comp;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), 0, NULL);
+    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), false, NULL);
     icalpvl_elem itr;
     icaltimezone *utc_zone;
 
@@ -373,8 +373,8 @@ icalcomponent *icalspanlist_as_vfreebusy(icalspanlist *sl,
 
         if (s && s->is_busy == 1) {
             struct icalperiodtype period;
-            period.start = icaltime_from_timet_with_zone(s->start, 0, utc_zone);
-            period.end = icaltime_from_timet_with_zone(s->end, 0, utc_zone);
+            period.start = icaltime_from_timet_with_zone(s->start, false, utc_zone);
+            period.end = icaltime_from_timet_with_zone(s->end, false, utc_zone);
             period.duration = icaldurationtype_null_duration();
 
             icalproperty *p = icalproperty_new_freebusy(period);

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -528,7 +528,7 @@ vcardcomponent *vcardcomponent_get_next_component(vcardcomponent *c,
 int vcardcomponent_check_restrictions(vcardcomponent *comp)
 {
     icalerror_check_arg_rz(comp != 0, "comp");
-    return vcardrestriction_check(comp);
+    return (int)vcardrestriction_check(comp);
 }
 
 int vcardcomponent_count_errors(vcardcomponent *comp)

--- a/src/libicalvcard/vcardparameter.c
+++ b/src/libicalvcard/vcardparameter.c
@@ -271,7 +271,7 @@ char *vcardparameter_as_vcard_string_r(vcardparameter *param)
             sep = ",";
         }
     } else if (vcardparameter_is_structured(param)) {
-        char *str = vcardstructured_as_vcard_string_r(param->structured, 1);
+        char *str = vcardstructured_as_vcard_string_r(param->structured, true);
 
         icalmemory_append_encoded_string(&buf, &buf_ptr, &buf_size, str);
         icalmemory_free_buffer(str);
@@ -426,7 +426,7 @@ bool vcardparameter_is_multivalued(const vcardparameter *param)
 {
     icalerror_check_arg_rz((param != 0), "param");
 
-    return param->is_multivalued;
+    return param->is_multivalued != 0;
 }
 
 bool vcardparameter_is_structured(const vcardparameter *param)

--- a/src/libicalvcard/vcardproperty.c
+++ b/src/libicalvcard/vcardproperty.c
@@ -65,8 +65,8 @@ void vcardproperty_add_parameters(vcardproperty *prop, va_list args)
     void *vp;
 
     while ((vp = va_arg(args, void *)) != 0) {
-        if (vcardvalue_isa_value(vp) != 0) {
-        } else if (vcardparameter_isa_parameter(vp) != 0) {
+        if (vcardvalue_isa_value(vp)) {
+        } else if (vcardparameter_isa_parameter(vp)) {
             vcardproperty_add_parameter((vcardproperty *)prop,
                                         (vcardparameter *)vp);
         } else {

--- a/src/libicalvcard/vcardtime.c
+++ b/src/libicalvcard/vcardtime.c
@@ -129,7 +129,7 @@ bool vcardtime_is_valid_time(const struct vcardtimetype t)
         break;
 
     case 2:
-        days = 28 + vcardtime_is_leap_year(t.year);
+        days = 28 + (int)vcardtime_is_leap_year(t.year);
         break;
 
     default:

--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -723,7 +723,7 @@ static char *vcardvalue_text_as_vcard_string_r(const vcardvalue *value)
     size_t buf_sz;
 
     return vcardmemory_strdup_and_quote(&str, &str_p, &buf_sz,
-                                        value->data.v_string, 0);
+                                        value->data.v_string, false);
 }
 
 static char *vcardvalue_string_as_vcard_string_r(const vcardvalue *value)
@@ -772,7 +772,7 @@ char *vcardstrarray_as_vcard_string_r(const vcardstrarray *array, const char sep
     size_t buf_size;
 
     _vcardstrarray_as_vcard_string_r(&buf, &buf_ptr, &buf_size,
-                                     (vcardstrarray *)array, sep, 0);
+                                     (vcardstrarray *)array, sep, false);
 
     return buf;
 }
@@ -819,7 +819,7 @@ static char *vcardvalue_structured_as_vcard_string_r(const vcardvalue *value)
 {
     icalerror_check_arg_rz((value != 0), "value");
 
-    return vcardstructured_as_vcard_string_r(value->data.v_structured, 0);
+    return vcardstructured_as_vcard_string_r(value->data.v_structured, false);
 }
 
 static char *vcardvalue_float_as_vcard_string_r(const vcardvalue *value)


### PR DESCRIPTION
This patch does not fix reported readability-implicit-bool-conversion
issues as I think clang-tidy is being overly noisy in some cases.

Will revist the false positives in a follow-on patch
