### PR TITLE
source-structure-boilerplate-template - unused-but-set-global warnings

### DIFF
--- a/src/libical-glib/tools/source-structure-boilerplate-template
+++ b/src/libical-glib/tools/source-structure-boilerplate-template
@@ -1,4 +1,11 @@
+#if defined(__clang__) && (__clang_major__ >= 23)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-global"
+#endif
 G_DEFINE_TYPE (${upperCamel}, ${lowerSnake}, I_CAL_TYPE_OBJECT)
+#if defined(__clang__) && (__clang_major__ >= 23)
+#pragma clang diagnostic pop
+#endif
 
 static void ${lowerSnake}_class_init (G_GNUC_UNUSED ${upperCamel}Class *klass)
 {


### PR DESCRIPTION
clang23 has a new diagnostic for -Wunused-but-set-global.

no reason to make things more difficult by hacking on the template
so just ignore the harmless warning.

Fixes:
```
/home/winterz/projects/libical/libical/build-testclang1-clang/src/libical-glib/i-cal-array.c:20:1: warning: variable 'i_cal_array_parent_class' set but not used [-Wunused-but-set-global]
/home/winterz/projects/libical/libical/build-testclang1-clang/src/libical-glib/i-cal-comp-iter.c:20:1: warning: variable 'i_cal_comp_iter_parent_class' set but not used [-Wunused-but-set-global]
/home/winterz/projects/libical/libical/build-testclang1-clang/src/libical-glib/i-cal-component.c:30:1: warning: variable 'i_cal_component_parent_class' set but not used [-Wunused-but-set-global]
/home/winterz/projects/libical/libical/build-testclang1-clang/src/libical-glib/i-cal-datetimeperiod.c:22:1: warning: variable 'i_cal_datetimeperiod_parent_class' set but not used [-Wunused-but-set-global]
...
