### PR TITLE
icalstrarray.c - cppcheck suppress constParamPointer

### DIFF
--- a/src/libical/icalstrarray.c
+++ b/src/libical/icalstrarray.c
@@ -142,6 +142,7 @@ void icalstrarray_sort(icalstrarray *array)
     icalarray_sort(array, (int (*)(const void *, const void *))&strpcmp);
 }
 
+/* cppcheck-suppress constParameterPointer */ /* TODO 5.0 */
 icalstrarray *icalstrarray_clone(icalstrarray *array)
 {
     if (!array) {


### PR DESCRIPTION
since ad6b6bd6175e1e34af569d37136edf6bd77cdb67 cppcheck says
that icalstrarray_clone can be passed a const parameter pointer.
True, but would break binary compatibility.

=> suppress the warning but add a TODO for the next major release.
