### PR TITLE
icalrecur.c - fix right shift overview warning

### DIFF
--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -1256,7 +1256,7 @@ static void daysmask_set_range(unsigned long days[], int fromDayIncl, int untilD
         if (lowerBitIdxIncl > 0) {
             mask &= ((unsigned long)-1) << lowerBitIdxIncl;
         }
-        if (upperBitIdxExcl < (int)BITS_PER_LONG) {
+        if ((upperBitIdxExcl > 0) && (upperBitIdxExcl < (int)BITS_PER_LONG)) {
             mask &= ((unsigned long)-1) >> (BITS_PER_LONG - upperBitIdxExcl);
         }
 


### PR DESCRIPTION
found by the clang23 scan-build analyzer tool

Fixes:
```
Right shift overflows the capacity of 'unsigned long'
```
