### PR TITLE
libicalvcard: make the typed value getters and setters type-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.6] - Unreleased
 
+- libicalvcard: the typed vcardvalue getters now check that the value type of
+  the property uses the same union member as the expected value type of the
+  getter. If the type mismatches, then they return the zero value for the
+  expected value type. The typed setters error with ICAL_BADARG_ERROR
+  instead of overwriting a value held in another union member.
 - Fix UBSAN issue "bsearch comparator through an incompatible function pointer"
 - Improve build paths in installed .cmake files (esp. for cross-compiling)
 

--- a/scripts/mkderivedvalues.pl
+++ b/scripts/mkderivedvalues.pl
@@ -49,6 +49,21 @@ if ($opt_i) {
 
 }
 
+# Return which ${lcprefix}value_impl union member a value type reads from, as a UNION_* tag.
+sub value_union_type
+{
+  my $value = shift;
+
+  my $uc = uc(join("", map {lc($_);} split(/-/, $value)));
+
+  return 'X'    if $opt_v and $uc eq 'X';
+  return 'ENUM' if @{$h{$value}->{'enums'}};
+
+  my $union_data = exists $union_map{$uc} ? $union_map{$uc} : lc($uc);
+
+  return exists $union_type_map{$union_data} ? $union_type_map{$union_data} : 'NONE';
+}
+
 sub insert_code
 {
   # Map type names to the value in the icalvalue_impl data union */
@@ -75,6 +90,19 @@ sub insert_code
     QUERY          => 'string',
     XMLREFERENCE   => 'string',
     X              => 'string'
+  );
+
+  # Map an icalvalue_impl union member name to its ${lcprefix}value_union tag
+
+  %union_type_map = (
+    'enum'       => 'ENUM',
+    'float'      => 'FLOAT',
+    'geo'        => 'GEO',
+    'int'        => 'INT',
+    'string'     => 'STRING',
+    'structured' => 'STRUCTURED',
+    'textlist'   => 'TEXTLIST',
+    'time'       => 'TIME'
   );
 
   if ($opt_h) {
@@ -172,6 +200,32 @@ sub insert_code
 
     print "    {${ucprefix}_NO_VALUE,\"\"}\n};";
 
+    # vCard only: emit the value_union enum and the kind -> union lookup the accessors call
+    if ($opt_v) {
+      print "\n\n";
+      print "typedef enum ${lcprefix}value_union {\n";
+      print "    ${ucprefix}_UNION_NONE = 0,\n";
+      foreach $ut (sort values %union_type_map) {
+        print "    ${ucprefix}_UNION_${ut},\n";
+      }
+      print "    ${ucprefix}_UNION_X\n} ${lcprefix}value_union;\n\n";
+
+      print
+"static ${lcprefix}value_union ${lcprefix}value_kind_to_union(${lcprefix}value_kind kind)\n{\n    switch (kind) {\n";
+
+      # No 'default' label: the switch must stay exhaustive over
+      # ${lcprefix}value_kind so that -Wswitch catches a newly added value type.
+      foreach $value (sort keys %h) {
+
+        my $ucv        = join("", map {uc(lc($_));} split(/-/, $value));
+        my $union_type = value_union_type($value);
+
+        print "    case ${ucprefix}_${ucv}_VALUE:\n";
+        print "        return ${ucprefix}_UNION_${union_type};\n";
+      }
+
+      print "    }\n\n    return ${ucprefix}_UNION_NONE;\n}\n";
+    }
   }
 
   foreach $value (sort keys %h) {
@@ -211,6 +265,54 @@ sub insert_code
       $union_data = $lc;
     }
 
+    my $union_type = value_union_type($value);
+
+    # Fail the build rather than emit accessors whose type check would always pass
+    if ($opt_v and $autogen and $union_type eq 'NONE') {
+      die "No ${lcprefix}value_impl union member is registered for value type " .
+        "$value (union data '$union_data'): the generated accessors would " .
+        "carry a vacuous type check.  Add '$union_data' to %union_type_map " .
+        "(and the member to struct ${lcprefix}value_impl), or mark $value as " .
+        "(m) in $ARGV[0] and write its accessors by hand.\n";
+    }
+
+    # Zero value a getter returns for a NULL or wrongly-typed argument
+    my $null_ret     = "0";
+    my $has_null_ret = 1;
+
+    if ($union_data eq 'enum') {
+      $null_ret = "${ucprefix}_${uc}_NONE";
+    } elsif ($union_data eq 'int') {
+      $null_ret = "0";
+    } elsif ($union_data eq 'float') {
+      $null_ret = "0.0";
+    } elsif ($union_data eq 'time') {
+      $null_ret = $opt_v ? "vcardtime_null_datetime()" : "icaltime_null_time()";
+    } elsif ($union_data eq 'duration') {
+      $null_ret = "icaldurationtype_null_duration()";
+    } elsif ($union_data eq 'period') {
+      $null_ret = "icalperiodtype_null_period()";
+    } elsif ($union_data eq 'requeststatus') {
+      $null_ret = "icalreqstattype_from_string(\"0.0\")";
+    } else {
+      $has_null_ret = 0;
+    }
+
+    # Likewise for a non-pointer getter with no zero value to return
+    if ($opt_v and $autogen and !$has_null_ret and $type !~ /\*/) {
+      die "No zero value is registered for value type $value (union data " .
+        "'$union_data'): the generated getter would return the literal 0 for " .
+        "its non-pointer return type '$type'.  Add a zero value for " .
+        "'$union_data' above, or mark $value as (m) in $ARGV[0] and write " .
+        "its accessors by hand.\n";
+    }
+
+    # Setter guard: vCard compares union tags, iCal keeps the exact-kind assertion
+    my $set_kind_check =
+      $opt_v
+      ? "    if (${lcprefix}value_kind_to_union(value->kind) != ${ucprefix}_UNION_${union_type}) {\n        icalerror_set_errno(ICAL_BADARG_ERROR);\n        return;\n    }"
+      : "    icalerror_check_value_type(value, ${ucprefix}_${uc}_VALUE);";
+
     if ($opt_c && $autogen) {
 
       print "\
@@ -228,7 +330,7 @@ void ${lcprefix}value_set_${lc}(${lcprefix}value *value, $type v)\
     struct ${lcprefix}value_impl *impl;\
     icalerror_check_arg_rv((value != 0), \"value\");\
 $pointer_check_rv\
-    icalerror_check_value_type(value, ${ucprefix}_${uc}_VALUE);\
+$set_kind_check\
     impl = (struct ${lcprefix}value_impl *)value;\n";
 
       if ($union_data eq 'string') {
@@ -248,33 +350,31 @@ $pointer_check_rv\
 
       print "$type\ ${lcprefix}value_get_${lc}(const ${lcprefix}value *value)\n{\n";
       $retString = "";
-      if ($union_data eq 'string' or $union_data eq 'textlist') {
-        print "    icalerror_check_arg_rz((value != 0), \"value\");\n";
-      } else {
-        print "    icalerror_check_arg((value != 0), \"value\");\n";
-        if ($union_data eq 'enum') {
-          print "    if (!value) {\n        return ${ucprefix}_${uc}_NONE;\n    }\n";
-          $retString = "(${type})";
-        } elsif ($union_data eq 'int') {
-          print "    if (!value) {\n        return 0;\n    }\n";
-        } elsif ($union_data eq 'float') {
-          print "    if (!value) {\n        return 0.0;\n     }\n";
-        } elsif ($union_data eq 'time') {
-          if ($opt_v) {
-            print "    if (!value) {\n        return vcardtime_null_datetime();\n    }\n";
-          } else {
-            print "    if (!value) {\n        return icaltime_null_time();\n    }\n";
-          }
-        } elsif ($union_data eq 'duration') {
-          print "    if (!value) {\n        return icaldurationtype_null_duration();\n    }\n";
-        } elsif ($union_data eq 'period') {
-          print "    if (!value) {\n        return icalperiodtype_null_period();\n    }\n";
-        } elsif ($union_data eq 'requeststatus') {
-          print "    if (!value) {\n        return icalreqstattype_from_string(\"0.0\");\n    }\n";
-        }
+      if ($union_data eq 'enum') {
+        $retString = "(${type})";
       }
-      print "    icalerror_check_value_type(value, ${ucprefix}_${uc}_VALUE);\
-    return ${retString}(((struct ${lcprefix}value_impl *)value)->data.v_${union_data});\n}\n";
+
+      # vCard getters return the zero value on a kind mismatch; iCal aborts via icalerror
+      if ($opt_v) {
+        print
+"    if (!value) {\
+        icalerror_set_errno(ICAL_BADARG_ERROR);\
+        return $null_ret;\
+    }\
+    if (${lcprefix}value_kind_to_union(value->kind) != ${ucprefix}_UNION_${union_type}) {\
+        return $null_ret;\
+    }\n";
+      } else {
+        if ($union_data eq 'string' or $union_data eq 'textlist') {
+          print "    icalerror_check_arg_rz((value != 0), \"value\");\n";
+        } else {
+          print "    icalerror_check_arg((value != 0), \"value\");\n";
+          print "    if (!value) {\n        return $null_ret;\n    }\n" if $has_null_ret;
+        }
+        print "    icalerror_check_value_type(value, ${ucprefix}_${uc}_VALUE);\n";
+      }
+      print
+"    return ${retString}(((struct ${lcprefix}value_impl *)value)->data.v_${union_data});\n}\n";
 
     } elsif ($opt_h && $autogen) {
 

--- a/scripts/mkderivedvalues.pl
+++ b/scripts/mkderivedvalues.pl
@@ -269,11 +269,11 @@ sub insert_code
 
     # Fail the build rather than emit accessors whose type check would always pass
     if ($opt_v and $autogen and $union_type eq 'NONE') {
-      die "No ${lcprefix}value_impl union member is registered for value type " .
-        "$value (union data '$union_data'): the generated accessors would " .
-        "carry a vacuous type check.  Add '$union_data' to %union_type_map " .
-        "(and the member to struct ${lcprefix}value_impl), or mark $value as " .
-        "(m) in $ARGV[0] and write its accessors by hand.\n";
+      die "No ${lcprefix}value_impl union member is registered for value type "
+        . "$value (union data '$union_data'): the generated accessors would "
+        . "carry a vacuous type check.  Add '$union_data' to %union_type_map "
+        . "(and the member to struct ${lcprefix}value_impl), or mark $value as "
+        . "(m) in $ARGV[0] and write its accessors by hand.\n";
     }
 
     # Zero value a getter returns for a NULL or wrongly-typed argument
@@ -300,11 +300,11 @@ sub insert_code
 
     # Likewise for a non-pointer getter with no zero value to return
     if ($opt_v and $autogen and !$has_null_ret and $type !~ /\*/) {
-      die "No zero value is registered for value type $value (union data " .
-        "'$union_data'): the generated getter would return the literal 0 for " .
-        "its non-pointer return type '$type'.  Add a zero value for " .
-        "'$union_data' above, or mark $value as (m) in $ARGV[0] and write " .
-        "its accessors by hand.\n";
+      die "No zero value is registered for value type $value (union data "
+        . "'$union_data'): the generated getter would return the literal 0 for "
+        . "its non-pointer return type '$type'.  Add a zero value for "
+        . "'$union_data' above, or mark $value as (m) in $ARGV[0] and write "
+        . "its accessors by hand.\n";
     }
 
     # Setter guard: vCard compares union tags, iCal keeps the exact-kind assertion
@@ -356,8 +356,7 @@ $set_kind_check\
 
       # vCard getters return the zero value on a kind mismatch; iCal aborts via icalerror
       if ($opt_v) {
-        print
-"    if (!value) {\
+        print "    if (!value) {\
         icalerror_set_errno(ICAL_BADARG_ERROR);\
         return $null_ret;\
     }\

--- a/src/libicalvcard/vcardcomponent.c
+++ b/src/libicalvcard/vcardcomponent.c
@@ -945,6 +945,9 @@ static void comp_to_v4(vcardcomponent *impl)
         case VCARD_UID_PROPERTY: {
             /* Does it look like a URI (the default)? */
             const char *data = vcardvalue_get_text(value);
+            if (!data) {
+                break;
+            }
             if (!strncasecmp(data, "urn:uuid:", 9) ||
                 !strncasecmp(data, "mailto:", 7) ||
                 !strncasecmp(data, "http://", 7) ||
@@ -1233,6 +1236,9 @@ static void comp_to_v3(vcardcomponent *impl)
 
         case VCARD_UID_PROPERTY:
             /* Treat all values as TEXT (the default) */
+            if (!vcardvalue_get_text(value)) {
+                break;
+            }
             value->kind = VCARD_TEXT_VALUE;
 
             if (val_param) {

--- a/src/libicalvcard/vcardderivedvalue.c.in
+++ b/src/libicalvcard/vcardderivedvalue.c.in
@@ -54,7 +54,10 @@ void vcardvalue_set_structured(vcardvalue *value, vcardstructuredtype *v)
     icalerror_check_arg_rv((value != 0), "value");
     icalerror_check_arg_rv((v != 0), "v");
 
-    icalerror_check_value_type(value, VCARD_STRUCTURED_VALUE);
+    if (vcardvalue_kind_to_union(value->kind) != VCARD_UNION_STRUCTURED) {
+        icalerror_set_errno(ICAL_BADARG_ERROR);
+        return;
+    }
     impl = (struct vcardvalue_impl *)value;
 
     vcardstructured_ref(v);
@@ -65,8 +68,13 @@ void vcardvalue_set_structured(vcardvalue *value, vcardstructuredtype *v)
 
 vcardstructuredtype *vcardvalue_get_structured(const vcardvalue *value)
 {
-    icalerror_check_arg((value != 0), "value");
-    icalerror_check_value_type(value, VCARD_STRUCTURED_VALUE);
+    if (!value) {
+        icalerror_set_errno(ICAL_BADARG_ERROR);
+        return 0;
+    }
+    if (vcardvalue_kind_to_union(value->kind) != VCARD_UNION_STRUCTURED) {
+        return 0;
+    }
     return ((struct vcardvalue_impl *)value)->data.v_structured;
 }
 
@@ -84,6 +92,16 @@ void vcardvalue_set_geo(vcardvalue *value, struct vcardgeotype v)
     struct vcardvalue_impl *impl;
 
     icalerror_check_arg_rv((value != 0), "value");
+
+    switch (value->kind) {
+    case VCARD_GEO_VALUE:
+    case VCARD_URI_VALUE:
+        break;
+
+    default:
+        icalerror_set_errno(ICAL_BADARG_ERROR);
+        return;
+    }
 
     impl = (struct vcardvalue_impl *)value;
 
@@ -119,8 +137,6 @@ struct vcardgeotype vcardvalue_get_geo(const vcardvalue *impl)
     } else if (impl->kind == VCARD_GEO_VALUE) {
         geo = impl->data.v_geo;
         geo.uri = NULL;
-    } else {
-        icalerror_set_errno(ICAL_BADARG_ERROR);
     }
 
     return geo;
@@ -138,6 +154,25 @@ vcardvalue *vcardvalue_new_tz(struct vcardtztype v)
 void vcardvalue_set_tz(vcardvalue *value, struct vcardtztype v)
 {
     icalerror_check_arg_rv((value != 0), "value");
+
+    switch (value->kind) {
+    case VCARD_TZ_VALUE:
+    case VCARD_UTCOFFSET_VALUE:
+        value->data.v_string = NULL;
+        break;
+
+    case VCARD_TEXT_VALUE:
+    case VCARD_URI_VALUE:
+        if (!v.tzid && !v.uri) {
+            icalmemory_free_buffer((void *)value->data.v_string);
+            value->data.v_string = NULL;
+        }
+        break;
+
+    default:
+        icalerror_set_errno(ICAL_BADARG_ERROR);
+        return;
+    }
 
     if (v.tzid) {
         value->kind = VCARD_TEXT_VALUE;
@@ -163,8 +198,6 @@ struct vcardtztype vcardvalue_get_tz(const vcardvalue *impl)
         tz.uri = impl->data.v_string;
     } else if (impl->kind == VCARD_UTCOFFSET_VALUE) {
         tz.utcoffset = impl->data.v_int;
-    } else {
-        icalerror_set_errno(ICAL_BADARG_ERROR);
     }
 
     return tz;
@@ -251,8 +284,10 @@ void vcardvalue_set_x(vcardvalue *impl, const char *v)
 
 const char *vcardvalue_get_x(const vcardvalue *value)
 {
-    icalerror_check_arg_rz((value != 0), "value");
-    icalerror_check_value_type(value, VCARD_X_VALUE);
+    if (!value) {
+        icalerror_set_errno(ICAL_BADARG_ERROR);
+        return 0;
+    }
     return value->x_value;
 }
 

--- a/src/test/libicalvcard/vcard_test_encode.c
+++ b/src/test/libicalvcard/vcard_test_encode.c
@@ -10,6 +10,10 @@
 #include <config.h>
 #endif
 
+#if defined(NDEBUG)
+#undef NDEBUG
+#endif
+
 #include "vcard.h"
 
 #include <assert.h>
@@ -184,11 +188,7 @@ static void test_prop_x(void)
 /* cppcheck-suppress constParameterCallback */
 static vcardvalue_kind my_xprop_value_kind_func(const char *name, void *data)
 {
-#if defined(NDEBUG)
-    _unused(data);
-#else
     assert(data == (void *)0x1234);
-#endif
     return !strcasecmp(name, "X-PROP-A") ? VCARD_TEXT_VALUE : VCARD_X_VALUE;
 }
 
@@ -546,6 +546,366 @@ static void test_line_folding(void)
 #undef TEST_LINE_FOLDING_PREAMBLE
 }
 
+static void assert_null_str(const char *str)
+{
+    if (str) {
+        fprintf(stderr, "expected NULL, got string of length %zu: %s\n",
+                strlen(str), str);
+        assert(0);
+    }
+}
+
+static void test_value_kind_mismatch_structured(void)
+{
+    /* The N and ADR values mimic a 32-byte vcardstructuredtype_impl, one byte
+       short, so a mismatched getter reads its field pointer out of bounds. */
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "N;VALUE=URI:AAAAAAAABBBBBBBBCCCCCCCCBBBBBB\r\n"
+        "ADR;VALUE=TEXT:AAAAAAAABBBBBBBBCCCCCCCCBBBBBB\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    vcardproperty *prop;
+    vcardstructuredtype *st;
+
+    prop = vcardcomponent_get_first_property(card, VCARD_N_PROPERTY);
+    assert(VCARD_URI_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    st = vcardproperty_get_n(prop);
+    assert(NULL == vcardstructured_field_at(st, 0));
+    assert(0 == vcardstructured_num_fields(st));
+    assert(NULL == st);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_ADR_PROPERTY);
+    assert(VCARD_TEXT_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    st = vcardproperty_get_adr(prop);
+    vcardstructured_set_num_fields(st, 5);
+    assert(0 == vcardstructured_num_fields(st));
+    assert(NULL == st);
+
+    vcardcomponent_transform(card, VCARD_VERSION_30);
+    assert(NULL != vcardcomponent_as_vcard_string(card));
+
+    vcardcomponent_free(card);
+}
+
+static void test_value_kind_mismatch_textlist(void)
+{
+    /* The CATEGORIES and NICKNAME values mimic a 40-byte struct _icalarray,
+       stopping before its chunks pointer. */
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "CATEGORIES;VALUE=URI:AAAAAAAABBBBBBBBCCCCCCCCDDDDDD\r\n"
+        "NICKNAME;VALUE=URI:AAAAAAAABBBBBBBBCCCCCCCCDDDDDD\r\n"
+        "ORG;VALUE=DATE:19700101\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    vcardproperty *prop;
+
+    vcardcomponent_normalize(card);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_CATEGORIES_PROPERTY);
+    assert(NULL == vcardproperty_get_categories(prop));
+    prop = vcardcomponent_get_first_property(card, VCARD_NICKNAME_PROPERTY);
+    assert(NULL == vcardproperty_get_nickname(prop));
+    prop = vcardcomponent_get_first_property(card, VCARD_ORG_PROPERTY);
+    assert(NULL == vcardproperty_get_org(prop));
+
+    vcardcomponent_free(card);
+}
+
+static void test_value_kind_mismatch_time(void)
+{
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "BDAY;VALUE=URI:urn:x:1\r\n"
+        "REV;VALUE=URI:urn:x:2\r\n"
+        "CREATED;VALUE=TEXT:not-a-timestamp\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    vcardproperty *prop;
+
+    vcardcomponent_transform(card, VCARD_VERSION_30);
+    assert(NULL != vcardcomponent_as_vcard_string(card));
+    vcardcomponent_free(card);
+
+    card = vcardparser_parse_string(input);
+    prop = vcardcomponent_get_first_property(card, VCARD_BDAY_PROPERTY);
+    assert(vcardtime_is_null_datetime(vcardproperty_get_bday(prop)));
+    prop = vcardcomponent_get_first_property(card, VCARD_REV_PROPERTY);
+    assert(vcardtime_is_null_datetime(vcardproperty_get_rev(prop)));
+    prop = vcardcomponent_get_first_property(card, VCARD_CREATED_PROPERTY);
+    assert(vcardtime_is_null_datetime(vcardproperty_get_created(prop)));
+
+    assert(1 == vcardrestriction_check(card));
+
+    vcardcomponent_free(card);
+}
+
+static void test_value_kind_mismatch_string(void)
+{
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN;VALUE=DATE:19700101\r\n"
+        "UID;VALUE=DATE:19700101\r\n"
+        "LANG;VALUE=DATE:19700101\r\n"
+        "NOTE;VALUE=BOOLEAN:TRUE\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    vcardproperty *prop;
+
+    prop = vcardcomponent_get_first_property(card, VCARD_FN_PROPERTY);
+    assert_null_str(vcardproperty_get_fn(prop));
+    prop = vcardcomponent_get_first_property(card, VCARD_UID_PROPERTY);
+    assert_null_str(vcardproperty_get_uid(prop));
+    prop = vcardcomponent_get_first_property(card, VCARD_LANG_PROPERTY);
+    assert_null_str(vcardproperty_get_lang(prop));
+    prop = vcardcomponent_get_first_property(card, VCARD_NOTE_PROPERTY);
+    assert_null_str(vcardproperty_get_note(prop));
+
+    assert_null_str(vcardcomponent_get_uid(card));
+    assert_null_str(vcardcomponent_get_fn(card));
+
+    vcardcomponent_free(card);
+
+    card = vcardparser_parse_string(
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "FN:x\r\n"
+        "UID:probe-uid\r\n"
+        "UID;VALUE=DATE:19700101\r\n"
+        "END:VCARD\r\n");
+
+    vcardcomponent_transform(card, VCARD_VERSION_30);
+    assert(NULL != vcardcomponent_as_vcard_string(card));
+    vcardcomponent_transform(card, VCARD_VERSION_40);
+    assert(NULL != vcardcomponent_as_vcard_string(card));
+
+    vcardcomponent_free(card);
+}
+
+static void test_value_kind_mismatch_scalar(void)
+{
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "KIND;VALUE=URI:urn:x:1\r\n"
+        "GRAMGENDER;VALUE=URI:urn:x:2\r\n"
+        "GEO;VALUE=BOOLEAN:TRUE\r\n"
+        "TZ;VALUE=DATE:19700101\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    vcardproperty *prop;
+
+    prop = vcardcomponent_get_first_property(card, VCARD_KIND_PROPERTY);
+    assert(VCARD_KIND_NONE == vcardproperty_get_kind(prop));
+    prop = vcardcomponent_get_first_property(card, VCARD_GRAMGENDER_PROPERTY);
+    assert(VCARD_GRAMGENDER_NONE == vcardproperty_get_gramgender(prop));
+
+    prop = vcardcomponent_get_first_property(card, VCARD_GEO_PROPERTY);
+    vcardgeotype geo = vcardproperty_get_geo(prop);
+    assert(NULL == geo.uri && '\0' == geo.coords.lat[0]);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_TZ_PROPERTY);
+    vcardtztype tz = vcardproperty_get_tz(prop);
+    assert(NULL == tz.tzid && NULL == tz.uri && 0 == tz.utcoffset);
+
+    vcardcomponent_free(card);
+
+    card = vcardparser_parse_string(
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "FN:x\r\n"
+        "GEO;VALUE=BOOLEAN:TRUE\r\n"
+        "TZ;VALUE=INTEGER:12345\r\n"
+        "END:VCARD\r\n");
+
+    vcardcomponent_transform(card, VCARD_VERSION_40);
+    assert(NULL != vcardcomponent_as_vcard_string(card));
+
+    vcardcomponent_free(card);
+}
+
+static void test_value_kind_mismatch_x(void)
+{
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "X-PROP;VALUE=DATE:19700101\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card = vcardparser_parse_string(input);
+    vcardproperty *prop =
+        vcardcomponent_get_first_property(card, VCARD_X_PROPERTY);
+    vcardvalue *val = vcardproperty_get_value(prop);
+
+    assert(VCARD_DATE_VALUE == vcardvalue_isa(val));
+    assert_null_str(vcardvalue_get_x(val));
+    assert_null_str(vcardvalue_get_text(val));
+    assert(NULL == vcardvalue_get_textlist(val));
+
+    vcardcomponent_free(card);
+}
+
+static void test_value_kind_enum_x(void)
+{
+    static const char *input =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "KIND:x-my-kind\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card;
+    vcardproperty *prop;
+    vcardvalue *val;
+
+    /* An unrecognized KIND value keeps the token verbatim in x_value */
+    card = vcardparser_parse_string(input);
+    prop = vcardcomponent_get_first_property(card, VCARD_KIND_PROPERTY);
+    val = vcardproperty_get_value(prop);
+
+    assert(VCARD_KIND_VALUE == vcardvalue_isa(val));
+    assert(VCARD_KIND_X == vcardvalue_get_kind(val));
+    assert(VCARD_KIND_X == vcardproperty_get_kind(prop));
+    assert(NULL != vcardvalue_get_x(val));
+    assert_str_equals("x-my-kind", vcardvalue_get_x(val));
+    assert_str_equals("KIND:x-my-kind\r\n", vcardproperty_as_vcard_string(prop));
+    assert_str_equals(input, vcardcomponent_as_vcard_string(card));
+
+    vcardcomponent_free(card);
+
+    /* A recognized KIND value does not use x_value */
+    val = vcardvalue_new_from_string(VCARD_KIND_VALUE, "individual");
+    assert(VCARD_KIND_VALUE == vcardvalue_isa(val));
+    assert(VCARD_KIND_INDIVIDUAL == vcardvalue_get_kind(val));
+    assert_null_str(vcardvalue_get_x(val));
+    assert_str_equals("INDIVIDUAL", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+
+    /* vcardvalue_set_x() and _get_x() also apply to enum-kind values */
+    val = vcardvalue_new_from_string(VCARD_KIND_VALUE, "x-my-kind");
+    assert(NULL != vcardvalue_get_x(val));
+    assert_str_equals("x-my-kind", vcardvalue_get_x(val));
+    vcardvalue_set_x(val, "x-other-kind");
+    assert_str_equals("x-other-kind", vcardvalue_get_x(val));
+    assert_str_equals("x-other-kind", vcardvalue_as_vcard_string(val));
+    vcardvalue_free(val);
+}
+
+static void test_value_kind_no_value(void)
+{
+    vcardproperty *prop = vcardproperty_new(VCARD_N_PROPERTY);
+
+    assert(NULL == vcardproperty_get_value(prop));
+    assert(NULL == vcardproperty_get_n(prop));
+    assert(vcardtime_is_null_datetime(vcardproperty_get_bday(prop)));
+    assert_null_str(vcardproperty_get_fn(prop));
+
+    vcardproperty_free(prop);
+}
+
+static void test_value_kind_compatible(void)
+{
+    static const char *v3 =
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "FN:x\r\n"
+        "UID:foo-bar\r\n"
+        "PHOTO;ENCODING=b:QUFB\r\n"
+        "TZ:-0500\r\n"
+        "GEO:1.5;2.5\r\n"
+        "BDAY:19700101\r\n"
+        "REV:19700101T000000Z\r\n"
+        "END:VCARD\r\n";
+    static const char *v4 =
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FN:x\r\n"
+        "UID:urn:uuid:1\r\n"
+        "TEL;VALUE=URI:tel:+1-418-656-9254\r\n"
+        "ANNIVERSARY;VALUE=TIMESTAMP:20090808T143000-0500\r\n"
+        "BDAY:19700101\r\n"
+        "TZ:Europe/Berlin\r\n"
+        "GEO:geo:1.5,2.5\r\n"
+        "END:VCARD\r\n";
+
+    vcardcomponent *card;
+    vcardproperty *prop;
+    vcardtimetype t;
+
+    card = vcardparser_parse_string(v3);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_UID_PROPERTY);
+    assert(VCARD_TEXT_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("foo-bar", vcardproperty_get_uid(prop));
+
+    prop = vcardcomponent_get_first_property(card, VCARD_PHOTO_PROPERTY);
+    assert(VCARD_TEXT_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("QUFB", vcardproperty_get_photo(prop));
+
+    prop = vcardcomponent_get_first_property(card, VCARD_TZ_PROPERTY);
+    assert(VCARD_UTCOFFSET_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert(-18000 == vcardproperty_get_tz(prop).utcoffset);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_GEO_PROPERTY);
+    assert(VCARD_GEO_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    vcardgeotype geo = vcardproperty_get_geo(prop);
+    assert_str_equals("1.5", geo.coords.lat);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_BDAY_PROPERTY);
+    assert(VCARD_DATE_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    t = vcardproperty_get_bday(prop);
+    assert(1970 == t.year && 1 == t.month && 1 == t.day);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_REV_PROPERTY);
+    assert(VCARD_TIMESTAMP_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert(1970 == vcardproperty_get_rev(prop).year);
+
+    assert_str_equals("foo-bar", vcardcomponent_get_uid(card));
+    assert_str_equals("x", vcardcomponent_get_fn(card));
+
+    vcardcomponent_free(card);
+
+    card = vcardparser_parse_string(v4);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_UID_PROPERTY);
+    assert(VCARD_URI_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("urn:uuid:1", vcardproperty_get_uid(prop));
+
+    prop = vcardcomponent_get_first_property(card, VCARD_TEL_PROPERTY);
+    assert(VCARD_URI_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("tel:+1-418-656-9254", vcardproperty_get_tel(prop));
+
+    prop = vcardcomponent_get_first_property(card, VCARD_ANNIVERSARY_PROPERTY);
+    assert(VCARD_TIMESTAMP_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    t = vcardproperty_get_anniversary(prop);
+    assert(2009 == t.year && 8 == t.month && 8 == t.day);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_TZ_PROPERTY);
+    assert(VCARD_TEXT_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("Europe/Berlin", vcardproperty_get_tz(prop).tzid);
+
+    prop = vcardcomponent_get_first_property(card, VCARD_GEO_PROPERTY);
+    assert(VCARD_URI_VALUE == vcardvalue_isa(vcardproperty_get_value(prop)));
+    assert_str_equals("geo:1.5,2.5", vcardproperty_get_geo(prop).uri);
+
+    vcardcomponent_free(card);
+}
+
 int main(int argc, char **argv)
 {
     _unused(argc);
@@ -568,6 +928,16 @@ int main(int argc, char **argv)
     test_value_structured_from_string_escaped();
 
     test_line_folding();
+
+    test_value_kind_mismatch_structured();
+    test_value_kind_mismatch_textlist();
+    test_value_kind_mismatch_time();
+    test_value_kind_mismatch_string();
+    test_value_kind_mismatch_scalar();
+    test_value_kind_mismatch_x();
+    test_value_kind_enum_x();
+    test_value_kind_no_value();
+    test_value_kind_compatible();
 
     return 0;
 }


### PR DESCRIPTION
This changes the vcardproperty getter functions to check if the value of the property has the expected value type of the getter. If the value type mismatches, then it returns the zero type for the expected type, e.g. a NULL for TEXT value. This typically only happens for invalid vCard data, but the validation code does allow to set arbitrary VALUE parameters on properties.

This issue was reported by interpolwantme <interpolwantme@gmail.com>.