### PR TITLE
Avoid `icalstrarray_clone()` allocating its capacity incrementally

### DIFF
--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -148,11 +148,29 @@ icalstrarray *icalstrarray_clone(icalstrarray *array)
         return NULL;
     }
 
-    icalstrarray *clone = icalstrarray_new(array->increment_size);
+    icalstrarray *clone = icalarray_copy(array);
     size_t i;
+    int err = 0;
+
+    if (!clone) {
+        return NULL;
+    }
 
     for (i = 0; i < array->num_elements; i++) {
-        icalstrarray_append(clone, icalstrarray_element_at(array, i));
+        char **p = (char **)icalarray_element_at(clone, i);
+
+        if (p && *p) {
+            // In case of a previous error we don't clone any further but instead set the
+            // remaining pointers to NULL. NULL is required so we don't free the original
+            // strings on cleanup.
+            *p = err ? NULL : icalmemory_strdup(*p);
+            err |= !*p;
+        }
+    }
+
+    if (err) {
+        icalstrarray_free(clone);
+        return NULL;
     }
 
     return clone;


### PR DESCRIPTION
Some performance improvement of icalstrarray_clone(): Allocate the whole array capacity right at the beginning rather than starting with a single chunk and resizing it incrementally as elements are added as done previously. The old behavior resulted in O(N^2) complexity, which made a difference in case of large arrays, as seen in some fuzz tests.