### PR TITLE
clang-tidy bugprone-multi-level-implicit-pointer-conversion fixes

### DIFF
--- a/src/libical/icalderivedvalue.c.in
+++ b/src/libical/icalderivedvalue.c.in
@@ -757,7 +757,7 @@ static bool is_valid_color(const char *v)
     }
 
     /* CSS named color */
-    if (bsearch(&v, css_colors, NUM_CSS_COLORS, sizeof(char *), &strpcasecmp)) {
+    if (bsearch((void *)&v, (void *)css_colors, NUM_CSS_COLORS, sizeof(char *), &strpcasecmp)) {
         return true;
     }
 


### PR DESCRIPTION
Fixes:
```
bugprone-multi-level-implicit-pointer-conversion: 2
+ <builddir>/src/libical/icalderivedvalue.c:
  -  1721:multilevel pointer conversion from 'const char **' to
          'const void *', please use explicit cast
  -  1721:multilevel pointer conversion from 'const char **' to
          'const void *', please use explicit cast
```
