### PR TITLE
clang-tidy readability-implicit-bool-conversion fixes+suppressions

### DIFF
--- a/examples/access_components.c
+++ b/examples/access_components.c
@@ -31,13 +31,13 @@ icalcomponent *create_new_component(void)
     /* variable definitions */
     icalcomponent *calendar;
     icalcomponent *event;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), 0, icaltimezone_get_utc_timezone());
+    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), false, icaltimezone_get_utc_timezone());
     struct icalperiodtype rtime;
     icalproperty *property;
 
     /* Define a time type that will use as data later. */
-    rtime.start = icaltime_from_timet_with_zone(time(0), 0, icaltimezone_get_utc_timezone());
-    rtime.end = icaltime_from_timet_with_zone(time(0), 0, icaltimezone_get_utc_timezone());
+    rtime.start = icaltime_from_timet_with_zone(time(0), false, icaltimezone_get_utc_timezone());
+    rtime.end = icaltime_from_timet_with_zone(time(0), false, icaltimezone_get_utc_timezone());
     rtime.end.hour++;
 
     /* Create calendar and add properties */
@@ -178,11 +178,11 @@ icalcomponent *create_new_component_with_va_args(void)
 {
     /* This is a similar set up to the last routine */
     icalcomponent *calendar;
-    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), 0, icaltimezone_get_utc_timezone());
+    struct icaltimetype atime = icaltime_from_timet_with_zone(time(0), false, icaltimezone_get_utc_timezone());
     struct icalperiodtype rtime;
 
-    rtime.start = icaltime_from_timet_with_zone(time(0), 0, icaltimezone_get_utc_timezone());
-    rtime.end = icaltime_from_timet_with_zone(time(0), 0, icaltimezone_get_utc_timezone());
+    rtime.start = icaltime_from_timet_with_zone(time(0), false, icaltimezone_get_utc_timezone());
+    rtime.end = icaltime_from_timet_with_zone(time(0), false, icaltimezone_get_utc_timezone());
     rtime.end.hour++;
 
     /* Some of these routines are the same as those in the previous

--- a/src/libical/icalderivedproperty.c.in
+++ b/src/libical/icalderivedproperty.c.in
@@ -237,9 +237,9 @@ bool icalproperty_value_kind_is_default(icalproperty_kind pkind,
         const struct icalproperty_map *map = &property_map[i];
 
         if (map->kind == pkind) {
-            return ((vkind == map->default_value) ||
-                    ((map->flags & ICAL_PROPERTY_IS_STRUCTURED) &&
-                     (vkind == map->libical_value)));
+            const bool is_structured = (bool)(map->flags & ICAL_PROPERTY_IS_STRUCTURED);
+            return ((vkind == map->default_value) || //NOLINT(readability-implicit-bool-conversion)
+                    (is_structured && (vkind == map->libical_value)));
         }
     }
 

--- a/src/libical/icalproperty.c
+++ b/src/libical/icalproperty.c
@@ -344,7 +344,7 @@ static const char *icalproperty_get_value_kind(icalproperty *prop)
         if (kind == ICAL_ATTACH_VALUE) {
             icalattach *a = icalvalue_get_attach(value);
 
-            kind = icalattach_get_is_url(a) ? ICAL_URI_VALUE : ICAL_BINARY_VALUE;
+            kind = icalattach_get_is_url(a) ? ICAL_URI_VALUE : ICAL_BINARY_VALUE; //NOLINT(readability-implicit-bool-conversion)
         }
     }
 

--- a/src/libical/icalrecur.c
+++ b/src/libical/icalrecur.c
@@ -2859,7 +2859,7 @@ static void expand_by_day(icalrecur_iterator *impl, int year,
 
             if (valid) {
                 const unsigned long daysmask = daysmask_getbit(bydays, day + doy_offset);
-                int new_val = is_limiting
+                int new_val = is_limiting //NOLINT(readability-implicit-bool-conversion)
                                   /* "Filter" the year days bitmask with the bydays bitmask */
                                   ? (int)daysmask
                                   /* Add each BYDAY to the year days bitmask */
@@ -3185,7 +3185,7 @@ static void expand_year_days(icalrecur_iterator *impl, int year)
     if (has_by_data(impl, ICAL_BY_DAY)) {
         /* Apply each BYDAY to the year days bitmask */
         bool limiting =
-            has_by_data(impl, ICAL_BY_YEAR_DAY) || has_by_data(impl, ICAL_BY_MONTH_DAY);
+            has_by_data(impl, ICAL_BY_YEAR_DAY) || has_by_data(impl, ICAL_BY_MONTH_DAY); //NOLINT(readability-implicit-bool-conversion)
         int first_dow, last_dow;
 
         impl->days_index = ICAL_YEARDAYS_MASK_SIZE;
@@ -3724,7 +3724,7 @@ struct icaltimetype icalrecur_iterator_next(icalrecur_iterator *impl)
     const size_t max_recurrence_time_count = icallimit_get(ICAL_LIMIT_RECURRENCE_TIME_STANDING_STILL);
     int lastTimeCompare = 0;
     bool hasSetPos = has_by_data(impl, ICAL_BY_SET_POS);
-    int checkContractingRules = check_contracting_rules(impl) ? 1 : 0;
+    int checkContractingRules = check_contracting_rules(impl) ? 1 : 0; //NOLINT(readability-implicit-bool-conversion)
     size_t cntRecurrences = 0;
     const size_t max_recurrences = icallimit_get(ICAL_LIMIT_RECURRENCE_SEARCH);
     do {
@@ -3779,7 +3779,7 @@ struct icaltimetype icalrecur_iterator_next(icalrecur_iterator *impl)
         }
 
         if (hasSetPos) {
-            int new_ccr = check_contracting_rules(impl) ? 1 : 0;
+            int new_ccr = check_contracting_rules(impl) ? 1 : 0; //NOLINT(readability-implicit-bool-conversion)
             if (new_ccr == 1) {
                 if (checkContractingRules == 0 || period_change) {
                     setup_setpos(impl, 1);
@@ -3820,7 +3820,7 @@ struct icaltimetype icalrecur_iterator_prev(icalrecur_iterator *impl)
     int period_change = 1;
     icalrecur_iterator impl_last = *impl;
     bool hasSetPos = has_by_data(impl, ICAL_BY_SET_POS);
-    int checkContractingRules = check_contracting_rules(impl) ? 1 : 0;
+    int checkContractingRules = check_contracting_rules(impl) ? 1 : 0; //NOLINT(readability-implicit-bool-conversion)
 
     /* Iterate until we get the next valid time */
     do {
@@ -3870,7 +3870,7 @@ struct icaltimetype icalrecur_iterator_prev(icalrecur_iterator *impl)
         }
 
         if (hasSetPos) {
-            int new_ccr = check_contracting_rules(impl) ? 1 : 0;
+            int new_ccr = check_contracting_rules(impl) ? 1 : 0; //NOLINT(readability-implicit-bool-conversion)
             if (new_ccr == 1) {
                 if (checkContractingRules == 0 || period_change) {
                     setup_setpos(impl, 0);
@@ -4261,7 +4261,7 @@ int icalrecurrencetype_month_month(short month)
 
 short icalrecurrencetype_encode_month(int month, bool is_leap)
 {
-    return (short)month | (is_leap ? LEAP_MONTH : 0);
+    return (short)month | (is_leap ? LEAP_MONTH : 0); //NOLINT(readability-implicit-bool-conversion)
 }
 
 bool icalrecur_expand_recurrence(const char *rule,

--- a/src/libical/icalrestriction.c.in
+++ b/src/libical/icalrestriction.c.in
@@ -321,9 +321,9 @@ static const char *icalrestriction_no_duration(const icalrestriction_record * re
         return temp;
     }
 
-    dtstart_islocal = !dtstart.zone &&
+    dtstart_islocal = !dtstart.zone && //NOLINT(readability-implicit-bool-conversion)
         !icalproperty_get_first_parameter(dtstartp, ICAL_TZID_PARAMETER);
-    dtend_due_islocal = !dtend_due.zone &&
+    dtend_due_islocal = !dtend_due.zone &&//NOLINT(readability-implicit-bool-conversion)
         !icalproperty_get_first_parameter(prop, ICAL_TZID_PARAMETER);
 
     if (dtend_due_islocal != dtstart_islocal) {
@@ -494,7 +494,7 @@ static bool icalrestriction_check_component(icalproperty_method method,
 
             compare = _check_restriction(comp, record, count, prop);
 
-            valid = valid && compare;
+            valid = valid && compare; //NOLINT(readability-implicit-bool-conversion)
         }
     }
 
@@ -517,7 +517,7 @@ static bool icalrestriction_check_component(icalproperty_method method,
 
             compare = _check_restriction(comp, record, count, NULL);
 
-            valid = valid && compare;
+            valid = valid && compare; //NOLINT(readability-implicit-bool-conversion)
         }
     }
 
@@ -533,7 +533,7 @@ static bool icalrestriction_check_component(icalproperty_method method,
 
         compare = icalrestriction_check_component(method, inner_comp);
 
-        valid = valid && compare;
+        valid = valid && compare; //NOLINT(readability-implicit-bool-conversion)
     }
 
     return valid;
@@ -550,7 +550,7 @@ bool icalrestriction_check(icalcomponent *outer_comp)
 
     if (comp_kind != ICAL_VCALENDAR_COMPONENT) {
         icalerror_set_errno(ICAL_BADARG_ERROR);
-        return 0;
+        return false;
     }
 
     /* Check the VCALENDAR wrapper */

--- a/src/libical/icaltime.c
+++ b/src/libical/icaltime.c
@@ -223,7 +223,7 @@ struct icaltimetype icaltime_from_timet_with_zone(const icaltime_t tm, const boo
     /* Convert the icaltime_t to a struct tm in UTC time. We can trust gmtime for this. */
     memset(&t, 0, sizeof(struct tm));
     if (!icalgmtime_r(&tm, &t)) {
-        return is_date ? icaltime_null_date() : icaltime_null_time();
+        return is_date ? icaltime_null_date() : icaltime_null_time(); //NOLINT(readability-implicit-bool-conversion)
     }
 
     tt.year = t.tm_year + 1900;
@@ -458,7 +458,7 @@ bool icaltime_is_leap_year(const int year)
     if (year <= 1752) {
         return (year % 4 == 0);
     } else {
-        return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0);
+        return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0); //NOLINT(readability-implicit-bool-conversion)
     }
 }
 

--- a/src/libicalss/icalgauge.c
+++ b/src/libicalss/icalgauge.c
@@ -365,9 +365,9 @@ bool icalgauge_compare(icalgauge *gauge, icalcomponent *comp)
            the value should be merge with the previous clause */
 
         if (w->logic == ICALGAUGELOGIC_AND) {
-            last_clause = this_clause && last_clause;
+            last_clause = this_clause && last_clause; //NOLINT(readability-implicit-bool-conversion)
         } else if (w->logic == ICALGAUGELOGIC_OR) {
-            last_clause = this_clause || last_clause;
+            last_clause = this_clause || last_clause; //NOLINT(readability-implicit-bool-conversion)
         } else {
             last_clause = this_clause;
         }

--- a/src/libicalvcard/vcardderivedproperty.c.in
+++ b/src/libicalvcard/vcardderivedproperty.c.in
@@ -200,7 +200,7 @@ bool vcardproperty_is_structured(vcardproperty_kind pkind)
         const struct vcardproperty_map *map = &property_map[i];
 
         if (map->kind == pkind) {
-            return (map->flags & VCARD_PROPERTY_IS_STRUCTURED);
+            return (bool)(map->flags & VCARD_PROPERTY_IS_STRUCTURED);
         }
     }
 
@@ -216,7 +216,7 @@ bool vcardproperty_is_multivalued(vcardproperty_kind pkind)
         const struct vcardproperty_map *map = &property_map[i];
 
         if (map->kind == pkind) {
-            return (map->flags & VCARD_PROPERTY_IS_MULTIVALUED);
+            return (bool)(map->flags & VCARD_PROPERTY_IS_MULTIVALUED);
         }
     }
 
@@ -233,9 +233,9 @@ bool vcardproperty_value_kind_is_default(vcardproperty_kind pkind,
         const struct vcardproperty_map *map = &property_map[i];
 
         if (map->kind == pkind) {
-            return ((vkind == map->default_value) ||
-                    ((map->flags & VCARD_PROPERTY_IS_STRUCTURED) &&
-                     (vkind == map->libical_value)));
+            return (bool)((vkind == map->default_value) ||
+                          ((map->flags & VCARD_PROPERTY_IS_STRUCTURED) &&
+                           (vkind == map->libical_value)));
         }
     }
 

--- a/src/libicalvcard/vcardparser.c
+++ b/src/libicalvcard/vcardparser.c
@@ -731,7 +731,7 @@ out:
     }
 
     if (state->value_kind == VCARD_TEXTLIST_VALUE) {
-        char sep = vcardproperty_is_structured(prop_kind) ? ';' : ',';
+        char sep = vcardproperty_is_structured(prop_kind) ? ';' : ','; //NOLINT(readability-implicit-bool-conversion)
         vcardstrarray *textlist =
             vcardtextlist_new_from_string(buf_cstring(&state->buf), sep);
         if (textlist) {

--- a/src/libicalvcard/vcardrestriction.c.in
+++ b/src/libicalvcard/vcardrestriction.c.in
@@ -55,15 +55,15 @@ static const vcardrestriction_record null_restriction_record =
    restriction, it passes, but if there are 0 or 2+, it fails. */
 
 static const bool compare_map[VCARD_RESTRICTION_UNKNOWN + 1][3] = {
-    {1, 1, 1}, /*VCARD_RESTRICTION_NONE */
-    {1, 0, 0}, /*VCARD_RESTRICTION_ZERO */
-    {0, 1, 0}, /*VCARD_RESTRICTION_ONE */
-    {1, 1, 1}, /*VCARD_RESTRICTION_ZEROPLUS */
-    {0, 1, 1}, /*VCARD_RESTRICTION_ONEPLUS */
-    {1, 1, 0}, /*VCARD_RESTRICTION_ZEROORONE */
-    {1, 1, 0}, /*VCARD_RESTRICTION_ONEEXCLUSIVE */
-    {1, 1, 0}, /*VCARD_RESTRICTION_ONEMUTUAL */
-    {1, 1, 1}  /*VCARD_RESTRICTION_UNKNOWN */
+    {true, true, true}, /*VCARD_RESTRICTION_NONE */
+    {true, false, false}, /*VCARD_RESTRICTION_ZERO */
+    {false, true, false}, /*VCARD_RESTRICTION_ONE */
+    {true, true, true}, /*VCARD_RESTRICTION_ZEROPLUS */
+    {false, true, true}, /*VCARD_RESTRICTION_ONEPLUS */
+    {true, true, false}, /*VCARD_RESTRICTION_ZEROORONE */
+    {true, true, false}, /*VCARD_RESTRICTION_ONEEXCLUSIVE */
+    {true, true, false}, /*VCARD_RESTRICTION_ONEMUTUAL */
+    {true, true, true}  /*VCARD_RESTRICTION_UNKNOWN */
 };
 
 static const char restr_string_map[VCARD_RESTRICTION_UNKNOWN + 1][60] = {
@@ -78,7 +78,7 @@ static const char restr_string_map[VCARD_RESTRICTION_UNKNOWN + 1][60] = {
     "unknown number"    /*VCARD_RESTRICTION_UNKNOWN */
 };
 
-int vcardrestriction_compare(vcardrestriction_kind restr, int count)
+int vcardrestriction_compare(vcardrestriction_kind restr, int count) //TODO: 5.0 return bool
 {
     /* restr is an unsigned int and VCARD_RESTRICTION_NONE == 0,
        so no need to check if restr < VCARD_RESTRICTION_NONE */
@@ -90,7 +90,7 @@ int vcardrestriction_compare(vcardrestriction_kind restr, int count)
         count = 2;
     }
 
-    return compare_map[restr][count];
+    return (int)compare_map[restr][count];
 }
 
 /* Special case routines */
@@ -157,13 +157,13 @@ static const char *vcardrestriction_validate_timestamp_value(
     return 0;
 }
 
-static int _check_restriction(vcardcomponent *comp,
+static bool _check_restriction(vcardcomponent *comp,
                               const vcardrestriction_record *record,
                               int count, vcardproperty *prop)
 {
     vcardrestriction_kind restr;
     const char *funcr = 0;
-    int compare;
+    bool compare;
 
     restr = record->restriction;
 
@@ -174,11 +174,9 @@ static int _check_restriction(vcardcomponent *comp,
         restr = VCARD_RESTRICTION_ZEROORONE;
     }
 
-    compare = vcardrestriction_compare(restr, count);
+    compare = (bool)vcardrestriction_compare(restr, count);
 
-    assert(compare != -1);
-
-    if (compare == 0) {
+    if (!compare) {
         char temp[TMP_BUF_SIZE];
         vcardproperty *errProp;
         vcardparameter *errParam;
@@ -217,7 +215,7 @@ static int _check_restriction(vcardcomponent *comp,
         vcardcomponent_add_property(comp, errProp);
         vcardproperty_free(errProp);
 
-        compare = 0;
+        compare = false;
     }
 
     return compare;
@@ -232,7 +230,7 @@ static bool vcardrestriction_check_component(vcardcomponent *comp)
     vcardproperty *version_prop = NULL;
     vcardcomponent *inner_comp;
     int count;
-    int compare;
+    bool compare;
     bool valid = true;
 
     comp_kind = vcardcomponent_isa(comp);
@@ -276,7 +274,7 @@ static bool vcardrestriction_check_component(vcardcomponent *comp)
 
             compare = _check_restriction(comp, record, count, prop);
 
-            valid = valid && compare;
+            valid = valid && compare; //NOLINT(readability-implicit-bool-conversion)
         }
     }
 
@@ -300,7 +298,7 @@ static bool vcardrestriction_check_component(vcardcomponent *comp)
 
             compare = _check_restriction(comp, record, count, NULL);
 
-            valid = valid && compare;
+            valid = valid && compare; //NOLINT(readability-implicit-bool-conversion)
         }
     }
 
@@ -310,7 +308,7 @@ static bool vcardrestriction_check_component(vcardcomponent *comp)
 
         compare = vcardrestriction_check_component(inner_comp);
 
-        valid = valid && compare;
+        valid = valid && compare;//NOLINT(readability-implicit-bool-conversion)
     }
 
     return valid;
@@ -328,7 +326,7 @@ bool vcardrestriction_check(vcardcomponent *outer_comp)
     if (comp_kind != VCARD_VCARD_COMPONENT &&
         comp_kind != VCARD_XROOT_COMPONENT) {
         icalerror_set_errno(ICAL_BADARG_ERROR);
-        return 0;
+        return false;
     }
 
     valid = vcardrestriction_check_component(outer_comp);

--- a/src/libicalvcard/vcardtime.c
+++ b/src/libicalvcard/vcardtime.c
@@ -58,34 +58,34 @@ vcardtimetype vcardtime_current_utc_time(void)
 
 bool vcardtime_is_time(const vcardtimetype t)
 {
-    return (t.year == -1 && t.month == -1 && t.day == -1);
+    return (t.year == -1 && t.month == -1 && t.day == -1); //NOLINT(readability-implicit-bool-conversion)
 }
 
 bool vcardtime_is_date(const vcardtimetype t)
 {
-    return (t.hour == -1 && t.minute == -1 && t.second == -1);
+    return (t.hour == -1 && t.minute == -1 && t.second == -1); //NOLINT(readability-implicit-bool-conversion)
 }
 
 bool vcardtime_is_null_datetime(const vcardtimetype t)
 {
-    return (vcardtime_is_time(t) && vcardtime_is_date(t));
+    return (vcardtime_is_time(t) && vcardtime_is_date(t)); //NOLINT(readability-implicit-bool-conversion)
 }
 
 bool vcardtime_is_datetime(const vcardtimetype t)
 {
-    return (t.day != -1 && t.hour != -1);
+    return (t.day != -1 && t.hour != -1); //NOLINT(readability-implicit-bool-conversion)
 }
 
 bool vcardtime_is_timestamp(const vcardtimetype t)
 {
-    return (t.year != -1 && t.month != -1 && t.day != -1 &&
+    return (t.year != -1 && t.month != -1 && t.day != -1 && //NOLINT(readability-implicit-bool-conversion)
             t.hour != -1 && t.minute != -1 && t.second != -1 &&
             t.utcoffset != -1);
 }
 
 bool vcardtime_is_utc(const vcardtimetype t)
 {
-    return (t.utcoffset == 0 && !vcardtime_is_date(t));
+    return (t.utcoffset == 0 && !vcardtime_is_date(t)); //NOLINT(readability-implicit-bool-conversion)
 }
 
 bool vcardtime_is_leap_year(const int year)
@@ -95,7 +95,7 @@ bool vcardtime_is_leap_year(const int year)
     } else if (year <= 1752) {
         return (year % 4 == 0);
     } else {
-        return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0);
+        return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0); //NOLINT(readability-implicit-bool-conversion)
     }
 }
 

--- a/src/libicalvcard/vcardvalue.c
+++ b/src/libicalvcard/vcardvalue.c
@@ -240,7 +240,7 @@ static char *vcardmemory_strdup_and_quote(char **str, char **str_p, size_t *buf_
         case '\n':
             /* If encoding a parameter value, embed literally
                (parameter encoding is done elsewhere), otherwise escape */
-            icalmemory_append_string(str, str_p, buf_sz, is_param ? "\n" : "\\n");
+            icalmemory_append_string(str, str_p, buf_sz, is_param ? "\n" : "\\n"); //NOLINT
             break;
 
         default:
@@ -906,7 +906,7 @@ char *vcardvalue_as_vcard_string_r(const vcardvalue *value)
 
     case VCARD_TEXTLIST_VALUE:
         return vcardvalue_textlist_as_vcard_string_r(value,
-                                                     is_structured ? ';' : ',');
+                                                     is_structured ? ';' : ','); //NOLINT
 
     case VCARD_STRUCTURED_VALUE:
         return vcardvalue_structured_as_vcard_string_r(value);


### PR DESCRIPTION
lots of NOLINTs too where I don't think extra casting is necessary
