### PR TITLE
vobject.c - fix a memory leak

### DIFF
--- a/src/libicalvcal/vobject.c
+++ b/src/libicalvcal/vobject.c
@@ -965,6 +965,7 @@ typedef struct OFile {
 
 static void appendcOFile_(OFile *fp, char c)
 {
+    char *tmpMem;
     if (fp->fail) return;
     if (fp->fp) {
         fputc(c,fp->fp);
@@ -978,9 +979,12 @@ stuff:
             }
         else if (fp->alloc) {
             fp->limit = fp->limit + OFILE_REALLOC_SIZE;
-            fp->s = realloc(fp->s,(size_t)fp->limit);
-            if (fp->s) goto stuff;
+            tmpMem = (char *)realloc(fp->s,(size_t)fp->limit);
+            if (tmpMem != NULL) {
+                fp->s = tmpMem;
+                goto stuff;
             }
+        }
         if (fp->s)
             free(fp->s);
         fp->s = 0;


### PR DESCRIPTION
found with clang23.
I know we said libicalvcal is frozen/deprecated/unsupported
but I can't help myself :)

no idea if this fixes #692
